### PR TITLE
docs: align backend startup commands

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,6 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
-    groups:
-      dependencies:
-        patterns:
-          - "*"
 
   # Maintain GitHub Actions
   - package-ecosystem: "github-actions"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Build, deploy, and manage intelligent AI agents with advanced knowledge retrieva
 
 <p align="center">
 <img src="https://img.shields.io/badge/Python-3.13-blue?logo=python&logoColor=white" />
-<img src="https://img.shields.io/badge/FastAPI-0.115-009688?logo=fastapi&logoColor=white" />
+<img src="https://img.shields.io/badge/FastAPI-0.135-009688?logo=fastapi&logoColor=white" />
 <img src="https://img.shields.io/badge/Next.js-16-black?logo=next.js&logoColor=white" />
 <img src="https://img.shields.io/badge/Bun-1.0-orange?logo=bun&logoColor=white" />
 <img src="https://img.shields.io/badge/License-GPLv3-blue.svg" />

--- a/README.md
+++ b/README.md
@@ -160,15 +160,17 @@ cp .env.example .env
 ### 3. Start Backend
 
 ```bash
+cd backend
+
 # Install dependencies
-uv sync --project backend
+uv sync
 
 # Start the API server (database will be auto-initialized on first run)
-uv run --project backend main.py server
+uv run uvicorn app.main:app --reload
 
 # In separate terminals, start Celery workers
-uv run --project backend main.py worker
-uv run --project backend main.py beat
+uv run celery -A app.core.celery worker --loglevel=info
+uv run celery -A app.core.celery beat --loglevel=info
 ```
 
 ### 4. Start Frontend

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ uv sync
 uv run uvicorn app.main:app --reload
 
 # In separate terminals, start Celery workers
-uv run celery -A app.core.celery worker --loglevel=info
-uv run celery -A app.core.celery beat --loglevel=info
+uv run celery -A app.core.celery:celery_app worker --loglevel=info
+uv run celery -A app.core.celery:celery_app beat --loglevel=info
 ```
 
 ### 4. Start Frontend

--- a/docs/guide/README_zh-CN.md
+++ b/docs/guide/README_zh-CN.md
@@ -12,7 +12,7 @@
 
 <p align="center">
 <img src="https://img.shields.io/badge/Python-3.13-blue?logo=python&logoColor=white" />
-<img src="https://img.shields.io/badge/FastAPI-0.115-009688?logo=fastapi&logoColor=white" />
+<img src="https://img.shields.io/badge/FastAPI-0.135-009688?logo=fastapi&logoColor=white" />
 <img src="https://img.shields.io/badge/Next.js-16-black?logo=next.js&logoColor=white" />
 <img src="https://img.shields.io/badge/Bun-1.0-orange?logo=bun&logoColor=white" />
 <img src="https://img.shields.io/badge/License-GPLv3-blue.svg" />
@@ -155,15 +155,17 @@ cp .env.example .env
 ### 3. 启动后端
 
 ```bash
+cd backend
+
 # 安装依赖
-uv sync --project backend
+uv sync
 
 # 启动 API 服务器（首次运行时数据库会自动初始化）
-uv run --project backend main.py server
+uv run uvicorn app.main:app --reload
 
 # 在单独的终端中启动 Celery workers
-uv run --project backend main.py worker
-uv run --project backend main.py beat
+uv run celery -A app.core.celery worker --loglevel=info
+uv run celery -A app.core.celery beat --loglevel=info
 ```
 
 ### 4. 启动前端

--- a/docs/guide/README_zh-CN.md
+++ b/docs/guide/README_zh-CN.md
@@ -164,8 +164,8 @@ uv sync
 uv run uvicorn app.main:app --reload
 
 # 在单独的终端中启动 Celery workers
-uv run celery -A app.core.celery worker --loglevel=info
-uv run celery -A app.core.celery beat --loglevel=info
+uv run celery -A app.core.celery:celery_app worker --loglevel=info
+uv run celery -A app.core.celery:celery_app beat --loglevel=info
 ```
 
 ### 4. 启动前端

--- a/docs/guide/getting-started/quick-start.md
+++ b/docs/guide/getting-started/quick-start.md
@@ -31,7 +31,7 @@ cp .env.example .env
 ```bash
 cd backend
 uv sync
-uv run main.py server
+uv run uvicorn app.main:app --reload
 ```
 
 5. **Start frontend**:


### PR DESCRIPTION
## Summary
- Updates README and guide backend startup commands to run from `backend/`, matching the current Python import path.
- Updates FastAPI badges to match `backend/pyproject.toml` (`fastapi>=0.135.3`).
- Removes frontend Dependabot grouping so large frontend dependency updates can be handled separately instead of bundled.

## Validation
- Verified old `main.py server/worker/beat` README commands are no longer present in the touched quick-start docs.
- Verified `cd backend && uv run python -c "import app.main, app.core.celery"` succeeds.
- Confirmed grouped Dependabot PR #98 is closed for separate dependency handling.