### PR TITLE
docs: update changelog for v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-05-17
+
+### Added
+
+#### Authentication
+- Added a configurable split authentication layout so deployments can switch between centered and split-screen auth pages.
+
+#### Automation
+- Added automatic GitHub issue and pull request assignment workflow support.
+
+### Changed
+
+#### Frontend and Site Settings
+- Updated site settings UI and API wiring for configurable auth layout options.
+- Refined numeric input handling across admin and platform forms.
+- Updated frontend dependencies including React, React DOM, shadcn, lucide-react, TypeScript, and Next.js lint configuration.
+
+#### CI/CD
+- Updated GitHub Actions release and automation dependencies.
+
+### Fixed
+
+#### Documentation
+- Corrected PostgreSQL environment variable references in deployment documentation from `POSTGRES_HOST` to `POSTGRES_SERVER`.
+- Tightened documentation sync verification notes for repository automation.
+
 ## [0.2.1] - 2026-05-11
 
 ### Fixed

--- a/docs/guide/CHANGELOG.md
+++ b/docs/guide/CHANGELOG.md
@@ -7,6 +7,32 @@ versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.2.2] - 2026-05-17
+
+### Added
+
+#### Authentication
+- Added a configurable split authentication layout so deployments can switch between centered and split-screen auth pages.
+
+#### Automation
+- Added automatic GitHub issue and pull request assignment workflow support.
+
+### Changed
+
+#### Frontend and Site Settings
+- Updated site settings UI and API wiring for configurable auth layout options.
+- Refined numeric input handling across admin and platform forms.
+- Updated frontend dependencies including React, React DOM, shadcn, lucide-react, TypeScript, and Next.js lint configuration.
+
+#### CI/CD
+- Updated GitHub Actions release and automation dependencies.
+
+### Fixed
+
+#### Documentation
+- Corrected PostgreSQL environment variable references in deployment documentation from `POSTGRES_HOST` to `POSTGRES_SERVER`.
+- Tightened documentation sync verification notes for repository automation.
+
 ## [0.1.0] - 2025-02-07
 
 First public release of Clouisle - an enterprise-grade knowledge base and AI Agent platform.

--- a/docs/guide/CHANGELOG_zh-CN.md
+++ b/docs/guide/CHANGELOG_zh-CN.md
@@ -7,6 +7,32 @@
 
 ---
 
+## [0.2.2] - 2026-05-17
+
+### 新增
+
+#### 认证
+- 新增可配置的分栏认证布局，部署时可在居中布局和分屏布局之间切换。
+
+#### 自动化
+- 新增 GitHub issue 和 pull request 自动分配工作流支持。
+
+### 变更
+
+#### 前端与站点设置
+- 更新站点设置界面和 API 接入，支持配置认证布局选项。
+- 优化后台和平台表单中的数字输入处理。
+- 更新前端依赖，包括 React、React DOM、shadcn、lucide-react、TypeScript 和 Next.js lint 配置。
+
+#### CI/CD
+- 更新 GitHub Actions 发布和自动化依赖。
+
+### 修复
+
+#### 文档
+- 修正部署文档中的 PostgreSQL 环境变量引用，将 `POSTGRES_HOST` 改为 `POSTGRES_SERVER`。
+- 完善仓库自动化相关的文档同步校验说明。
+
 ## [0.1.0] - 2025-02-07
 
 Clouisle 首个公开发布版本 - 企业级知识库与 AI Agent 平台。


### PR DESCRIPTION
## Summary
- Add v0.2.2 release notes to the root changelog.
- Sync English and Chinese guide changelogs with the v0.2.2 release summary.
- Document changes since v0.2.1, including auth layout configuration, auto-assignment workflow support, dependency updates, and deployment documentation fixes.

## Test plan
- [x] Verified branch diff only contains changelog updates.
- [x] Created and pushed annotated tag `v0.2.2` with release summary.