### PR TITLE
style: unify delete UI styles across platform

### DIFF
--- a/frontend/app/(dashboard)/capabilities/_components/admin-skills-panel.tsx
+++ b/frontend/app/(dashboard)/capabilities/_components/admin-skills-panel.tsx
@@ -646,7 +646,7 @@ export function AdminSkillsPanel() {
                               </DropdownMenuItem>
                             )}
                             {canPerform('admin:capability:delete') && (
-                              <DropdownMenuItem className="text-destructive" onClick={() => handleDelete(skill)}>
+                              <DropdownMenuItem variant="destructive" onClick={() => handleDelete(skill)}>
                                 <Trash2 className="mr-2 h-4 w-4" />
                                 {t('delete')}
                               </DropdownMenuItem>

--- a/frontend/app/(dashboard)/site-settings/sso/page.tsx
+++ b/frontend/app/(dashboard)/site-settings/sso/page.tsx
@@ -228,7 +228,7 @@ export default function SSOSettingsPage() {
                           onClick={() => setDeleteId(provider.id)}
                           title={t('deleteProvider')}
                         >
-                          <Trash2 className="h-4 w-4" />
+                          <Trash2 className="h-4 w-4 text-destructive" />
                         </Button>
                       </div>
                     )}

--- a/frontend/app/(dashboard)/site-settings/sso/page.tsx
+++ b/frontend/app/(dashboard)/site-settings/sso/page.tsx
@@ -256,7 +256,7 @@ export default function SSOSettingsPage() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t('cancel')}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDelete}>
+            <AlertDialogAction variant="destructive" onClick={handleDelete}>
               {t('delete')}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/frontend/app/(dashboard)/teams/_components/team-detail-dialog.tsx
+++ b/frontend/app/(dashboard)/teams/_components/team-detail-dialog.tsx
@@ -504,7 +504,7 @@ export function TeamDetailDialog({
                                   </DropdownMenuItem>
                                   <DropdownMenuSeparator />
                                   <DropdownMenuItem
-                                    className="text-destructive focus:text-destructive"
+                                    variant="destructive"
                                     onClick={() => openRemoveMemberDialog(member)}
                                   >
                                     <Trash2 className="mr-2 h-4 w-4" />

--- a/frontend/app/(dashboard)/teams/_components/teams-client.tsx
+++ b/frontend/app/(dashboard)/teams/_components/teams-client.tsx
@@ -348,8 +348,8 @@ export function TeamsClient() {
                         <>
                           {canPerform('admin:team:update') && <DropdownMenuSeparator />}
                           <DropdownMenuItem
+                            variant="destructive"
                             onClick={(e) => { e.stopPropagation(); handleDelete(team) }}
-                            className="text-destructive focus:text-destructive"
                           >
                             <Trash2 className="mr-2 h-4 w-4" />
                             {commonT('delete')}

--- a/frontend/app/(platform)/app/capabilities/_components/skills-panel.tsx
+++ b/frontend/app/(platform)/app/capabilities/_components/skills-panel.tsx
@@ -489,7 +489,7 @@ export function SkillsPanel() {
                             />
                             <DropdownMenuContent align="end">
                               <DropdownMenuItem
-                                className="text-destructive"
+                                variant="destructive"
                                 onClick={(event) => {
                                   event.stopPropagation()
                                   handleDelete(skill)

--- a/frontend/app/(platform)/app/capabilities/_components/tool-card.tsx
+++ b/frontend/app/(platform)/app/capabilities/_components/tool-card.tsx
@@ -277,7 +277,7 @@ export function ToolCard({
                         {t('share.title')}
                       </DropdownMenuItem>
                       <DropdownMenuItem
-                        className="text-destructive"
+                        variant="destructive"
                         onClick={(e) => {
                           e.stopPropagation()
                           onDelete?.(tool)

--- a/frontend/app/(platform)/app/kb/page.tsx
+++ b/frontend/app/(platform)/app/kb/page.tsx
@@ -263,7 +263,7 @@ export default function KnowledgeBasePage() {
                     <>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
-                        className="text-destructive"
+                        variant="destructive"
                         onClick={(e) => { e.preventDefault(); handleDeleteClick(kb) }}
                       >
                         <Trash2 className="mr-2 h-4 w-4" />

--- a/frontend/components/layout/platform-header.tsx
+++ b/frontend/components/layout/platform-header.tsx
@@ -320,7 +320,7 @@ export function PlatformHeader() {
                     </AvatarFallback>
                   </Avatar>
                   {unreadCount > 0 && (
-                    <span className="absolute -top-1 -right-1 inline-flex min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] text-white">
+                    <span className="absolute -top-1 -right-1 inline-flex min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] text-white hover:!text-white">
                       {unreadCount > 99 ? '99+' : unreadCount}
                     </span>
                   )}
@@ -364,7 +364,7 @@ export function PlatformHeader() {
            <Bell className="mr-2 h-4 w-4" />
                 <span className="flex-1">{t('nav.notifications')}</span>
        {unreadCount > 0 && (
-                  <span className="ml-auto inline-flex min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] text-white">
+                  <span className="ml-auto inline-flex min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] !text-white">
               {unreadCount > 99 ? '99+' : unreadCount}
                   </span>
                 )}


### PR DESCRIPTION
## Summary
- Unified delete menu item hover effects to use `variant="destructive"` for consistent red background
- Fixed notification badge text color to remain white on hover
- Made SSO delete icon and dialog button red

## Changes
- **Notification badges**: Added `!text-white` to prevent text color change on hover
- **Delete menu items**: Changed from `className="text-destructive"` to `variant="destructive"` for:
  - Knowledge bases page
  - Capabilities page (tools and skills)
  - Teams page (team deletion and member removal)
  - Admin skills panel
- **SSO page**: Made delete icon red and dialog button use destructive variant

## Test plan
- [x] Verify notification badge text stays white on hover
- [x] Verify all delete menu items show red background on hover
- [x] Verify SSO delete icon is red
- [x] Verify SSO delete dialog button is red
- [x] Lint passes