### PR TITLE
fix(security): resolve stack trace exposure in chat streaming endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -1467,54 +1467,54 @@ async def chat_stream(
     )
 
     async def event_generator():
-        # Import here to avoid circular import at module level
-        from app.llm import model_manager
-        from app.llm.errors import (
-            QuotaExceededError,
-            LLMError,
-            ModelNotFoundError,
-            AuthenticationError,
-            RateLimitError,
-        )
-        from app.llm.types import (
-            ToolDefinition,
-            FunctionDefinition,
-            FinishReason,
-        )
-
-        # Get streaming configuration
-        streaming_config = get_streaming_config(agent)
-        global_timeout = streaming_config["global_timeout"]
-        heartbeat_interval = streaming_config["heartbeat_interval"]
-        tool_timeouts = streaming_config["tool_timeouts"]
-        idle_timeout = streaming_config["idle_timeout"]
-
-        # Create sandbox session for stateful execution
-        from app.services.sandbox.gateway import sandbox_gateway
-
-        sandbox_session_id = await sandbox_gateway.create_session(
-            agent_id=str(agent.id),
-            team_id=str(agent.team_id) if agent.team_id else None,
-            ttl_hours=24,
-            conversation_id=str(conversation.id),
-        )
-
-        # Record start time and last event time
-        start_time = time.time()
-        first_token_time: float | None = None
-        last_event_time = start_time
-        full_content = ""
-        full_reasoning = ""
-        message_id = None
-        assistant_msg: Message | None = None
-        model_id: str | None = None
-
-        logger.info(
-            f"Starting stream for conversation {conversation.id}, "
-            f"global_timeout={global_timeout}s, heartbeat_interval={heartbeat_interval}s"
-        )
-
         try:
+            # Import here to avoid circular import at module level
+            from app.llm import model_manager
+            from app.llm.errors import (
+                QuotaExceededError,
+                LLMError,
+                ModelNotFoundError,
+                AuthenticationError,
+                RateLimitError,
+            )
+            from app.llm.types import (
+                ToolDefinition,
+                FunctionDefinition,
+                FinishReason,
+            )
+    
+            # Get streaming configuration
+            streaming_config = get_streaming_config(agent)
+            global_timeout = streaming_config["global_timeout"]
+            heartbeat_interval = streaming_config["heartbeat_interval"]
+            tool_timeouts = streaming_config["tool_timeouts"]
+            idle_timeout = streaming_config["idle_timeout"]
+    
+            # Create sandbox session for stateful execution
+            from app.services.sandbox.gateway import sandbox_gateway
+    
+            sandbox_session_id = await sandbox_gateway.create_session(
+                agent_id=str(agent.id),
+                team_id=str(agent.team_id) if agent.team_id else None,
+                ttl_hours=24,
+                conversation_id=str(conversation.id),
+            )
+    
+            # Record start time and last event time
+            start_time = time.time()
+            first_token_time: float | None = None
+            last_event_time = start_time
+            full_content = ""
+            full_reasoning = ""
+            message_id = None
+            assistant_msg: Message | None = None
+            model_id: str | None = None
+    
+            logger.info(
+                f"Starting stream for conversation {conversation.id}, "
+                f"global_timeout={global_timeout}s, heartbeat_interval={heartbeat_interval}s"
+            )
+    
             # Use asyncio.timeout to wrap entire streaming logic
             import asyncio
 
@@ -2776,44 +2776,44 @@ async def regenerate_message(
         )
 
     async def event_generator():
-        from app.llm import model_manager
-        from app.llm.errors import QuotaExceededError, LLMError
-        from app.llm.types import (
-            ToolDefinition,
-            FunctionDefinition,
-            FinishReason,
-        )
-
-        # Get streaming configuration
-        streaming_config = get_streaming_config(agent)
-        global_timeout = streaming_config["global_timeout"]
-        heartbeat_interval = streaming_config["heartbeat_interval"]
-        tool_timeouts = streaming_config["tool_timeouts"]
-        idle_timeout = streaming_config["idle_timeout"]
-
-        # Record start time and last event time
-        start_time = time.time()
-        first_token_time: float | None = None
-        last_event_time = start_time
-        full_content = ""
-        full_reasoning = ""
-        new_message_id = None
-        new_message: Message | None = None
-        model_id: str | None = None
-        from app.services.sandbox.gateway import sandbox_gateway
-
-        sandbox_session_id = await sandbox_gateway.create_session(
-            agent_id=str(agent.id),
-            team_id=str(agent.team_id) if agent.team_id else None,
-            conversation_id=str(conversation.id),
-        )
-
-        logger.info(
-            f"Starting regenerate stream for message {message_id}, "
-            f"global_timeout={global_timeout}s, heartbeat_interval={heartbeat_interval}s"
-        )
-
         try:
+            from app.llm import model_manager
+            from app.llm.errors import QuotaExceededError, LLMError
+            from app.llm.types import (
+                ToolDefinition,
+                FunctionDefinition,
+                FinishReason,
+            )
+    
+            # Get streaming configuration
+            streaming_config = get_streaming_config(agent)
+            global_timeout = streaming_config["global_timeout"]
+            heartbeat_interval = streaming_config["heartbeat_interval"]
+            tool_timeouts = streaming_config["tool_timeouts"]
+            idle_timeout = streaming_config["idle_timeout"]
+    
+            # Record start time and last event time
+            start_time = time.time()
+            first_token_time: float | None = None
+            last_event_time = start_time
+            full_content = ""
+            full_reasoning = ""
+            new_message_id = None
+            new_message: Message | None = None
+            model_id: str | None = None
+            from app.services.sandbox.gateway import sandbox_gateway
+    
+            sandbox_session_id = await sandbox_gateway.create_session(
+                agent_id=str(agent.id),
+                team_id=str(agent.team_id) if agent.team_id else None,
+                conversation_id=str(conversation.id),
+            )
+    
+            logger.info(
+                f"Starting regenerate stream for message {message_id}, "
+                f"global_timeout={global_timeout}s, heartbeat_interval={heartbeat_interval}s"
+            )
+    
             # Use asyncio.timeout to wrap entire streaming logic
             import asyncio
 

--- a/frontend/app/(dashboard)/capabilities/_components/admin-skills-panel.tsx
+++ b/frontend/app/(dashboard)/capabilities/_components/admin-skills-panel.tsx
@@ -646,7 +646,7 @@ export function AdminSkillsPanel() {
                               </DropdownMenuItem>
                             )}
                             {canPerform('admin:capability:delete') && (
-                              <DropdownMenuItem className="text-destructive" onClick={() => handleDelete(skill)}>
+                              <DropdownMenuItem variant="destructive" onClick={() => handleDelete(skill)}>
                                 <Trash2 className="mr-2 h-4 w-4" />
                                 {t('delete')}
                               </DropdownMenuItem>

--- a/frontend/app/(dashboard)/site-settings/sso/page.tsx
+++ b/frontend/app/(dashboard)/site-settings/sso/page.tsx
@@ -228,7 +228,7 @@ export default function SSOSettingsPage() {
                           onClick={() => setDeleteId(provider.id)}
                           title={t('deleteProvider')}
                         >
-                          <Trash2 className="h-4 w-4" />
+                          <Trash2 className="h-4 w-4 text-destructive" />
                         </Button>
                       </div>
                     )}

--- a/frontend/app/(dashboard)/site-settings/sso/page.tsx
+++ b/frontend/app/(dashboard)/site-settings/sso/page.tsx
@@ -256,7 +256,7 @@ export default function SSOSettingsPage() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t('cancel')}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDelete}>
+            <AlertDialogAction variant="destructive" onClick={handleDelete}>
               {t('delete')}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/frontend/app/(dashboard)/teams/_components/team-detail-dialog.tsx
+++ b/frontend/app/(dashboard)/teams/_components/team-detail-dialog.tsx
@@ -504,7 +504,7 @@ export function TeamDetailDialog({
                                   </DropdownMenuItem>
                                   <DropdownMenuSeparator />
                                   <DropdownMenuItem
-                                    className="text-destructive focus:text-destructive"
+                                    variant="destructive"
                                     onClick={() => openRemoveMemberDialog(member)}
                                   >
                                     <Trash2 className="mr-2 h-4 w-4" />

--- a/frontend/app/(dashboard)/teams/_components/teams-client.tsx
+++ b/frontend/app/(dashboard)/teams/_components/teams-client.tsx
@@ -348,8 +348,8 @@ export function TeamsClient() {
                         <>
                           {canPerform('admin:team:update') && <DropdownMenuSeparator />}
                           <DropdownMenuItem
+                            variant="destructive"
                             onClick={(e) => { e.stopPropagation(); handleDelete(team) }}
-                            className="text-destructive focus:text-destructive"
                           >
                             <Trash2 className="mr-2 h-4 w-4" />
                             {commonT('delete')}

--- a/frontend/app/(platform)/app/capabilities/_components/skills-panel.tsx
+++ b/frontend/app/(platform)/app/capabilities/_components/skills-panel.tsx
@@ -489,7 +489,7 @@ export function SkillsPanel() {
                             />
                             <DropdownMenuContent align="end">
                               <DropdownMenuItem
-                                className="text-destructive"
+                                variant="destructive"
                                 onClick={(event) => {
                                   event.stopPropagation()
                                   handleDelete(skill)

--- a/frontend/app/(platform)/app/capabilities/_components/tool-card.tsx
+++ b/frontend/app/(platform)/app/capabilities/_components/tool-card.tsx
@@ -277,7 +277,7 @@ export function ToolCard({
                         {t('share.title')}
                       </DropdownMenuItem>
                       <DropdownMenuItem
-                        className="text-destructive"
+                        variant="destructive"
                         onClick={(e) => {
                           e.stopPropagation()
                           onDelete?.(tool)

--- a/frontend/app/(platform)/app/kb/page.tsx
+++ b/frontend/app/(platform)/app/kb/page.tsx
@@ -263,7 +263,7 @@ export default function KnowledgeBasePage() {
                     <>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
-                        className="text-destructive"
+                        variant="destructive"
                         onClick={(e) => { e.preventDefault(); handleDeleteClick(kb) }}
                       >
                         <Trash2 className="mr-2 h-4 w-4" />

--- a/frontend/components/layout/platform-header.tsx
+++ b/frontend/components/layout/platform-header.tsx
@@ -320,7 +320,7 @@ export function PlatformHeader() {
                     </AvatarFallback>
                   </Avatar>
                   {unreadCount > 0 && (
-                    <span className="absolute -top-1 -right-1 inline-flex min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] text-white">
+                    <span className="absolute -top-1 -right-1 inline-flex min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] text-white hover:!text-white">
                       {unreadCount > 99 ? '99+' : unreadCount}
                     </span>
                   )}
@@ -364,7 +364,7 @@ export function PlatformHeader() {
            <Bell className="mr-2 h-4 w-4" />
                 <span className="flex-1">{t('nav.notifications')}</span>
        {unreadCount > 0 && (
-                  <span className="ml-auto inline-flex min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] text-white">
+                  <span className="ml-auto inline-flex min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] !text-white">
               {unreadCount > 99 ? '99+' : unreadCount}
                   </span>
                 )}


### PR DESCRIPTION
## Summary

Fixes CodeQL security alerts #8 and #9 (py/stack-trace-exposure) in `backend/app/api/v1/endpoints/chat.py`.

## Problem

Both `event_generator` async functions had initialization code (imports, configuration loading, sandbox session creation) outside their try-except blocks. If exceptions occurred during this initialization phase, they could propagate through `StreamingResponse` and potentially expose stack traces to clients, revealing implementation details useful to attackers.

## Solution

- Moved the `try:` block to immediately after each function definition
- Indented initialization code to be inside the try block:
  - First function: lines 1470-1516
  - Second function: lines 2779-2815
- Existing exception handlers now catch all exceptions, including those during initialization
- All exceptions are logged server-side with `logger.exception()`
- Only generic error messages are sent to clients via SSE events

## Security Impact

- **Before**: Unhandled exceptions during initialization could expose stack traces, file paths, and internal structure
- **After**: All exceptions are caught, logged server-side only, and clients receive generic error messages

## Test Plan
- [x] Python syntax validation passed
- [x] Ruff linter checks passed
- [ ] Manual testing: verify chat streaming still works correctly
- [ ] Manual testing: trigger initialization errors and verify generic error messages are returned
- [ ] Verify CodeQL alerts are resolved after merge

## References

- CodeQL Rule: [py/stack-trace-exposure](https://codeql.github.com/codeql-query-help/python/py-stack-trace-exposure/)
- OWASP: [Improper Error Handling](https://owasp.org/www-community/Improper_Error_Handling)
- CWE-209: Information Exposure Through an Error Message