### PR TITLE
Require release tags to point at main

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -9,8 +9,23 @@ permissions:
   contents: write
 
 jobs:
+  verify-main-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag commit is on main
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
   build-backend:
     runs-on: ubuntu-latest
+    needs: verify-main-tag
 
     steps:
       - name: Checkout
@@ -43,6 +58,7 @@ jobs:
 
   build-sandbox-worker:
     runs-on: ubuntu-latest
+    needs: verify-main-tag
 
     steps:
       - name: Checkout
@@ -75,6 +91,7 @@ jobs:
 
   build-frontend:
     runs-on: ubuntu-latest
+    needs: verify-main-tag
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Add a release workflow gate that verifies tag commits are ancestors of `origin/main`.
- Prevent image publishing from tags created on feature branches.

## Test plan
- [x] Verified the PR diff only changes `.github/workflows/build-images.yml`