### PR TITLE
Fix Docker production logs routing and auth layout

### DIFF
--- a/frontend/app/(auth)/layout.tsx
+++ b/frontend/app/(auth)/layout.tsx
@@ -8,19 +8,34 @@ function normalizeAuthPageLayout(value: string | undefined): AuthPageLayout {
 }
 
 async function getPublicSettings(): Promise<Pick<PublicSiteSettings, 'site_name' | 'auth_page_layout'>> {
-  const response = await fetch(`${getServerApiBaseUrl()}/site-settings/public`, {
-    next: { revalidate: 300 } // Cache for 5 minutes
-  })
+  try {
+    const response = await fetch(`${getServerApiBaseUrl()}/site-settings/public`, {
+      next: { revalidate: 300 }, // Cache for 5 minutes
+      headers: {
+        'Cache-Control': 'no-cache',
+      },
+    })
 
-  if (!response.ok) {
-    throw new Error('Failed to load public site settings')
-  }
+    if (!response.ok) {
+      console.warn(`Failed to fetch public settings: ${response.status}`)
+      return {
+        site_name: 'Clouisle',
+        auth_page_layout: 'centered',
+      }
+    }
 
-  const body = await response.json() as { data?: Partial<PublicSiteSettings> }
+    const body = await response.json() as { data?: Partial<PublicSiteSettings> }
 
-  return {
+    return {
     site_name: body.data?.site_name || 'Clouisle',
-    auth_page_layout: normalizeAuthPageLayout(body.data?.auth_page_layout),
+      auth_page_layout: normalizeAuthPageLayout(body.data?.auth_page_layout),
+    }
+  } catch (error) {
+    console.error('Error fetching public settings:', error)
+    return {
+      site_name: 'Clouisle',
+      auth_page_layout: 'centered',
+    }
   }
 }
 
@@ -31,21 +46,7 @@ export default async function AuthLayout({
 }) {
   const t = await getTranslations('auth')
 
-  let settings = {
-    site_name: 'Clouisle',
-    auth_page_layout: 'centered' as AuthPageLayout,
-  }
-
-  try {
-    settings = await getPublicSettings()
-  } catch (error) {
-    console.error('Failed to load public settings for auth layout:', error)
-    // Keep all defaults on error
-    settings = {
-      site_name: 'Clouisle',
-      auth_page_layout: 'centered',
-    }
-  }
+  const settings = await getPublicSettings()
 
   return (
     <AuthLayoutShell

--- a/frontend/app/(platform)/app/apps/[id]/logs/page.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/logs/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useParams } from 'next/navigation'
 import { useTranslations, useLocale } from 'next-intl'
 import { Search, Calendar, ArrowUpDown, MessageSquare, ChevronLeft, ChevronRight, X } from 'lucide-react'
 import { agentsApi, type Agent, type ConversationListItem, type ConversationWithMessages } from '@/lib/api'
@@ -36,10 +36,6 @@ import {
 import { AgentSidebar } from '../_components/agent-sidebar'
 import { ConversationDrawer } from './_components/conversation-drawer'
 
-interface LogsPageProps {
-  params: Promise<{ id: string }>
-}
-
 const PAGE_SIZE = 20
 
 // Helper to format datetime
@@ -66,10 +62,12 @@ function formatDateTime(dateString: string, locale: string): string {
   }
 }
 
-export default function LogsPage({ params }: LogsPageProps) {
+export default function LogsPage() {
   const t = useTranslations('agents.logs')
   const locale = useLocale()
   const router = useRouter()
+  const params = useParams()
+  const agentId = params.id as string
 
   const [agent, setAgent] = React.useState<Agent | null>(null)
   const [isLoading, setIsLoading] = React.useState(true)
@@ -77,12 +75,12 @@ export default function LogsPage({ params }: LogsPageProps) {
   const [totalConversations, setTotalConversations] = React.useState(0)
   const [currentPage, setCurrentPage] = React.useState(1)
   const [isLoadingConversations, setIsLoadingConversations] = React.useState(false)
-  
+
   // Search and filter state
   const [searchQuery, setSearchQuery] = React.useState('')
   const [dateFilter, setDateFilter] = React.useState('all')
   const [sortBy, setSortBy] = React.useState('created_at')
-  
+
   // Drawer state
   const [drawerOpen, setDrawerOpen] = React.useState(false)
   const [selectedConversation, setSelectedConversation] = React.useState<ConversationWithMessages | null>(null)
@@ -91,35 +89,28 @@ export default function LogsPage({ params }: LogsPageProps) {
   // Delete dialog state
   const [deleteId, setDeleteId] = React.useState<string | null>(null)
 
-  // Unwrap params
-  const [resolvedParams, setResolvedParams] = React.useState<{ id: string } | null>(null)
-
-  React.useEffect(() => {
-    params.then(setResolvedParams)
-  }, [params])
-
   // Fetch agent data
   const fetchAgent = React.useCallback(async () => {
-    if (!resolvedParams) return
+    if (!agentId) return
 
     try {
       setIsLoading(true)
-      const data = await agentsApi.getAgent(resolvedParams.id)
+      const data = await agentsApi.getAgent(agentId)
       setAgent(data)
     } catch {
       router.push('/app/apps')
     } finally {
       setIsLoading(false)
     }
-  }, [resolvedParams, router])
+  }, [agentId, router])
 
   // Fetch conversations
   const fetchConversations = React.useCallback(async (page: number = 1) => {
-    if (!resolvedParams) return
+    if (!agentId) return
 
     try {
       setIsLoadingConversations(true)
-      const result = await agentsApi.getAgentConversations(resolvedParams.id, {
+      const result = await agentsApi.getAgentConversations(agentId, {
         page,
         pageSize: PAGE_SIZE,
       })
@@ -131,7 +122,7 @@ export default function LogsPage({ params }: LogsPageProps) {
     } finally {
       setIsLoadingConversations(false)
     }
-  }, [resolvedParams])
+  }, [agentId])
 
   // Fetch conversation detail
   const handleRowClick = async (conversationId: string) => {


### PR DESCRIPTION
## Summary
- Fix agent logs page dynamic route handling in client components by using `useParams()`.
- Make auth layout public settings fetch fail gracefully during SSR.
- Prevent stale auth layout settings from being reused unexpectedly.

## Test plan
- [x] `bun run lint`
- [x] `bun run build`