### PR TITLE
Fix agent message version branch context

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/.codegraph/daemon.pid
+++ b/.codegraph/daemon.pid
@@ -1,6 +1,6 @@
 {
-  "pid": 23488,
+  "pid": 24489,
   "version": "0.9.5",
   "socketPath": "/Users/yunhai/Documents/CodeData/Project/Clouisle/.codegraph/daemon.sock",
-  "startedAt": 1779808670494
+  "startedAt": 1779866630054
 }

--- a/.codegraph/daemon.pid
+++ b/.codegraph/daemon.pid
@@ -1,0 +1,6 @@
+{
+  "pid": 23488,
+  "version": "0.9.5",
+  "socketPath": "/Users/yunhai/Documents/CodeData/Project/Clouisle/.codegraph/daemon.sock",
+  "startedAt": 1779808670494
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "codegraph": {
+      "type": "stdio",
+      "command": "codegraph",
+      "args": [
+        "serve",
+        "--mcp"
+      ]
+    }
+  }
+}

--- a/backend/app/api/v1/admin/endpoints/conversations.py
+++ b/backend/app/api/v1/admin/endpoints/conversations.py
@@ -31,6 +31,7 @@ from app.schemas.response import (
     success,
 )
 from app.api.v1.endpoints.chat import build_message_round_payloads
+from app.services.message_branching import get_visible_conversation_messages
 
 
 router = APIRouter()
@@ -483,11 +484,8 @@ async def get_conversation_detail(
                     status_code=404,
                 )
 
-    # Get only active messages
-    messages = await Message.filter(
-        conversation_id=conversation.id,
-        is_active=True,
-    ).order_by("created_at")
+    # Get visible branch messages
+    messages = await get_visible_conversation_messages(conversation.id)
 
     # Batch calculate version counts
     root_ids = set()

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -51,6 +51,7 @@ from app.services.auto_notification import AutoNotificationService
 from app.models.notification import AutoNotificationType
 from app.core.i18n import t
 from app.api.v1.endpoints.chat import build_message_round_payloads
+from app.services.message_branching import get_visible_conversation_messages
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -1057,10 +1058,7 @@ async def get_conversation(
             status_code=404,
         )
 
-    messages = await Message.filter(
-        conversation_id=conversation.id,
-        is_active=True,
-    ).order_by("created_at")
+    messages = await get_visible_conversation_messages(conversation.id)
 
     # Batch calculate version counts to avoid N+1 queries
     # Get all parent_ids we need to count

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -1250,6 +1250,7 @@ async def chat(
                         tool_timeouts=tool_timeouts,
                         user=current_user,
                         session_id=sandbox_session_id,
+                        current_images=chat_in.images,
                     )
                     display_result, llm_result = get_tool_execution_payloads(result)
 
@@ -2076,7 +2077,7 @@ async def chat_stream(
                                 yield f"event: {SSEEventType.TOOL_CALL}\ndata: {json.dumps({'tool_call_id': tc.id, 'tool_name': tool_name, 'tool_display_name': tool_display_name, 'arguments': arguments})}\n\n"
                                 last_event_time = time.time()
 
-                                # Execute the tool (pass agent and tool_timeouts)
+                                # Execute the tool (pass agent, tool_timeouts, and current uploaded images)
                                 result = await execute_tool_call(
                                     tool_name,
                                     arguments,
@@ -2084,6 +2085,7 @@ async def chat_stream(
                                     tool_timeouts=tool_timeouts,
                                     user=current_user,
                                     session_id=sandbox_session_id,
+                                    current_images=chat_in.images,
                                 )
                                 display_result, llm_result = (
                                     get_tool_execution_payloads(result)
@@ -3248,6 +3250,7 @@ async def regenerate_message(
                                     tool_timeouts=tool_timeouts,
                                     user=current_user,
                                     session_id=sandbox_session_id,
+                                    current_images=user_message.images,
                                 )
                                 display_result, llm_result = (
                                     get_tool_execution_payloads(result)

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -5,6 +5,7 @@ Provides streaming and non-streaming chat with AI agents.
 
 from __future__ import annotations
 
+import ast
 import json
 import logging
 import time
@@ -103,6 +104,28 @@ def _is_model_stream_activity(chunk: ChatStreamChunk) -> bool:
         or delta.stream_activity
         or chunk.finish_reason
     )
+
+
+def _extract_llm_error_message(error: Exception) -> str:
+    message = getattr(error, "message", None) or str(error)
+    marker = " - "
+    if marker in message:
+        payload_text = message.split(marker, 1)[1]
+        try:
+            payload = ast.literal_eval(payload_text)
+        except (SyntaxError, ValueError):
+            return message
+        provider_message = payload.get("error", {}).get("message")
+        if isinstance(provider_message, str) and provider_message:
+            return provider_message
+    return message
+
+
+def _format_llm_error_message(error: Exception) -> str:
+    message = _extract_llm_error_message(error)
+    if not message:
+        return t("model_call_failed")
+    return t("model_service_request_failed", message=message)
 
 
 async def check_agent_chat_access(agent_id: UUID, user: User) -> Agent:
@@ -2387,17 +2410,18 @@ async def chat_stream(
                     )
                     logger.warning("Rate limit error during stream: %s", e)
                     yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t('rate_limit_exceeded')})}\n\n"
-                except LLMError:
+                except LLMError as e:
                     logger.exception("LLM error during stream")
+                    error_message = _format_llm_error_message(e)
                     await persist_partial_round_error(
                         assistant_msg,
                         content=full_content,
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
-                        fallback_content=t(GENERIC_STREAM_ERROR_KEY),
+                        fallback_content=error_message,
                     )
-                    yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t(GENERIC_STREAM_ERROR_KEY)})}\n\n"
+                    yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': error_message})}\n\n"
                 except StreamIdleTimeoutError:
                     logger.warning(
                         "Stream idle timeout (%ss) for conversation %s",
@@ -3493,14 +3517,15 @@ async def regenerate_message(
                         await Message.filter(id=message.id).update(is_active=True)
                     logger.warning("Quota exceeded during regenerate: %s", e)
                     yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.MODEL_QUOTA_EXCEEDED, 'msg': t('model_quota_exceeded'), 'quota_type': e.quota_type})}\n\n"
-                except LLMError:
+                except LLMError as e:
+                    error_message = _format_llm_error_message(e)
                     preserved_partial = await persist_partial_round_error(
                         new_message,
                         content=full_content,
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
-                        fallback_content=t(GENERIC_STREAM_ERROR_KEY),
+                        fallback_content=error_message,
                     )
                     if preserved_partial:
                         await Message.filter(id=message.id).update(is_active=False)
@@ -3509,7 +3534,7 @@ async def regenerate_message(
                             await Message.filter(id=new_message_id).delete()
                         await Message.filter(id=message.id).update(is_active=True)
                     logger.exception("LLM error during regenerate")
-                    yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t(GENERIC_STREAM_ERROR_KEY)})}\n\n"
+                    yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': error_message})}\n\n"
                 except StreamIdleTimeoutError:
                     preserved_partial = await persist_partial_round_error(
                         new_message,

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -1041,12 +1041,6 @@ async def chat(
     if chat_in.images and agent.enable_vision:
         model_capabilities = await get_model_capabilities(agent)
         model_supports_vision = model_capabilities.get("vision", False)
-        if not model_supports_vision:
-            raise BusinessError(
-                code=ResponseCode.MODEL_VISION_NOT_SUPPORTED,
-                msg_key="model_vision_not_supported",
-                status_code=400,
-            )
 
     streaming_config = get_streaming_config(agent)
     tool_timeouts = streaming_config["tool_timeouts"]
@@ -1548,14 +1542,11 @@ async def chat_stream(
                 try:
                     from app.models.agent import RAGMode
 
-                    # Check if model supports vision when images are provided (before creating messages)
+                    # Check if model supports vision before creating multimodal messages.
                     model_supports_vision = False
                     if chat_in.images and agent.enable_vision:
                         model_capabilities = await get_model_capabilities(agent)
                         model_supports_vision = model_capabilities.get("vision", False)
-                        if not model_supports_vision:
-                            yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.MODEL_VISION_NOT_SUPPORTED, 'msg': t('model_vision_not_supported')})}\n\n"
-                            return
 
                     # Handle RAG based on mode
                     rag_contexts: list[dict] = []

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -62,6 +62,15 @@ from app.services.chat_context import (
     prepare_model_context,
     retry_prepare_model_context,
 )
+from app.services.message_branching import (
+    activate_conversation_branch,
+    find_descendant_branch_from,
+    get_last_active_canonical_message,
+    get_prefix_path_before,
+    get_version_count as get_branch_version_count,
+    get_version_root_id,
+    stale_session_memory_if_source_outside_active_branch,
+)
 
 # Import helper functions from modules
 from app.api.v1.endpoints.chat_helpers import (
@@ -273,6 +282,11 @@ async def get_or_create_conversation(
     )
 
     return conversation
+
+
+async def get_next_user_branch_parent_id(conversation: Conversation) -> UUID | None:
+    last_message = await get_last_active_canonical_message(conversation.id)
+    return last_message.id if last_message else None
 
 
 async def update_message_stats(agent: Agent, token_usage: dict | None = None):
@@ -1009,6 +1023,7 @@ async def chat(
 
     round_id = uuid4()
     next_round_index = 1
+    user_branch_parent_id = await get_next_user_branch_parent_id(conversation)
 
     # Save user message with images and file_urls
     user_msg = await Message.create(
@@ -1020,6 +1035,7 @@ async def chat(
         if chat_in.file_urls
         else None,
         rag_context=rag_contexts if rag_contexts else None,
+        branch_parent_id=user_branch_parent_id,
         round_id=round_id,
         round_index=0,
         round_role=MessageRoundRole.USER_INPUT,
@@ -1371,6 +1387,7 @@ async def chat(
             },
             duration_ms=duration_ms,
             tool_calls=final_tool_calls,
+            branch_parent_id=user_msg.id,
             round_id=round_id,
             round_index=next_round_index,
             round_role=MessageRoundRole.ASSISTANT_FINAL,
@@ -1404,6 +1421,11 @@ async def chat(
         # Update agent stats atomically
         await Agent.filter(id=agent.id).update(message_count=F("message_count") + 2)
 
+        branch_prefix = await get_prefix_path_before(user_msg)
+        await activate_conversation_branch(
+            conversation.id,
+            [*branch_prefix, user_msg, assistant_msg],
+        )
         enqueue_session_memory_extraction(agent, conversation, assistant_msg)
 
         return success(
@@ -1573,6 +1595,9 @@ async def chat_stream(
 
                     round_id = uuid4()
                     next_round_index = 1
+                    user_branch_parent_id = await get_next_user_branch_parent_id(
+                        conversation
+                    )
 
                     # Save user message with images and file_urls
                     user_msg = await Message.create(
@@ -1586,6 +1611,7 @@ async def chat_stream(
                         if chat_in.file_urls
                         else None,
                         rag_context=rag_contexts if rag_contexts else None,
+                        branch_parent_id=user_branch_parent_id,
                         round_id=round_id,
                         round_index=0,
                         round_role=MessageRoundRole.USER_INPUT,
@@ -1597,6 +1623,7 @@ async def chat_stream(
                         conversation=conversation,
                         role=MessageRole.ASSISTANT,
                         content="",  # Will be updated
+                        branch_parent_id=user_msg.id,
                         round_id=round_id,
                         round_index=0,
                         round_role=MessageRoundRole.ASSISTANT_FINAL,
@@ -2315,6 +2342,11 @@ async def chat_stream(
                         "completion": output_tokens,
                     }
                     await assistant_msg.save()
+                    branch_prefix = await get_prefix_path_before(user_msg)
+                    await activate_conversation_branch(
+                        conversation.id,
+                        [*branch_prefix, user_msg, assistant_msg],
+                    )
                     enqueue_session_memory_extraction(
                         agent, conversation, assistant_msg
                     )
@@ -2666,8 +2698,8 @@ async def switch_message_version(
         )
 
     # Verify target version belongs to the same version group
-    root_id = message.parent_id or message.id
-    target_root_id = target_version.parent_id or target_version.id
+    root_id = get_version_root_id(message)
+    target_root_id = get_version_root_id(target_version)
     if root_id != target_root_id:
         raise BusinessError(
             code=ResponseCode.BAD_REQUEST,
@@ -2675,45 +2707,13 @@ async def switch_message_version(
             status_code=400,
         )
 
-    # Deactivate all versions in this group
-    await Message.filter(id=root_id).update(is_active=False)
-    await Message.filter(parent_id=root_id).update(is_active=False)
-
-    # Activate the target version
-    target_version.is_active = True
-    await target_version.save()
-
-    # Get the root message to use its created_at for deactivating subsequent messages
-    root_message = await Message.filter(id=root_id).first()
-    if root_message:
-        # Get all tool_call_ids from the target version
-        target_tool_call_ids = set()
-        if target_version.tool_calls:
-            for tc in target_version.tool_calls:
-                if isinstance(tc, dict) and "id" in tc:
-                    target_tool_call_ids.add(tc["id"])
-
-        # Deactivate all messages after the root message in the conversation
-        # EXCEPT the target version itself and tool messages that belong to it
-        messages_to_deactivate = await Message.filter(
-            conversation_id=message.conversation_id,
-            created_at__gt=root_message.created_at,
-            is_active=True,
-        ).all()
-
-        for msg in messages_to_deactivate:
-            # Keep the target version itself
-            if msg.id == target_version.id:
-                continue
-            # Keep tool messages that belong to the target version
-            if (
-                msg.role == MessageRole.TOOL
-                and msg.tool_call_id in target_tool_call_ids
-            ):
-                continue
-            # Deactivate all other messages
-            msg.is_active = False
-            await msg.save()
+    prefix = await get_prefix_path_before(target_version)
+    descendant_branch = await find_descendant_branch_from(target_version)
+    await activate_conversation_branch(
+        message.conversation_id,
+        [*prefix, *descendant_branch],
+    )
+    await stale_session_memory_if_source_outside_active_branch(message.conversation_id)
 
     return success(
         data=await build_message_out_with_versions(
@@ -2774,17 +2774,14 @@ async def regenerate_message(
             status_code=404,
         )
 
-    # Find the user message before this assistant message
-    # We need to get the active user message that preceded this response
-    user_message = (
-        await Message.filter(
-            conversation_id=conversation.id,
-            role=MessageRole.USER,
-            created_at__lt=message.created_at,
-            is_active=True,
-        )
-        .order_by("-created_at")
-        .first()
+    prefix_for_message = await get_prefix_path_before(message)
+    user_message = next(
+        (
+            item
+            for item in reversed(prefix_for_message)
+            if item.role == MessageRole.USER
+        ),
+        None,
     )
 
     if not user_message:
@@ -2815,6 +2812,26 @@ async def regenerate_message(
                 FinishReason,
             )
 
+            async def activate_regenerated_path() -> None:
+                if not new_message:
+                    return
+                prefix = await get_prefix_path_before(new_message)
+                await activate_conversation_branch(
+                    conversation.id,
+                    [*prefix, new_message],
+                )
+                await stale_session_memory_if_source_outside_active_branch(
+                    conversation.id
+                )
+
+            async def restore_original_path() -> None:
+                prefix = await get_prefix_path_before(message)
+                descendant_branch = await find_descendant_branch_from(message)
+                await activate_conversation_branch(
+                    conversation.id,
+                    [*prefix, *descendant_branch],
+                )
+
             # Get streaming configuration
             streaming_config = get_streaming_config(agent)
             global_timeout = streaming_config["global_timeout"]
@@ -2843,17 +2860,15 @@ async def regenerate_message(
                     from app.models.agent import RAGMode
 
                     # Determine the root message ID for versioning
-                    root_id = message.parent_id or message.id
+                    root_id = get_version_root_id(message)
 
                     # Get current version count
-                    current_version_count = (
-                        await Message.filter(parent_id=root_id).count() + 1
-                    )
+                    current_version_count = await get_branch_version_count(message)
                     new_version_number = current_version_count + 1
-
-                    # Deactivate all versions in this group
-                    await Message.filter(id=root_id).update(is_active=False)
-                    await Message.filter(parent_id=root_id).update(is_active=False)
+                    branch_parent_id = message.branch_parent_id
+                    if branch_parent_id is None:
+                        prefix = await get_prefix_path_before(message)
+                        branch_parent_id = prefix[-1].id if prefix else None
 
                     round_id = uuid4()
                     next_round_index = 1
@@ -2866,6 +2881,7 @@ async def regenerate_message(
                         parent_id=root_id,
                         is_active=True,
                         version_number=new_version_number,
+                        branch_parent_id=branch_parent_id,
                         round_id=round_id,
                         round_index=0,
                         round_role=MessageRoundRole.ASSISTANT_FINAL,
@@ -2959,6 +2975,7 @@ async def regenerate_message(
                             )
                             new_message.created_at = now_utc()
                             await new_message.save()
+                            await activate_regenerated_path()
                             return
 
                         # If we need to send heartbeat
@@ -3331,6 +3348,7 @@ async def regenerate_message(
                                     ],
                                     parent_id=new_message.parent_id or new_message.id,
                                     version_number=new_version_number,
+                                    branch_parent_id=new_message.id,
                                     round_id=round_id,
                                     round_index=assistant_step_index,
                                     round_role=MessageRoundRole.ASSISTANT_STEP,
@@ -3347,6 +3365,7 @@ async def regenerate_message(
                                     tool_name=tool_name,
                                     parent_id=new_message.parent_id or new_message.id,
                                     version_number=new_version_number,
+                                    branch_parent_id=new_message.id,
                                     round_id=round_id,
                                     round_index=tool_step_index,
                                     round_role=MessageRoundRole.TOOL_RESULT,
@@ -3466,6 +3485,14 @@ async def regenerate_message(
                         "completion": output_tokens,
                     }
                     await new_message.save()
+                    prefix = await get_prefix_path_before(new_message)
+                    await activate_conversation_branch(
+                        conversation.id,
+                        [*prefix, new_message],
+                    )
+                    await stale_session_memory_if_source_outside_active_branch(
+                        conversation.id
+                    )
                     enqueue_session_memory_extraction(agent, conversation, new_message)
 
                     # Update agent and team stats for regenerated message
@@ -3501,11 +3528,11 @@ async def regenerate_message(
                         fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                     )
                     if preserved_partial:
-                        await Message.filter(id=message.id).update(is_active=False)
+                        await activate_regenerated_path()
                     else:
                         if new_message_id:
                             await Message.filter(id=new_message_id).delete()
-                        await Message.filter(id=message.id).update(is_active=True)
+                        await restore_original_path()
                     logger.warning("Quota exceeded during regenerate: %s", e)
                     yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.MODEL_QUOTA_EXCEEDED, 'msg': t('model_quota_exceeded'), 'quota_type': e.quota_type})}\n\n"
                 except LLMError as e:
@@ -3519,11 +3546,11 @@ async def regenerate_message(
                         fallback_content=error_message,
                     )
                     if preserved_partial:
-                        await Message.filter(id=message.id).update(is_active=False)
+                        await activate_regenerated_path()
                     else:
                         if new_message_id:
                             await Message.filter(id=new_message_id).delete()
-                        await Message.filter(id=message.id).update(is_active=True)
+                        await restore_original_path()
                     logger.exception("LLM error during regenerate")
                     yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': error_message})}\n\n"
                 except StreamIdleTimeoutError:
@@ -3536,11 +3563,11 @@ async def regenerate_message(
                         fallback_content=t("stream_timeout_exceeded"),
                     )
                     if preserved_partial:
-                        await Message.filter(id=message.id).update(is_active=False)
+                        await activate_regenerated_path()
                     else:
                         if new_message_id:
                             await Message.filter(id=new_message_id).delete()
-                        await Message.filter(id=message.id).update(is_active=True)
+                        await restore_original_path()
                     logger.warning(
                         "Regenerate stream idle timeout (%ss) for message %s",
                         idle_timeout,
@@ -3557,11 +3584,11 @@ async def regenerate_message(
                         fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                     )
                     if preserved_partial:
-                        await Message.filter(id=message.id).update(is_active=False)
+                        await activate_regenerated_path()
                     else:
                         if new_message_id:
                             await Message.filter(id=new_message_id).delete()
-                        await Message.filter(id=message.id).update(is_active=True)
+                        await restore_original_path()
                     logger.exception("Unexpected error during regenerate")
                     yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t(GENERIC_STREAM_ERROR_KEY)})}\n\n"
 
@@ -3579,10 +3606,10 @@ async def regenerate_message(
                 fallback_content=t("stream_timeout_exceeded"),
             )
             if preserved_partial:
-                await Message.filter(id=message.id).update(is_active=False)
+                await activate_regenerated_path()
             elif new_message_id:
                 await Message.filter(id=new_message_id).delete()
-                await Message.filter(id=message.id).update(is_active=True)
+                await restore_original_path()
             # Send timeout error event
             yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t('stream_timeout_exceeded'), 'timeout': global_timeout})}\n\n"
         except asyncio.CancelledError:
@@ -3604,9 +3631,10 @@ async def regenerate_message(
                     or new_message.tool_calls
                 ):
                     await new_message.save()
+                    await activate_regenerated_path()
                 else:
                     await Message.filter(id=new_message.id).delete()
-                    await Message.filter(id=message.id).update(is_active=True)
+                    await restore_original_path()
             return
 
         except Exception as exc:
@@ -3620,10 +3648,10 @@ async def regenerate_message(
                 fallback_content=t(GENERIC_STREAM_ERROR_KEY),
             )
             if preserved_partial:
-                await Message.filter(id=message.id).update(is_active=False)
+                await activate_regenerated_path()
             elif new_message_id:
                 await Message.filter(id=new_message_id).delete()
-                await Message.filter(id=message.id).update(is_active=True)
+                await restore_original_path()
             yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t(GENERIC_STREAM_ERROR_KEY)})}\n\n"
             return
 

--- a/backend/app/api/v1/endpoints/chat_tools.py
+++ b/backend/app/api/v1/endpoints/chat_tools.py
@@ -22,6 +22,7 @@ async def execute_tool_call(
     tool_timeouts: dict | None = None,
     user: Any = None,
     session_id: str | None = None,
+    current_images: list[Any] | None = None,
 ) -> Any:
     """Execute a tool and return the result payload."""
     from app.core.i18n import t
@@ -330,6 +331,7 @@ async def execute_tool_call(
                 session_id=session_id,
                 agent=agent,
                 user=user,
+                current_images=current_images,
             )
         except Exception as e:
             logger.exception("Builtin tool execution failed: %s", e)

--- a/backend/app/api/v1/endpoints/conversations.py
+++ b/backend/app/api/v1/endpoints/conversations.py
@@ -31,6 +31,7 @@ from app.schemas.response import (
     success,
 )
 from app.api.v1.endpoints.chat import build_message_round_payloads
+from app.services.message_branching import get_visible_conversation_messages
 
 
 router = APIRouter()
@@ -485,10 +486,7 @@ async def get_conversation_detail(
                     status_code=404,
                 )
 
-    messages = await Message.filter(
-        conversation_id=conversation.id,
-        is_active=True,
-    ).order_by("created_at")
+    messages = await get_visible_conversation_messages(conversation.id)
 
     # Batch calculate version counts
     root_ids = set()

--- a/backend/app/api/v1/endpoints/embed.py
+++ b/backend/app/api/v1/endpoints/embed.py
@@ -29,6 +29,7 @@ from app.models.workflow import Workflow, WorkflowStatus
 from app.schemas.agent import ChatRequest, EmbedAgentInfo
 from app.api.v1.endpoints.chat import build_message_round_payloads
 from app.schemas.response import BusinessError, ResponseCode, success
+from app.services.message_branching import get_visible_conversation_messages
 
 logger = logging.getLogger(__name__)
 
@@ -232,8 +233,6 @@ async def get_embed_conversation_messages(
     user, api_key = auth_result
     agent = await _get_embed_agent(agent_id, api_key, request)
 
-    from app.models.agent import Message
-
     conversation = await Conversation.filter(
         id=conversation_id,
         agent_id=agent.id,
@@ -247,10 +246,7 @@ async def get_embed_conversation_messages(
             status_code=404,
         )
 
-    messages = await Message.filter(
-        conversation=conversation,
-        is_active=True,
-    ).order_by("created_at")
+    messages = await get_visible_conversation_messages(conversation.id)
 
     return success(
         data=await build_message_round_payloads(messages),

--- a/backend/app/core/i18n_legacy.py
+++ b/backend/app/core/i18n_legacy.py
@@ -2322,6 +2322,11 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "en": "Cannot convert between {from_unit} and {to_unit}",
         "zh": "无法在 {from_unit} 和 {to_unit} 之间转换",
     },
+    "model_service_request_failed": {
+        "en": "Model service request failed: {message}",
+        "zh": "模型服务请求失败：{message}",
+    },
+    "model_call_failed": {"en": "Model call failed", "zh": "模型调用失败"},
     "unknown": {"en": "Unknown", "zh": "未知"},
     "unknown_error": {"en": "Unknown error", "zh": "未知错误"},
     "unknown_error_generic": {"en": "Unknown error", "zh": "未知错误"},

--- a/backend/app/core/i18n_legacy.py
+++ b/backend/app/core/i18n_legacy.py
@@ -909,6 +909,22 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "en": "Reference images are disabled for this agent",
         "zh": "当前智能体已禁用参考图",
     },
+    "image_reference_images_conflict": {
+        "en": "Use either explicit reference images or uploaded image indexes, not both",
+        "zh": "请仅使用显式参考图或上传图片索引之一，不能同时使用",
+    },
+    "image_reference_image_index_out_of_range": {
+        "en": "Reference image index {index} is out of range. Available uploaded images: {count}",
+        "zh": "参考图片索引 {index} 超出范围。可用上传图片数量：{count}",
+    },
+    "image_reference_invalid_uploaded_image": {
+        "en": "Uploaded image #{index} does not contain usable image data",
+        "zh": "上传图片 #{index} 不包含可用的图片数据",
+    },
+    "image_reference_no_uploaded_images": {
+        "en": "No uploaded images are available for the selected reference indexes",
+        "zh": "当前没有可用于所选参考索引的上传图片",
+    },
     "image_to_video_removed_from_project": {
         "en": "Image-to-video has been removed from the project",
         "zh": "项目已移除图生视频功能",
@@ -2395,6 +2411,14 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
     "video_generation_not_enabled_for_agent": {
         "en": "Video generation is not enabled for this agent",
         "zh": "当前智能体未启用视频生成",
+    },
+    "video_reference_images_not_supported_for_model": {
+        "en": "The selected video model does not support uploaded images as starting-frame references yet",
+        "zh": "当前选择的视频模型暂不支持将上传图片作为首帧参考",
+    },
+    "video_reference_image_requires_remote_url": {
+        "en": "Provider {provider} requires a public image URL for video start-frame references",
+        "zh": "服务商 {provider} 需要公网图片 URL 才能作为视频首帧参考",
     },
     "video_generation_started": {
         "en": "Video generation started. Task {task_id} is {status}. Prompt: {prompt}",

--- a/backend/app/core/init_data.py
+++ b/backend/app/core/init_data.py
@@ -516,6 +516,82 @@ async def init_message_round_fields():
     logger.info("Message round metadata migration complete")
 
 
+async def init_message_branch_parent_field():
+    """
+    Add branch_parent_id to messages and backfill a best-effort visible branch.
+    Must be called BEFORE Tortoise.generate_schemas() to avoid schema mismatch.
+    """
+    logger.info("Initializing message branch parent field...")
+
+    conn = Tortoise.get_connection("default")
+
+    _, tables = await conn.execute_query("""
+        SELECT table_name FROM information_schema.tables
+        WHERE table_name = 'messages' AND table_schema = 'public'
+    """)
+
+    if not tables:
+        logger.info(
+            "Messages table does not exist yet, skipping branch parent migration"
+        )
+        return
+
+    await conn.execute_query("""
+        ALTER TABLE messages
+        ADD COLUMN IF NOT EXISTS branch_parent_id UUID NULL
+    """)
+    await conn.execute_query("""
+        CREATE INDEX IF NOT EXISTS idx_messages_conversation_branch_parent
+        ON messages (conversation_id, branch_parent_id)
+    """)
+
+    await conn.execute_query("""
+        WITH active_canonical AS (
+            SELECT
+                id,
+                LAG(id) OVER (PARTITION BY conversation_id ORDER BY created_at, id) AS previous_id
+            FROM messages
+            WHERE is_active = TRUE
+              AND (round_id IS NULL OR is_round_canonical = TRUE)
+        )
+        UPDATE messages AS m
+        SET branch_parent_id = active_canonical.previous_id
+        FROM active_canonical
+        WHERE m.id = active_canonical.id
+          AND m.branch_parent_id IS NULL
+    """)
+
+    await conn.execute_query("""
+        UPDATE messages AS m
+        SET branch_parent_id = root.branch_parent_id
+        FROM messages AS root
+        WHERE m.parent_id = root.id
+          AND m.branch_parent_id IS NULL
+    """)
+
+    await conn.execute_query("""
+        WITH round_canonical AS (
+            SELECT DISTINCT ON (conversation_id, round_id)
+                conversation_id,
+                round_id,
+                id AS canonical_id
+            FROM messages
+            WHERE round_id IS NOT NULL
+              AND is_round_canonical = TRUE
+            ORDER BY conversation_id, round_id, created_at, id
+        )
+        UPDATE messages AS m
+        SET branch_parent_id = round_canonical.canonical_id
+        FROM round_canonical
+        WHERE m.conversation_id = round_canonical.conversation_id
+          AND m.round_id = round_canonical.round_id
+          AND m.is_round_canonical = FALSE
+          AND m.branch_parent_id IS NULL
+    """)
+
+    logger.info("Message branch parent migration complete")
+
+
 async def init_conversation_session_memory_table():
     """Create the conversation_session_memories table if it does not exist."""
     logger.info("Initializing conversation session memory table...")

--- a/backend/app/llm/adapters/dashscope_video_client.py
+++ b/backend/app/llm/adapters/dashscope_video_client.py
@@ -121,10 +121,15 @@ class DashScopeVideoClient:
 
         return response.json()
 
-    async def create_task(self, payload: dict[str, Any]) -> dict[str, Any]:
+    async def create_task(
+        self,
+        payload: dict[str, Any],
+        *,
+        path: str = "/services/aigc/video-generation/generation",
+    ) -> dict[str, Any]:
         return await self._request(
             "POST",
-            "/services/aigc/video-generation/generation",
+            path,
             json=payload,
             async_mode=True,
         )

--- a/backend/app/llm/adapters/kling_client.py
+++ b/backend/app/llm/adapters/kling_client.py
@@ -120,8 +120,13 @@ class KlingClient:
     async def create_task(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         return await self._request("POST", path, json=payload)
 
-    async def get_task(self, task_id: str) -> dict[str, Any]:
-        return await self._request("GET", f"/v1/videos/text2video/{task_id}")
+    async def get_task(
+        self,
+        task_id: str,
+        *,
+        task_type: str = "text2video",
+    ) -> dict[str, Any]:
+        return await self._request("GET", f"/v1/videos/{task_type}/{task_id}")
 
     async def wait_for_task(self, task_id: str) -> dict[str, Any]:
         elapsed = 0.0

--- a/backend/app/llm/adapters/media_utils.py
+++ b/backend/app/llm/adapters/media_utils.py
@@ -123,7 +123,9 @@ def image_content_to_data_uri(
     field_name: str,
 ) -> str:
     mime_format = content.format or "png"
-    mime_type = "image/jpeg" if mime_format in {"jpg", "jpeg"} else f"image/{mime_format}"
+    mime_type = (
+        "image/jpeg" if mime_format in {"jpg", "jpeg"} else f"image/{mime_format}"
+    )
     return media_content_to_data_uri(
         content,
         default_mime=mime_type,

--- a/backend/app/llm/adapters/media_utils.py
+++ b/backend/app/llm/adapters/media_utils.py
@@ -8,8 +8,9 @@ import base64
 import mimetypes
 from pathlib import Path
 
+from app.core.i18n import t
 from app.llm.errors import InvalidRequestError
-from app.llm.types.base import MediaContent
+from app.llm.types.base import ImageContent, MediaContent
 
 _ASPECT_RATIO_VALUES: dict[str, float] = {
     "21:9": 21 / 9,
@@ -90,6 +91,42 @@ def media_content_to_data_uri(
     )
 
 
+def image_content_to_data_uri(
+    content: ImageContent,
+    *,
+    provider: str,
+    model: str,
+    field_name: str,
+) -> str:
+    mime_format = content.format or "png"
+    mime_type = "image/jpeg" if mime_format in {"jpg", "jpeg"} else f"image/{mime_format}"
+    return media_content_to_data_uri(
+        content,
+        default_mime=mime_type,
+        provider=provider,
+        model=model,
+        field_name=field_name,
+    )
+
+
+def image_content_to_raw_base64(
+    content: ImageContent,
+    *,
+    provider: str,
+    model: str,
+    field_name: str,
+) -> str:
+    value = image_content_to_data_uri(
+        content,
+        provider=provider,
+        model=model,
+        field_name=field_name,
+    )
+    if value.startswith("data:"):
+        return value.split(",", 1)[1]
+    return value
+
+
 def require_remote_url(
     content: MediaContent,
     *,
@@ -102,7 +139,10 @@ def require_remote_url(
         return content.url
 
     raise InvalidRequestError(
-        message=f"{field_name} must provide a remote URL for provider {provider}",
+        message=t(
+            "video_reference_image_requires_remote_url",
+            provider=provider,
+        ),
         field=field_name,
         provider=provider,
         model=model,

--- a/backend/app/llm/adapters/media_utils.py
+++ b/backend/app/llm/adapters/media_utils.py
@@ -55,6 +55,30 @@ def infer_format(value: str | None, default: str) -> str:
     return default
 
 
+def infer_image_format_from_mime(mime_type: str | None) -> str | None:
+    if not mime_type:
+        return None
+    normalized = mime_type.split(";", 1)[0].strip().lower()
+    if normalized in {"image/jpeg", "image/jpg"}:
+        return "jpg"
+    if normalized.startswith("image/"):
+        return normalized.split("/", 1)[1]
+    return None
+
+
+def parse_image_data_url(value: str) -> tuple[str, str | None] | None:
+    if not value.startswith("data:"):
+        return None
+    try:
+        metadata, data_part = value.split(",", 1)
+    except ValueError:
+        return None
+    header = metadata[5:]
+    if ";base64" not in header.lower():
+        return None
+    return data_part, infer_image_format_from_mime(header.split(";", 1)[0])
+
+
 def media_content_to_data_uri(
     content: MediaContent,
     *,

--- a/backend/app/llm/adapters/video/base.py
+++ b/backend/app/llm/adapters/video/base.py
@@ -12,7 +12,9 @@ from app.llm.types import VideoGenerationRequest, VideoGenerationResponse
 class BaseVideoAdapter(ABC):
     """Base class for text-to-video adapters."""
 
-    def _ensure_reference_images_supported(self, request: VideoGenerationRequest) -> None:
+    def _ensure_reference_images_supported(
+        self, request: VideoGenerationRequest
+    ) -> None:
         if request.start_image is None:
             return
         raise InvalidRequestError(

--- a/backend/app/llm/adapters/video/base.py
+++ b/backend/app/llm/adapters/video/base.py
@@ -4,11 +4,21 @@ Video generation adapter base classes.
 
 from abc import ABC, abstractmethod
 
+from app.core.i18n import t
+from app.llm.errors import InvalidRequestError
 from app.llm.types import VideoGenerationRequest, VideoGenerationResponse
 
 
 class BaseVideoAdapter(ABC):
     """Base class for text-to-video adapters."""
+
+    def _ensure_reference_images_supported(self, request: VideoGenerationRequest) -> None:
+        if request.start_image is None:
+            return
+        raise InvalidRequestError(
+            message=t("video_reference_images_not_supported_for_model"),
+            field="start_image",
+        )
 
     @abstractmethod
     async def generate(

--- a/backend/app/llm/adapters/video/dashscope.py
+++ b/backend/app/llm/adapters/video/dashscope.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.core.i18n import t
-from app.llm.errors import ProviderError
+from app.llm.errors import InvalidRequestError, ProviderError
 from app.llm.types import (
     TaskStatus,
     VideoContent,
@@ -16,9 +16,12 @@ from app.llm.types import (
 )
 from app.models.model import Model
 
-from ..media_utils import append_prompt_directives
+from ..media_utils import append_prompt_directives, image_content_to_data_uri
 from ..dashscope_video_client import DashScopeVideoClient
 from .base import BaseVideoAdapter
+
+
+_DASHSCOPE_IMAGE_TO_VIDEO_MODEL_MARKERS = ("i2v", "image-to-video")
 
 
 class DashScopeVideoAdapter(BaseVideoAdapter):
@@ -32,8 +35,15 @@ class DashScopeVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
+        if request.start_image is None:
+            self._ensure_reference_images_supported(request)
         payload = self._build_payload(request)
-        result = await self.client.create_task(payload)
+        path = (
+            "/services/aigc/video-generation/video-synthesis"
+            if request.start_image is not None
+            else "/services/aigc/video-generation/generation"
+        )
+        result = await self.client.create_task(payload, path=path)
         output = result.get("output", {})
         task_id = output.get("task_id")
         if not task_id:
@@ -71,6 +81,15 @@ class DashScopeVideoAdapter(BaseVideoAdapter):
             "parameters": {},
         }
 
+        if request.start_image is not None:
+            self._ensure_image_to_video_model()
+            payload["input"]["img_url"] = image_content_to_data_uri(
+                request.start_image,
+                provider="qwen",
+                model=self.model_id,
+                field_name="img_url",
+            )
+
         if request.aspect_ratio:
             payload["parameters"]["size"] = request.aspect_ratio
         if request.duration:
@@ -83,6 +102,17 @@ class DashScopeVideoAdapter(BaseVideoAdapter):
             payload["parameters"].update(request.extra_params)
 
         return payload
+
+    def _ensure_image_to_video_model(self) -> None:
+        normalized = self.model_id.lower()
+        if any(marker in normalized for marker in _DASHSCOPE_IMAGE_TO_VIDEO_MODEL_MARKERS):
+            return
+        raise InvalidRequestError(
+            message=t("video_reference_images_not_supported_for_model"),
+            field="start_image",
+            provider="qwen",
+            model=self.model_id,
+        )
 
     def _map_status(self, raw_status: Any) -> TaskStatus:
         status = str(raw_status or "").upper()

--- a/backend/app/llm/adapters/video/dashscope.py
+++ b/backend/app/llm/adapters/video/dashscope.py
@@ -35,8 +35,6 @@ class DashScopeVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
-        if request.start_image is None:
-            self._ensure_reference_images_supported(request)
         payload = self._build_payload(request)
         path = (
             "/services/aigc/video-generation/video-synthesis"

--- a/backend/app/llm/adapters/video/dashscope.py
+++ b/backend/app/llm/adapters/video/dashscope.py
@@ -103,7 +103,9 @@ class DashScopeVideoAdapter(BaseVideoAdapter):
 
     def _ensure_image_to_video_model(self) -> None:
         normalized = self.model_id.lower()
-        if any(marker in normalized for marker in _DASHSCOPE_IMAGE_TO_VIDEO_MODEL_MARKERS):
+        if any(
+            marker in normalized for marker in _DASHSCOPE_IMAGE_TO_VIDEO_MODEL_MARKERS
+        ):
             return
         raise InvalidRequestError(
             message=t("video_reference_images_not_supported_for_model"),

--- a/backend/app/llm/adapters/video/kling.py
+++ b/backend/app/llm/adapters/video/kling.py
@@ -17,7 +17,7 @@ from app.llm.types import (
 from app.models.model import Model
 
 from ..kling_client import KlingClient
-from ..media_utils import append_prompt_directives
+from ..media_utils import append_prompt_directives, image_content_to_raw_base64
 from .base import BaseVideoAdapter
 
 
@@ -32,8 +32,11 @@ class KlingVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
+        if request.start_image is None:
+            self._ensure_reference_images_supported(request)
         payload = self._build_payload(request)
-        task = await self.client.create_task("/v1/videos/text2video", payload)
+        task_type = "image2video" if request.start_image is not None else "text2video"
+        task = await self.client.create_task(f"/v1/videos/{task_type}", payload)
         task_id = task.get("task_id")
         if not task_id:
             raise ProviderError(
@@ -41,10 +44,11 @@ class KlingVideoAdapter(BaseVideoAdapter):
                 provider="kling",
                 model=self.model_id,
             )
-        return await self.get_status(str(task_id))
+        return await self.get_status(self._encode_task_id(str(task_id), task_type))
 
     async def get_status(self, task_id: str) -> VideoGenerationResponse:
-        task = await self.client.get_task(task_id)
+        task_type, raw_task_id = self._decode_task_id(task_id)
+        task = await self.client.get_task(raw_task_id, task_type=task_type)
         status = self._map_status(task.get("task_status"))
         video_url = self._extract_video_url(task)
         return VideoGenerationResponse(
@@ -69,6 +73,14 @@ class KlingVideoAdapter(BaseVideoAdapter):
             "aspect_ratio": request.aspect_ratio,
         }
 
+        if request.start_image is not None:
+            payload["image"] = image_content_to_raw_base64(
+                request.start_image,
+                provider="kling",
+                model=self.model_id,
+                field_name="image",
+            )
+
         if request.seed is not None:
             payload["seed"] = request.seed
 
@@ -76,6 +88,19 @@ class KlingVideoAdapter(BaseVideoAdapter):
             payload.update(request.extra_params)
 
         return payload
+
+    def _encode_task_id(self, task_id: str, task_type: str) -> str:
+        if task_type == "text2video":
+            return task_id
+        return f"{task_type}:{task_id}"
+
+    def _decode_task_id(self, task_id: str) -> tuple[str, str]:
+        if ":" not in task_id:
+            return "text2video", task_id
+        task_type, raw_task_id = task_id.split(":", 1)
+        if task_type in {"text2video", "image2video"} and raw_task_id:
+            return task_type, raw_task_id
+        return "text2video", task_id
 
     def _map_status(self, raw_status: Any) -> TaskStatus:
         status = str(raw_status or "").lower()

--- a/backend/app/llm/adapters/video/kling.py
+++ b/backend/app/llm/adapters/video/kling.py
@@ -32,8 +32,6 @@ class KlingVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
-        if request.start_image is None:
-            self._ensure_reference_images_supported(request)
         payload = self._build_payload(request)
         task_type = "image2video" if request.start_image is not None else "text2video"
         task = await self.client.create_task(f"/v1/videos/{task_type}", payload)

--- a/backend/app/llm/adapters/video/luma.py
+++ b/backend/app/llm/adapters/video/luma.py
@@ -32,8 +32,6 @@ class LumaVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
-        if request.start_image is None:
-            self._ensure_reference_images_supported(request)
         payload = self._build_payload(request)
         generation = await self.client.create_generation("/generations", payload)
         generation_id = generation.get("id")

--- a/backend/app/llm/adapters/video/luma.py
+++ b/backend/app/llm/adapters/video/luma.py
@@ -17,7 +17,7 @@ from app.llm.types import (
 from app.models.model import Model
 
 from ..luma_client import LumaClient
-from ..media_utils import append_prompt_directives
+from ..media_utils import append_prompt_directives, require_remote_url
 from .base import BaseVideoAdapter
 
 
@@ -32,6 +32,8 @@ class LumaVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
+        if request.start_image is None:
+            self._ensure_reference_images_supported(request)
         payload = self._build_payload(request)
         generation = await self.client.create_generation("/generations", payload)
         generation_id = generation.get("id")
@@ -73,6 +75,19 @@ class LumaVideoAdapter(BaseVideoAdapter):
             "duration": self._format_duration(request.duration),
             "aspect_ratio": request.aspect_ratio,
         }
+
+        if request.start_image is not None:
+            payload["keyframes"] = {
+                "frame0": {
+                    "type": "image",
+                    "url": require_remote_url(
+                        request.start_image,
+                        provider="luma",
+                        model=self.model_id,
+                        field_name="start_image",
+                    ),
+                }
+            }
 
         if request.seed is not None:
             payload["seed"] = request.seed

--- a/backend/app/llm/adapters/video/pika.py
+++ b/backend/app/llm/adapters/video/pika.py
@@ -32,8 +32,6 @@ class PikaVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
-        if request.start_image is None:
-            self._ensure_reference_images_supported(request)
         payload = self._build_payload(request)
         generation = await self.client.create_generation("/generate", payload)
         generation_id = generation.get("id")

--- a/backend/app/llm/adapters/video/pika.py
+++ b/backend/app/llm/adapters/video/pika.py
@@ -16,7 +16,7 @@ from app.llm.types import (
 )
 from app.models.model import Model
 
-from ..media_utils import append_prompt_directives
+from ..media_utils import append_prompt_directives, image_content_to_data_uri
 from ..pika_client import PikaClient
 from .base import BaseVideoAdapter
 
@@ -32,6 +32,8 @@ class PikaVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
+        if request.start_image is None:
+            self._ensure_reference_images_supported(request)
         payload = self._build_payload(request)
         generation = await self.client.create_generation("/generate", payload)
         generation_id = generation.get("id")
@@ -71,6 +73,15 @@ class PikaVideoAdapter(BaseVideoAdapter):
             "aspectRatio": request.aspect_ratio,
         }
 
+        if request.start_image is not None:
+            field_name = self._start_image_field_name()
+            payload[field_name] = image_content_to_data_uri(
+                request.start_image,
+                provider="pika",
+                model=self.model_id,
+                field_name=field_name,
+            )
+
         if request.seed is not None:
             payload["seed"] = request.seed
 
@@ -78,6 +89,12 @@ class PikaVideoAdapter(BaseVideoAdapter):
             payload.update(request.extra_params)
 
         return payload
+
+    def _start_image_field_name(self) -> str:
+        value = self.client.config.get("start_image_field")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return "image_url"
 
     def _map_status(self, raw_status: Any) -> TaskStatus:
         status = str(raw_status or "").lower()

--- a/backend/app/llm/adapters/video/runway.py
+++ b/backend/app/llm/adapters/video/runway.py
@@ -16,11 +16,12 @@ from app.llm.types import (
 )
 from app.models.model import Model
 
-from ..media_utils import append_prompt_directives
+from ..media_utils import append_prompt_directives, image_content_to_data_uri
 from ..runway_client import RunwayClient
 from .base import BaseVideoAdapter
 
 _TEXT_TO_VIDEO_MODELS = {"gen4.5", "veo3", "veo3.1", "veo3.1_fast"}
+_IMAGE_TO_VIDEO_MODELS = {"gen4_turbo", "gen4.5_turbo", "gen4_aleph"}
 _TEXT_TO_VIDEO_RATIOS = {
     "16:9": "1280:720",
     "9:16": "720:1280",
@@ -38,6 +39,7 @@ class RunwayVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
+        self._ensure_reference_images_supported(request)
         task = await self.client.create_task(*self._build_request(request))
         task_id = task.get("id")
         if not task_id:
@@ -72,6 +74,9 @@ class RunwayVideoAdapter(BaseVideoAdapter):
         )
         duration = int(round(request.duration))
 
+        if request.start_image is not None:
+            return self._build_image_to_video_request(request, prompt, duration)
+
         if self.model_id not in _TEXT_TO_VIDEO_MODELS:
             raise InvalidRequestError(
                 message=f"Model {self.model_id} does not support text-to-video on Runway",
@@ -92,6 +97,39 @@ class RunwayVideoAdapter(BaseVideoAdapter):
         if request.extra_params:
             payload.update(request.extra_params)
         return "/v1/text_to_video", payload
+
+    def _build_image_to_video_request(
+        self,
+        request: VideoGenerationRequest,
+        prompt: str,
+        duration: int,
+    ) -> tuple[str, dict[str, Any]]:
+        if self.model_id not in _IMAGE_TO_VIDEO_MODELS:
+            raise InvalidRequestError(
+                message=f"Model {self.model_id} does not support image-to-video on Runway",
+                provider="runway",
+                model=self.model_id,
+            )
+
+        payload = {
+            "model": self.model_id,
+            "promptText": prompt,
+            "promptImage": image_content_to_data_uri(
+                request.start_image,
+                provider="runway",
+                model=self.model_id,
+                field_name="promptImage",
+            ),
+            "ratio": _TEXT_TO_VIDEO_RATIOS.get(
+                request.aspect_ratio, _TEXT_TO_VIDEO_RATIOS["16:9"]
+            ),
+            "duration": duration,
+        }
+        if request.seed is not None:
+            payload["seed"] = request.seed
+        if request.extra_params:
+            payload.update(request.extra_params)
+        return "/v1/image_to_video", payload
 
     def _map_status(self, raw_status: Any) -> TaskStatus:
         status = str(raw_status or "").upper()

--- a/backend/app/llm/adapters/video/runway.py
+++ b/backend/app/llm/adapters/video/runway.py
@@ -39,7 +39,6 @@ class RunwayVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
-        self._ensure_reference_images_supported(request)
         task = await self.client.create_task(*self._build_request(request))
         task_id = task.get("id")
         if not task_id:

--- a/backend/app/llm/adapters/video/siliconflow.py
+++ b/backend/app/llm/adapters/video/siliconflow.py
@@ -44,8 +44,6 @@ class SiliconFlowVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
-        if request.start_image is None:
-            self._ensure_reference_images_supported(request)
         payload = self._build_payload(request)
         result = await self.client.create_task(payload)
         request_id = result.get("requestId")

--- a/backend/app/llm/adapters/video/siliconflow.py
+++ b/backend/app/llm/adapters/video/siliconflow.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.core.i18n import t
-from app.llm.errors import ProviderError
+from app.llm.errors import InvalidRequestError, ProviderError
 from app.llm.types import (
     TaskStatus,
     VideoContent,
@@ -16,7 +16,7 @@ from app.llm.types import (
 )
 from app.models.model import Model
 
-from ..media_utils import append_prompt_directives
+from ..media_utils import append_prompt_directives, image_content_to_data_uri
 from ..siliconflow_client import SiliconFlowClient
 from .base import BaseVideoAdapter
 
@@ -30,6 +30,9 @@ _ASPECT_RATIO_TO_SIZE: dict[str, str] = {
 }
 
 
+_SILICONFLOW_IMAGE_TO_VIDEO_MODEL_MARKERS = ("i2v", "image-to-video")
+
+
 class SiliconFlowVideoAdapter(BaseVideoAdapter):
     """SiliconFlow video-generation adapter."""
 
@@ -41,6 +44,8 @@ class SiliconFlowVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
+        if request.start_image is None:
+            self._ensure_reference_images_supported(request)
         payload = self._build_payload(request)
         result = await self.client.create_task(payload)
         request_id = result.get("requestId")
@@ -84,10 +89,30 @@ class SiliconFlowVideoAdapter(BaseVideoAdapter):
         if request.seed is not None:
             payload["seed"] = request.seed
 
+        if request.start_image is not None:
+            self._ensure_image_to_video_model()
+            payload["image"] = image_content_to_data_uri(
+                request.start_image,
+                provider="siliconflow",
+                model=self.model_id,
+                field_name="start_image",
+            )
+
         if request.extra_params:
             payload.update(request.extra_params)
 
         return payload
+
+    def _ensure_image_to_video_model(self) -> None:
+        normalized = self.model_id.lower()
+        if any(marker in normalized for marker in _SILICONFLOW_IMAGE_TO_VIDEO_MODEL_MARKERS):
+            return
+        raise InvalidRequestError(
+            message=t("video_reference_images_not_supported_for_model"),
+            field="start_image",
+            provider="siliconflow",
+            model=self.model_id,
+        )
 
     def _map_status(self, raw_status: Any) -> TaskStatus:
         status = str(raw_status or "")

--- a/backend/app/llm/adapters/video/siliconflow.py
+++ b/backend/app/llm/adapters/video/siliconflow.py
@@ -103,7 +103,9 @@ class SiliconFlowVideoAdapter(BaseVideoAdapter):
 
     def _ensure_image_to_video_model(self) -> None:
         normalized = self.model_id.lower()
-        if any(marker in normalized for marker in _SILICONFLOW_IMAGE_TO_VIDEO_MODEL_MARKERS):
+        if any(
+            marker in normalized for marker in _SILICONFLOW_IMAGE_TO_VIDEO_MODEL_MARKERS
+        ):
             return
         raise InvalidRequestError(
             message=t("video_reference_images_not_supported_for_model"),

--- a/backend/app/llm/adapters/video/volcengine.py
+++ b/backend/app/llm/adapters/video/volcengine.py
@@ -32,8 +32,6 @@ class VolcengineVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
-        if request.start_image is None:
-            self._ensure_reference_images_supported(request)
         payload = self._build_payload(request)
         result = await self.client.create_task(payload)
         task_id = result.get("id")

--- a/backend/app/llm/adapters/video/volcengine.py
+++ b/backend/app/llm/adapters/video/volcengine.py
@@ -16,7 +16,7 @@ from app.llm.types import (
 )
 from app.models.model import Model
 
-from ..media_utils import append_prompt_directives
+from ..media_utils import append_prompt_directives, image_content_to_data_uri
 from ..volcengine_client import VolcengineClient
 from .base import BaseVideoAdapter
 
@@ -32,6 +32,8 @@ class VolcengineVideoAdapter(BaseVideoAdapter):
     async def generate(
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResponse:
+        if request.start_image is None:
+            self._ensure_reference_images_supported(request)
         payload = self._build_payload(request)
         result = await self.client.create_task(payload)
         task_id = result.get("id")
@@ -68,6 +70,21 @@ class VolcengineVideoAdapter(BaseVideoAdapter):
             "content": [{"type": "text", "text": prompt}],
             "parameters": {},
         }
+
+        if request.start_image is not None:
+            payload["content"].append(
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": image_content_to_data_uri(
+                            request.start_image,
+                            provider="volcengine",
+                            model=self.model_id,
+                            field_name="start_image",
+                        )
+                    },
+                }
+            )
 
         if request.duration:
             payload["parameters"]["duration"] = request.duration

--- a/backend/app/llm/tools/builtin/media.py
+++ b/backend/app/llm/tools/builtin/media.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from app.core.i18n import t
 from app.llm import model_manager
+from app.llm.adapters.media_utils import parse_image_data_url
 from app.models.model import ModelType
 from app.services.error_messages import resolve_user_visible_error
 from app.llm.types import (
@@ -139,31 +140,6 @@ async def _normalize_image_quality(
     return mapped_quality
 
 
-def _infer_image_format_from_mime(mime_type: str | None) -> str | None:
-    if not mime_type:
-        return None
-    normalized = mime_type.split(";", 1)[0].strip().lower()
-    if normalized in {"image/jpeg", "image/jpg"}:
-        return "jpg"
-    if normalized.startswith("image/"):
-        return normalized.split("/", 1)[1]
-    return None
-
-
-def _parse_data_url_image(value: str) -> tuple[str, str] | None:
-    if not value.startswith("data:"):
-        return None
-    try:
-        metadata, data_part = value.split(",", 1)
-    except ValueError:
-        return None
-    header = metadata[5:]
-    if ";base64" not in header.lower():
-        return None
-    image_format = _infer_image_format_from_mime(header.split(";", 1)[0]) or "png"
-    return data_part, image_format
-
-
 def _get_image_source_value(image: Any, key: str) -> Any:
     if isinstance(image, dict):
         return image.get(key)
@@ -173,19 +149,19 @@ def _get_image_source_value(image: Any, key: str) -> Any:
 def _chat_image_to_generation_image(image: Any, *, index: int) -> ImageContent:
     base64_value = _get_image_source_value(image, "base64")
     if isinstance(base64_value, str) and base64_value:
-        parsed = _parse_data_url_image(base64_value)
+        parsed = parse_image_data_url(base64_value)
         if parsed:
             payload, image_format = parsed
-            return ImageContent(base64=payload, format=image_format)
+            return ImageContent(base64=payload, format=image_format or "png")
         image_format = _get_image_source_value(image, "format") or "png"
         return ImageContent(base64=base64_value, format=image_format)
 
     url = _get_image_source_value(image, "url")
     if isinstance(url, str) and url:
-        parsed = _parse_data_url_image(url)
+        parsed = parse_image_data_url(url)
         if parsed:
             payload, image_format = parsed
-            return ImageContent(base64=payload, format=image_format)
+            return ImageContent(base64=payload, format=image_format or "png")
 
     raise ValueError(t("image_reference_invalid_uploaded_image", index=index))
 

--- a/backend/app/llm/tools/builtin/media.py
+++ b/backend/app/llm/tools/builtin/media.py
@@ -139,6 +139,124 @@ async def _normalize_image_quality(
     return mapped_quality
 
 
+def _infer_image_format_from_mime(mime_type: str | None) -> str | None:
+    if not mime_type:
+        return None
+    normalized = mime_type.split(";", 1)[0].strip().lower()
+    if normalized in {"image/jpeg", "image/jpg"}:
+        return "jpg"
+    if normalized.startswith("image/"):
+        return normalized.split("/", 1)[1]
+    return None
+
+
+def _parse_data_url_image(value: str) -> tuple[str, str] | None:
+    if not value.startswith("data:"):
+        return None
+    try:
+        metadata, data_part = value.split(",", 1)
+    except ValueError:
+        return None
+    header = metadata[5:]
+    if ";base64" not in header.lower():
+        return None
+    image_format = _infer_image_format_from_mime(header.split(";", 1)[0]) or "png"
+    return data_part, image_format
+
+
+def _get_image_source_value(image: Any, key: str) -> Any:
+    if isinstance(image, dict):
+        return image.get(key)
+    return getattr(image, key, None)
+
+
+def _chat_image_to_generation_image(image: Any, *, index: int) -> ImageContent:
+    base64_value = _get_image_source_value(image, "base64")
+    if isinstance(base64_value, str) and base64_value:
+        parsed = _parse_data_url_image(base64_value)
+        if parsed:
+            payload, image_format = parsed
+            return ImageContent(base64=payload, format=image_format)
+        image_format = _get_image_source_value(image, "format") or "png"
+        return ImageContent(base64=base64_value, format=image_format)
+
+    url = _get_image_source_value(image, "url")
+    if isinstance(url, str) and url:
+        parsed = _parse_data_url_image(url)
+        if parsed:
+            payload, image_format = parsed
+            return ImageContent(base64=payload, format=image_format)
+
+    raise ValueError(t("image_reference_invalid_uploaded_image", index=index))
+
+
+def _deduplicate_indexes(indexes: Sequence[Any]) -> list[int]:
+    selected: list[int] = []
+    seen: set[int] = set()
+    for raw_index in indexes:
+        if isinstance(raw_index, bool):
+            continue
+        try:
+            index = int(raw_index)
+        except (TypeError, ValueError):
+            continue
+        if index not in seen:
+            selected.append(index)
+            seen.add(index)
+    return selected
+
+
+def _resolve_generation_reference_images(
+    *,
+    images: list[dict[str, Any]] | None,
+    reference_image_indexes: Sequence[Any] | None,
+    current_images: Sequence[Any] | None,
+) -> list[ImageContent] | None:
+    if images and reference_image_indexes:
+        raise ValueError(t("image_reference_images_conflict"))
+    if images:
+        return [ImageContent.model_validate(image) for image in images]
+    if reference_image_indexes is None:
+        return None
+
+    selected_indexes = _deduplicate_indexes(reference_image_indexes)
+    if not selected_indexes:
+        return None
+    if not current_images:
+        raise ValueError(t("image_reference_no_uploaded_images"))
+
+    resolved: list[ImageContent] = []
+    available_count = len(current_images)
+    for index in selected_indexes:
+        if index < 1 or index > available_count:
+            raise ValueError(
+                t(
+                    "image_reference_image_index_out_of_range",
+                    index=index,
+                    count=available_count,
+                )
+            )
+        resolved.append(
+            _chat_image_to_generation_image(current_images[index - 1], index=index)
+        )
+    return resolved
+
+
+def _resolve_start_image_reference(
+    *,
+    start_image_index: Any,
+    current_images: Sequence[Any] | None,
+) -> ImageContent | None:
+    if start_image_index is None:
+        return None
+    reference_images = _resolve_generation_reference_images(
+        images=None,
+        reference_image_indexes=[start_image_index],
+        current_images=current_images,
+    )
+    return reference_images[0] if reference_images else None
+
+
 class ToolExecutionResult(dict):
     """Structured tool result for UI persistence and LLM replay."""
 
@@ -316,8 +434,10 @@ async def generate_image(
     negative_prompt: str | None = None,
     seed: int | None = None,
     images: list[dict[str, Any]] | None = None,
+    reference_image_indexes: list[int] | None = None,
     extra_params: dict[str, Any] | None = None,
     agent: Any | None = None,
+    current_images: list[Any] | None = None,
 ) -> dict[str, Any]:
     """Generate images through the unified model manager."""
     resolved_model_ref: str | None = None
@@ -335,7 +455,12 @@ async def generate_image(
                 t("image_generation_exceeds_agent_limit", max_images=max_images)
             )
 
-        if images and not config.get("allow_reference_images", True):
+        reference_images = _resolve_generation_reference_images(
+            images=images,
+            reference_image_indexes=reference_image_indexes,
+            current_images=current_images,
+        )
+        if reference_images and not config.get("allow_reference_images", True):
             raise ValueError(t("image_reference_images_disabled"))
 
         normalized_quality = await _normalize_image_quality(
@@ -365,9 +490,7 @@ async def generate_image(
             style=style,
             quality=normalized_quality,
             seed=seed,
-            images=[ImageContent.model_validate(image) for image in images]
-            if images
-            else None,
+            images=reference_images,
             extra_params=extra_params,
         )
         image_response = await model_manager.generate_image(
@@ -412,8 +535,10 @@ async def generate_video(
     camera_motion: str | None = None,
     style: str | None = None,
     seed: int | None = None,
+    start_image_index: int | None = None,
     extra_params: dict[str, Any] | None = None,
     agent: Any | None = None,
+    current_images: list[Any] | None = None,
 ) -> dict[str, Any]:
     """Generate videos through the unified model manager."""
     resolved_model_ref: str | None = None
@@ -441,6 +566,11 @@ async def generate_video(
         poll_interval_ms = int(config.get("poll_interval_ms", 3000))
         poll_timeout_s = int(config.get("poll_timeout_s", 120))
 
+        start_image = _resolve_start_image_reference(
+            start_image_index=start_image_index,
+            current_images=current_images,
+        )
+
         request = VideoGenerationRequest(
             prompt=prompt,
             duration=final_duration,
@@ -449,6 +579,7 @@ async def generate_video(
             camera_motion=camera_motion,
             style=style,
             seed=seed,
+            start_image=start_image,
             extra_params=extra_params,
         )
         response: VideoGenerationResponse | None = await model_manager.generate_video(
@@ -512,7 +643,9 @@ def register_media_tools() -> None:
         description=(
             "Generate one or more images from a prompt. Use this when the user asks "
             "you to create illustrations, product shots, mockups, concept art, "
-            "or edit/reference-based image outputs."
+            "or edit/reference-based image outputs. Uploaded chat images are "
+            "available as 1-based indexes; use reference_image_indexes for only "
+            "the specific uploaded images the user wants to reference."
         ),
         parameters=[
             ToolParameter(
@@ -559,8 +692,21 @@ def register_media_tools() -> None:
             ToolParameter(
                 name="images",
                 type="array",
-                description="Optional reference images for edit/reference generation",
+                description=(
+                    "Optional explicit reference image objects. For images uploaded "
+                    "in the current chat, use reference_image_indexes instead."
+                ),
                 items={"type": "object"},
+            ),
+            ToolParameter(
+                name="reference_image_indexes",
+                type="array",
+                description=(
+                    "1-based indexes of uploaded chat images to use as references. "
+                    "Choose only the specific images needed, e.g. [3] for uploaded "
+                    "image #3 or [5] for the last image when five images were uploaded."
+                ),
+                items={"type": "integer"},
             ),
             ToolParameter(
                 name="extra_params",
@@ -574,7 +720,10 @@ def register_media_tools() -> None:
         name="generate_video",
         description=(
             "Generate a short video clip from a prompt. Use this when the user asks "
-            "for cinematic motion, animated scenes, or motion-based concept clips."
+            "for cinematic motion, animated scenes, or motion-based concept clips. "
+            "When the user asks to use an uploaded image as the video's first frame, "
+            "set start_image_index to that uploaded image's 1-based index. Current "
+            "video providers may reject image references explicitly if unsupported."
         ),
         parameters=[
             ToolParameter(
@@ -612,6 +761,14 @@ def register_media_tools() -> None:
                 name="seed",
                 type="integer",
                 description="Optional random seed",
+            ),
+            ToolParameter(
+                name="start_image_index",
+                type="integer",
+                description=(
+                    "1-based index of the uploaded chat image to use as the video's "
+                    "starting frame/reference image when the selected video model supports it."
+                ),
             ),
             ToolParameter(
                 name="extra_params",

--- a/backend/app/llm/tools/builtin/media.py
+++ b/backend/app/llm/tools/builtin/media.py
@@ -450,10 +450,7 @@ async def generate_image(
         _validate_allowed_providers(resolved_model_ref, config)
 
         max_images = int(config.get("max_images", 4))
-        if num_images > max_images:
-            raise ValueError(
-                t("image_generation_exceeds_agent_limit", max_images=max_images)
-            )
+        final_num_images = min(num_images, max_images)
 
         reference_images = _resolve_generation_reference_images(
             images=images,
@@ -486,7 +483,7 @@ async def generate_image(
             negative_prompt=negative_prompt,
             width=width or int(default_width or 1024),
             height=height or int(default_height or 1024),
-            num_images=num_images,
+            num_images=final_num_images,
             style=style,
             quality=normalized_quality,
             seed=seed,

--- a/backend/app/llm/types/video.py
+++ b/backend/app/llm/types/video.py
@@ -4,7 +4,7 @@
 
 from pydantic import BaseModel, Field
 
-from .base import VideoContent, TaskStatus
+from .base import ImageContent, VideoContent, TaskStatus
 
 
 class AspectRatio(str):
@@ -33,6 +33,10 @@ class VideoGenerationRequest(BaseModel):
     camera_motion: str | None = Field(default=None, description="镜头运动描述")
     style: str | None = Field(default=None, description="风格")
     seed: int | None = Field(default=None, description="随机种子")
+    start_image: ImageContent | None = Field(
+        default=None,
+        description="起始参考图像（用于支持首帧参考的视频模型）",
+    )
     # 供应商特定参数
     extra_params: dict | None = Field(default=None, description="供应商特定参数")
 

--- a/backend/app/locales/en/LC_MESSAGES/messages.po
+++ b/backend/app/locales/en/LC_MESSAGES/messages.po
@@ -2503,6 +2503,18 @@ msgstr "Image generation request exceeds the agent limit ({max_images})"
 msgid "image_reference_images_disabled"
 msgstr "Reference images are disabled for this agent"
 
+msgid "image_reference_images_conflict"
+msgstr "Use either explicit reference images or uploaded image indexes, not both"
+
+msgid "image_reference_image_index_out_of_range"
+msgstr "Reference image index {index} is out of range. Available uploaded images: {count}"
+
+msgid "image_reference_invalid_uploaded_image"
+msgstr "Uploaded image #{index} does not contain usable image data"
+
+msgid "image_reference_no_uploaded_images"
+msgstr "No uploaded images are available for the selected reference indexes"
+
 msgid "image_generation_invalid_quality"
 msgstr "Image quality '{quality}' is not supported. Supported values: {supported}"
 
@@ -2514,6 +2526,12 @@ msgstr "Image generation succeeded. Generated {count} images using model {model}
 
 msgid "video_generation_not_enabled_for_agent"
 msgstr "Video generation is not enabled for this agent"
+
+msgid "video_reference_images_not_supported_for_model"
+msgstr "The selected video model does not support uploaded images as starting-frame references yet"
+
+msgid "video_reference_image_requires_remote_url"
+msgstr "Provider {provider} requires a public image URL for video start-frame references"
 
 msgid "embedding_model_locked_after_kb_creation"
 msgstr "Embedding model cannot be changed after knowledge base creation"

--- a/backend/app/locales/en/LC_MESSAGES/messages.po
+++ b/backend/app/locales/en/LC_MESSAGES/messages.po
@@ -2242,6 +2242,12 @@ msgstr "...[content truncated]..."
 msgid "truncation_middle_marker"
 msgstr "...[middle content truncated, {count} characters]..."
 
+msgid "model_service_request_failed"
+msgstr "Model service request failed: {message}"
+
+msgid "model_call_failed"
+msgstr "Model call failed"
+
 msgid "unauthorized"
 msgstr "Unauthorized"
 

--- a/backend/app/locales/zh/LC_MESSAGES/messages.po
+++ b/backend/app/locales/zh/LC_MESSAGES/messages.po
@@ -2242,6 +2242,12 @@ msgstr "...[内容已截断]..."
 msgid "truncation_middle_marker"
 msgstr "...[中间内容已截断，共 {count} 字符]..."
 
+msgid "model_service_request_failed"
+msgstr "模型服务请求失败：{message}"
+
+msgid "model_call_failed"
+msgstr "模型调用失败"
+
 msgid "unauthorized"
 msgstr "未授权"
 

--- a/backend/app/locales/zh/LC_MESSAGES/messages.po
+++ b/backend/app/locales/zh/LC_MESSAGES/messages.po
@@ -2503,6 +2503,18 @@ msgstr "图片生成请求超出当前智能体限制（{max_images}）"
 msgid "image_reference_images_disabled"
 msgstr "当前智能体已禁用参考图"
 
+msgid "image_reference_images_conflict"
+msgstr "请仅使用显式参考图或上传图片索引之一，不能同时使用"
+
+msgid "image_reference_image_index_out_of_range"
+msgstr "参考图片索引 {index} 超出范围。可用上传图片数量：{count}"
+
+msgid "image_reference_invalid_uploaded_image"
+msgstr "上传图片 #{index} 不包含可用的图片数据"
+
+msgid "image_reference_no_uploaded_images"
+msgstr "当前没有可用于所选参考索引的上传图片"
+
 msgid "image_generation_invalid_quality"
 msgstr "图片质量“{quality}”不受支持。支持的值：{supported}"
 
@@ -2514,6 +2526,12 @@ msgstr "图片生成成功。使用模型 {model} 生成了 {count} 张图片。
 
 msgid "video_generation_not_enabled_for_agent"
 msgstr "当前智能体未启用视频生成"
+
+msgid "video_reference_images_not_supported_for_model"
+msgstr "当前选择的视频模型暂不支持将上传图片作为首帧参考"
+
+msgid "video_reference_image_requires_remote_url"
+msgstr "服务商 {provider} 需要公网图片 URL 才能作为视频首帧参考"
 
 msgid "embedding_model_locked_after_kb_creation"
 msgstr "知识库创建后不可修改嵌入模型"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -64,6 +64,7 @@ async def lifespan(app: FastAPI):
         init_agent_context_compression_config,
         init_message_manual_stop_field,
         init_message_round_fields,
+        init_message_branch_parent_field,
         init_conversation_session_memory_table,
         init_agent_user_input_request,
         init_agent_hide_tool_calls_field,
@@ -125,6 +126,11 @@ async def lifespan(app: FastAPI):
         await init_message_round_fields()
     except Exception as e:
         logger.warning(f"Message round metadata migration failed: {e}")
+
+    try:
+        await init_message_branch_parent_field()
+    except Exception as e:
+        logger.warning(f"Message branch parent migration failed: {e}")
 
     try:
         await init_conversation_session_memory_table()

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -389,6 +389,10 @@ class Message(models.Model):
     version_number = fields.IntField(
         default=1, description="Version number within the group"
     )
+    branch_parent_id = fields.UUIDField(
+        null=True,
+        description="Previous visible message version in the conversation branch",
+    )
 
     # Attachments (for user messages with images/files)
     images: list | None = fields.JSONField(

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -832,6 +832,7 @@ class MessageOut(BaseModel):
     steps: list[MessageRoundStep] | None = None
     # Version info
     parent_id: UUID | None = None
+    branch_parent_id: UUID | None = None
     is_active: bool = True
     version_number: int = 1
     version_count: int = 1  # Total versions in this group

--- a/backend/app/services/chat_context.py
+++ b/backend/app/services/chat_context.py
@@ -375,32 +375,51 @@ When you need the user to choose from predefined options, use this XML format:
 - When guiding the conversation flow"""
 
 
+def _infer_image_format_from_mime(mime_type: str | None) -> str | None:
+    if not mime_type:
+        return None
+    normalized = mime_type.split(";", 1)[0].strip().lower()
+    if normalized in {"image/jpeg", "image/jpg"}:
+        return "jpg"
+    if normalized.startswith("image/"):
+        return normalized.split("/", 1)[1]
+    return None
+
+
+def _parse_image_data_url(value: str) -> tuple[str, str | None] | None:
+    if not value.startswith("data:"):
+        return None
+    try:
+        metadata, data_part = value.split(",", 1)
+    except ValueError:
+        return None
+    header = metadata[5:]
+    mime_type = header.split(";", 1)[0]
+    return data_part, _infer_image_format_from_mime(mime_type)
+
+
 def build_vision_content(text: str, images: Sequence[Any]) -> list[ContentPart]:
     """Build multimodal content for vision-capable models."""
     content_parts: list[ContentPart] = [ContentPart(type=ContentType.TEXT, text=text)]
-    for img in images:
+    for index, img in enumerate(images, start=1):
         img_url = getattr(img, "url", None)
         if not img_url and isinstance(img, dict):
             img_url = img.get("url")
         if not img_url:
             continue
 
-        if img_url.startswith("data:"):
-            try:
-                _, data_part = img_url.split(",", 1)
-                content_parts.append(
-                    ContentPart(
-                        type=ContentType.IMAGE,
-                        image=ImageContent(base64=data_part),
-                    )
+        content_parts.append(
+            ContentPart(type=ContentType.TEXT, text=f"Uploaded image #{index}:")
+        )
+        parsed_data_url = _parse_image_data_url(img_url)
+        if parsed_data_url:
+            data_part, image_format = parsed_data_url
+            content_parts.append(
+                ContentPart(
+                    type=ContentType.IMAGE,
+                    image=ImageContent(base64=data_part, format=image_format or "png"),
                 )
-            except ValueError:
-                content_parts.append(
-                    ContentPart(
-                        type=ContentType.IMAGE,
-                        image=ImageContent(url=img_url),
-                    )
-                )
+            )
         else:
             content_parts.append(
                 ContentPart(

--- a/backend/app/services/chat_context.py
+++ b/backend/app/services/chat_context.py
@@ -430,6 +430,17 @@ def build_vision_content(text: str, images: Sequence[Any]) -> list[ContentPart]:
     return content_parts
 
 
+def build_uploaded_image_reference_text(images: Sequence[Any]) -> str:
+    labels: list[str] = []
+    for index, image in enumerate(images, start=1):
+        has_image = bool(getattr(image, "url", None) or getattr(image, "base64", None))
+        if isinstance(image, dict):
+            has_image = bool(image.get("url") or image.get("base64"))
+        if has_image:
+            labels.append(f"Uploaded image #{index}: available as a reference image.")
+    return "\n".join(labels)
+
+
 def _safe_json_loads(value: str | None) -> dict[str, Any] | None:
     if not value:
         return None
@@ -630,6 +641,10 @@ def _build_current_user_content(
 ) -> str | list[ContentPart]:
     if current_images and model_supports_vision:
         return build_vision_content(user_message, current_images)
+    if current_images:
+        image_reference_text = build_uploaded_image_reference_text(current_images)
+        if image_reference_text:
+            return f"{user_message}\n\n{image_reference_text}" if user_message else image_reference_text
     return user_message
 
 

--- a/backend/app/services/chat_context.py
+++ b/backend/app/services/chat_context.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 from uuid import UUID
 
 from app.llm.errors import ContextLengthError
+from app.llm.adapters.media_utils import parse_image_data_url
 from app.llm.token_counter import count_message_tokens
 from app.llm.types import (
     ContentPart,
@@ -375,29 +376,6 @@ When you need the user to choose from predefined options, use this XML format:
 - When guiding the conversation flow"""
 
 
-def _infer_image_format_from_mime(mime_type: str | None) -> str | None:
-    if not mime_type:
-        return None
-    normalized = mime_type.split(";", 1)[0].strip().lower()
-    if normalized in {"image/jpeg", "image/jpg"}:
-        return "jpg"
-    if normalized.startswith("image/"):
-        return normalized.split("/", 1)[1]
-    return None
-
-
-def _parse_image_data_url(value: str) -> tuple[str, str | None] | None:
-    if not value.startswith("data:"):
-        return None
-    try:
-        metadata, data_part = value.split(",", 1)
-    except ValueError:
-        return None
-    header = metadata[5:]
-    mime_type = header.split(";", 1)[0]
-    return data_part, _infer_image_format_from_mime(mime_type)
-
-
 def build_vision_content(text: str, images: Sequence[Any]) -> list[ContentPart]:
     """Build multimodal content for vision-capable models."""
     content_parts: list[ContentPart] = [ContentPart(type=ContentType.TEXT, text=text)]
@@ -411,7 +389,7 @@ def build_vision_content(text: str, images: Sequence[Any]) -> list[ContentPart]:
         content_parts.append(
             ContentPart(type=ContentType.TEXT, text=f"Uploaded image #{index}:")
         )
-        parsed_data_url = _parse_image_data_url(img_url)
+        parsed_data_url = parse_image_data_url(img_url)
         if parsed_data_url:
             data_part, image_format = parsed_data_url
             content_parts.append(

--- a/backend/app/services/chat_context.py
+++ b/backend/app/services/chat_context.py
@@ -622,7 +622,11 @@ def _build_current_user_content(
     if current_images:
         image_reference_text = build_uploaded_image_reference_text(current_images)
         if image_reference_text:
-            return f"{user_message}\n\n{image_reference_text}" if user_message else image_reference_text
+            return (
+                f"{user_message}\n\n{image_reference_text}"
+                if user_message
+                else image_reference_text
+            )
     return user_message
 
 

--- a/backend/app/services/chat_context.py
+++ b/backend/app/services/chat_context.py
@@ -29,6 +29,10 @@ from app.models.agent import (
     Message as ConversationMessage,
     MessageRole as ConversationMessageRole,
 )
+from app.services.message_branching import (
+    get_visible_conversation_messages,
+    is_message_on_active_branch,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -988,6 +992,7 @@ async def _apply_session_memory_compaction(
     recent_raw_turns: int = DEFAULT_RECENT_RAW_TURNS,
     recent_tool_turns: int = DEFAULT_RECENT_TOOL_TURNS,
     protected_indexes: set[int] | None = None,
+    before_created_at=None,
 ) -> tuple[list[Message], bool, set[int]]:
     """
     Apply conversation-scoped session memory compaction.
@@ -1005,7 +1010,16 @@ async def _apply_session_memory_compaction(
     protected_indexes = protected_indexes or set()
     try:
         snapshot = await get_ready_session_memory(conversation.id)
-        if not snapshot or not snapshot.summary_text:
+        if not snapshot or not snapshot.summary_text or not snapshot.source_message_id:
+            cloned_messages, cloned_protected_indexes = _clone_messages(
+                messages, protected_indexes
+            )
+            return cloned_messages, False, cloned_protected_indexes
+        if not await is_message_on_active_branch(
+            conversation.id,
+            snapshot.source_message_id,
+            before_created_at=before_created_at,
+        ):
             cloned_messages, cloned_protected_indexes = _clone_messages(
                 messages, protected_indexes
             )
@@ -1229,18 +1243,11 @@ async def _build_messages_with_file_content(
             )
         return messages, protected_indexes
 
-    history_query = ConversationMessage.filter(
-        conversation_id=conversation.id,
-        is_active=True,
+    history = await get_visible_conversation_messages(
+        conversation.id,
+        before_created_at=history_before_message_created_at,
+        exclude_message_ids=exclude_message_ids,
     )
-    if history_before_message_created_at is not None:
-        history_query = history_query.filter(
-            created_at__lt=history_before_message_created_at
-        )
-    if exclude_message_ids:
-        history_query = history_query.exclude(id__in=list(exclude_message_ids))
-
-    history = await history_query.order_by("created_at")
     historical_file_content_tasks = {
         msg.id: asyncio.create_task(
             _build_file_content_for_user_message(
@@ -1574,6 +1581,7 @@ async def _apply_micro_compaction(
     policy_used: str = DEFAULT_COMPACTION_POLICY,
     trigger_budget: int | None = None,
     protected_indexes: set[int] | None = None,
+    before_created_at=None,
 ) -> tuple[list[Message], CompressionMeta, set[int]]:
     protected_indexes = protected_indexes or set()
     before_tokens = _estimate_message_tokens(
@@ -1639,6 +1647,7 @@ async def _apply_micro_compaction(
         recent_raw_turns=recent_raw_turns,
         recent_tool_turns=recent_tool_turns,
         protected_indexes=tool_protected_indexes,
+        before_created_at=before_created_at,
     )
     after_tokens = _estimate_message_tokens(
         session_memory_messages,
@@ -2082,6 +2091,7 @@ async def prepare_model_context(
             policy_used=policy_used,
             trigger_budget=thresholds.trigger_input_budget,
             protected_indexes=base_protected_indexes,
+            before_created_at=history_before_message_created_at,
         )
         compression.file_content_trimmed = file_content_trimmed
         if file_content_trimmed and "trim_file_content" not in (

--- a/backend/app/services/message_branching.py
+++ b/backend/app/services/message_branching.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from uuid import UUID
+
+from tortoise.expressions import Q
+
+from app.models.agent import (
+    ConversationSessionMemory,
+    ConversationSessionMemoryStatus,
+    Message,
+)
+
+
+def get_version_root_id(message: Message) -> UUID:
+    return message.parent_id or message.id
+
+
+async def get_message_version_group(message: Message) -> list[Message]:
+    root_id = get_version_root_id(message)
+    versions = await Message.filter(Q(id=root_id) | Q(parent_id=root_id)).all()
+    versions.sort(key=lambda item: item.version_number)
+    return versions
+
+
+async def get_version_count(message: Message) -> int:
+    root_id = get_version_root_id(message)
+    return await Message.filter(Q(id=root_id) | Q(parent_id=root_id)).count()
+
+
+def _is_canonical_visible(message: Message) -> bool:
+    return message.round_id is None or message.is_round_canonical
+
+
+async def get_active_canonical_path(conversation_id: UUID) -> list[Message]:
+    messages = await Message.filter(
+        conversation_id=conversation_id,
+        is_active=True,
+    ).order_by("created_at", "id")
+    return [message for message in messages if _is_canonical_visible(message)]
+
+
+async def get_visible_conversation_messages(
+    conversation_id: UUID,
+    *,
+    before_created_at=None,
+    exclude_message_ids: Iterable[UUID] | None = None,
+) -> list[Message]:
+    query = Message.filter(conversation_id=conversation_id, is_active=True)
+    if before_created_at is not None:
+        query = query.filter(created_at__lt=before_created_at)
+    if exclude_message_ids:
+        query = query.exclude(id__in=list(exclude_message_ids))
+    return await query.order_by("created_at", "id")
+
+
+async def get_last_active_canonical_message(conversation_id: UUID) -> Message | None:
+    path = await get_active_canonical_path(conversation_id)
+    return path[-1] if path else None
+
+
+async def get_prefix_path_before(message: Message) -> list[Message]:
+    if message.branch_parent_id:
+        path = await get_active_canonical_path(message.conversation_id)
+        prefix: list[Message] = []
+        for item in path:
+            prefix.append(item)
+            if item.id == message.branch_parent_id:
+                return prefix
+
+    path = await get_active_canonical_path(message.conversation_id)
+    return [item for item in path if item.created_at < message.created_at]
+
+
+async def _select_descendant_child(parent: Message) -> Message | None:
+    children = await Message.filter(
+        conversation_id=parent.conversation_id,
+        branch_parent_id=parent.id,
+    ).order_by("-is_active", "-created_at", "-id")
+    for child in children:
+        if _is_canonical_visible(child):
+            return child
+    return None
+
+
+async def find_descendant_branch_from(message: Message) -> list[Message]:
+    branch = [message]
+    current = message
+    seen = {message.id}
+    while True:
+        child = await _select_descendant_child(current)
+        if not child or child.id in seen:
+            break
+        branch.append(child)
+        seen.add(child.id)
+        current = child
+    return branch
+
+
+async def activate_conversation_branch(
+    conversation_id: UUID,
+    canonical_path: Iterable[Message],
+) -> None:
+    canonical_ids = [message.id for message in canonical_path]
+    round_ids = [
+        message.round_id
+        for message in canonical_path
+        if message.round_id is not None
+    ]
+
+    active_ids = set(canonical_ids)
+    if round_ids:
+        round_steps = await Message.filter(
+            conversation_id=conversation_id,
+            round_id__in=round_ids,
+            is_round_canonical=False,
+        ).all()
+        active_ids.update(message.id for message in round_steps)
+
+    await Message.filter(conversation_id=conversation_id).update(is_active=False)
+    if active_ids:
+        await Message.filter(id__in=list(active_ids)).update(is_active=True)
+
+
+async def is_message_on_active_branch(
+    conversation_id: UUID,
+    message_id: UUID,
+    *,
+    before_created_at=None,
+) -> bool:
+    query = Message.filter(
+        conversation_id=conversation_id,
+        id=message_id,
+        is_active=True,
+    )
+    if before_created_at is not None:
+        query = query.filter(created_at__lt=before_created_at)
+    return await query.exists()
+
+
+async def stale_session_memory_if_source_outside_active_branch(
+    conversation_id: UUID,
+) -> None:
+    snapshot = await ConversationSessionMemory.filter(
+        conversation_id=conversation_id,
+        status=ConversationSessionMemoryStatus.READY,
+    ).first()
+    if not snapshot or not snapshot.source_message_id:
+        return
+    if await is_message_on_active_branch(conversation_id, snapshot.source_message_id):
+        return
+    snapshot.status = ConversationSessionMemoryStatus.STALE
+    await snapshot.save(update_fields=["status", "updated_at"])

--- a/backend/app/services/session_memory.py
+++ b/backend/app/services/session_memory.py
@@ -22,6 +22,10 @@ from app.models.agent import (
     MessageRole,
 )
 from app.models.model import TeamModel
+from app.services.message_branching import (
+    get_visible_conversation_messages,
+    is_message_on_active_branch,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -100,9 +104,12 @@ async def extract_session_memory_for_message(
     source_message = await Message.filter(
         id=source_uuid,
         conversation_id=conversation_uuid,
-        is_active=True,
     ).first()
-    if not source_message or source_message.role != MessageRole.ASSISTANT:
+    if (
+        not source_message
+        or source_message.role != MessageRole.ASSISTANT
+        or not await is_message_on_active_branch(conversation_uuid, source_uuid)
+    ):
         logger.warning(
             "Skip session memory extraction: source message %s invalid for "
             "conversation %s",
@@ -111,11 +118,15 @@ async def extract_session_memory_for_message(
         )
         return {"status": "skipped", "reason": "invalid_source_message"}
 
-    history = await Message.filter(
-        conversation_id=conversation_uuid,
-        is_active=True,
-        created_at__lte=source_message.created_at,
-    ).order_by("created_at")
+    history = await get_visible_conversation_messages(
+        conversation_uuid,
+        before_created_at=None,
+    )
+    history = [
+        message
+        for message in history
+        if message.created_at <= source_message.created_at
+    ]
 
     turn_blocks = _split_turn_blocks(history)
     min_turns = int(compression_config.get("session_memory_min_turns", 4) or 4)

--- a/backend/tests/llm/test_media_adapters.py
+++ b/backend/tests/llm/test_media_adapters.py
@@ -669,7 +669,7 @@ class TestModelManagerVideoRouting:
         assert result.task_id == "task-1"
         mock_get_model.assert_awaited_once_with(None, ModelType.TEXT_TO_VIDEO)
 
-    def test_generate_video_rejects_image_input(self):
+    def test_generate_video_rejects_legacy_image_input(self):
         manager = ModelManager()
         with pytest.raises(InvalidRequestError):
             asyncio.run(
@@ -678,6 +678,16 @@ class TestModelManagerVideoRouting:
                         "prompt": "Animate this still image",
                         "image": {"url": "https://example.com/input.png"},
                     }
+                )
+            )
+
+    def test_video_adapter_base_guard_rejects_start_image(self):
+        adapter = RunwayVideoAdapter(build_model("runway", "gen4.5"))
+        with pytest.raises(InvalidRequestError):
+            adapter._ensure_reference_images_supported(
+                VideoGenerationRequest(
+                    prompt="Animate this still image",
+                    start_image=ImageContent(base64="cmVm", format="png"),
                 )
             )
 
@@ -695,6 +705,34 @@ class TestRunwayVideoAdapter:
         assert path == "/v1/text_to_video"
         assert payload["ratio"] == "1280:720"
         assert payload["duration"] == 5
+
+    def test_builds_image_to_video_request_with_prompt_image(self):
+        adapter = RunwayVideoAdapter(build_model("runway", "gen4_turbo"))
+
+        path, payload = adapter._build_request(
+            VideoGenerationRequest(
+                prompt="A drifting spaceship",
+                duration=5,
+                aspect_ratio="16:9",
+                start_image=ImageContent(base64="cmVm", format="png"),
+            )
+        )
+
+        assert path == "/v1/image_to_video"
+        assert payload["promptImage"] == "data:image/png;base64,cmVm"
+        assert payload["ratio"] == "1280:720"
+        assert payload["duration"] == 5
+
+    def test_rejects_image_request_for_non_image_video_model(self):
+        adapter = RunwayVideoAdapter(build_model("runway", "gen4.5"))
+
+        with pytest.raises(InvalidRequestError):
+            adapter._build_request(
+                VideoGenerationRequest(
+                    prompt="Use this image",
+                    start_image=ImageContent(base64="cmVm", format="png"),
+                )
+            )
 
     def test_rejects_text_request_for_non_text_video_model(self):
         adapter = RunwayVideoAdapter(build_model("runway", "gen4_turbo"))
@@ -717,6 +755,28 @@ class TestKlingVideoAdapter:
         assert payload["prompt"] == "A sunset over mountains"
         assert payload["duration"] == 6
         assert payload["aspect_ratio"] == "16:9"
+
+    def test_builds_payload_with_start_image(self):
+        adapter = KlingVideoAdapter(build_model("kling", "kling-v1"))
+
+        payload = adapter._build_payload(
+            VideoGenerationRequest(
+                prompt="A sunset over mountains",
+                duration=5,
+                aspect_ratio="16:9",
+                start_image=ImageContent(base64="cmVm", format="png"),
+            )
+        )
+
+        assert payload["image"] == "cmVm"
+
+    def test_encodes_image_to_video_task_ids(self):
+        adapter = KlingVideoAdapter(build_model("kling", "kling-v1"))
+
+        assert adapter._encode_task_id("task-1", "text2video") == "task-1"
+        assert adapter._encode_task_id("task-1", "image2video") == "image2video:task-1"
+        assert adapter._decode_task_id("task-1") == ("text2video", "task-1")
+        assert adapter._decode_task_id("image2video:task-1") == ("image2video", "task-1")
 
     def test_maps_kling_statuses(self):
         adapter = KlingVideoAdapter(build_model("kling", "kling-v1"))
@@ -746,6 +806,36 @@ class TestKlingVideoAdapter:
         assert adapter._extract_error({}) is None
 
 
+class TestLumaVideoAdapter:
+    def test_builds_payload_with_remote_start_image_keyframe(self):
+        adapter = LumaVideoAdapter(build_model("luma", "ray-2"))
+
+        payload = adapter._build_payload(
+            VideoGenerationRequest(
+                prompt="A cinematic reveal",
+                start_image=ImageContent(url="https://cdn.example.com/start.png"),
+            )
+        )
+
+        assert payload["keyframes"] == {
+            "frame0": {
+                "type": "image",
+                "url": "https://cdn.example.com/start.png",
+            }
+        }
+
+    def test_rejects_base64_start_image_for_direct_luma(self):
+        adapter = LumaVideoAdapter(build_model("luma", "ray-2"))
+
+        with pytest.raises(InvalidRequestError):
+            adapter._build_payload(
+                VideoGenerationRequest(
+                    prompt="A cinematic reveal",
+                    start_image=ImageContent(base64="cmVm", format="png"),
+                )
+            )
+
+
 class TestPikaVideoAdapter:
     def test_builds_payload_with_camel_case_aspect_ratio(self):
         adapter = PikaVideoAdapter(build_model("pika", "pika-v1"))
@@ -760,6 +850,32 @@ class TestPikaVideoAdapter:
         assert payload["prompt"] == "A robot dancing"
         assert payload["duration"] == 4
         assert payload["aspectRatio"] == "9:16"
+
+    def test_builds_default_start_image_field(self):
+        adapter = PikaVideoAdapter(build_model("pika", "pika-v1"))
+
+        payload = adapter._build_payload(
+            VideoGenerationRequest(
+                prompt="A robot dancing",
+                start_image=ImageContent(base64="cmVm", format="png"),
+            )
+        )
+
+        assert payload["image_url"] == "data:image/png;base64,cmVm"
+
+    def test_builds_configured_start_image_field(self):
+        adapter = PikaVideoAdapter(
+            build_model("pika", "pika-v1", config={"start_image_field": "image_url"})
+        )
+
+        payload = adapter._build_payload(
+            VideoGenerationRequest(
+                prompt="A robot dancing",
+                start_image=ImageContent(base64="cmVm", format="png"),
+            )
+        )
+
+        assert payload["image_url"] == "data:image/png;base64,cmVm"
 
     def test_maps_pika_statuses(self):
         adapter = PikaVideoAdapter(build_model("pika", "pika-v1"))
@@ -805,6 +921,30 @@ class TestSiliconFlowVideoAdapter:
         assert payload["model"] == "Wan2.1-T2V-14B"
         assert payload["prompt"] == "A cat playing piano"
         assert payload["image_size"] == "1280x720"
+
+    def test_builds_payload_with_start_image(self):
+        adapter = SiliconFlowVideoAdapter(build_model("siliconflow", "Wan-AI/Wan2.2-I2V-A14B"))
+
+        payload = adapter._build_payload(
+            VideoGenerationRequest(
+                prompt="A cat playing piano",
+                aspect_ratio="16:9",
+                start_image=ImageContent(base64="cmVm", format="png"),
+            )
+        )
+
+        assert payload["image"] == "data:image/png;base64,cmVm"
+
+    def test_rejects_start_image_for_text_video_model(self):
+        adapter = SiliconFlowVideoAdapter(build_model("siliconflow", "Wan2.1-T2V-14B"))
+
+        with pytest.raises(InvalidRequestError):
+            adapter._build_payload(
+                VideoGenerationRequest(
+                    prompt="A cat playing piano",
+                    start_image=ImageContent(base64="cmVm", format="png"),
+                )
+            )
 
     def test_maps_siliconflow_statuses(self):
         adapter = SiliconFlowVideoAdapter(build_model("siliconflow", "Wan2.1-T2V-14B"))
@@ -852,6 +992,24 @@ class TestVolcengineVideoAdapter:
         assert payload["parameters"]["duration"] == 5
         assert payload["parameters"]["aspect_ratio"] == "16:9"
 
+    def test_builds_payload_with_start_image_content(self):
+        adapter = VolcengineVideoAdapter(build_model("volcengine", "seedance-1-lite"))
+
+        payload = adapter._build_payload(
+            VideoGenerationRequest(
+                prompt="Ocean waves at sunset",
+                start_image=ImageContent(base64="cmVm", format="png"),
+            )
+        )
+
+        assert payload["content"] == [
+            {"type": "text", "text": "Ocean waves at sunset"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,cmVm"},
+            },
+        ]
+
     def test_maps_volcengine_statuses(self):
         adapter = VolcengineVideoAdapter(build_model("volcengine", "seedance-1-lite"))
 
@@ -895,6 +1053,54 @@ class TestDashScopeVideoAdapter:
         assert payload["input"]["prompt"] == "A futuristic city"
         assert payload["parameters"]["duration"] == 4
         assert payload["parameters"]["size"] == "16:9"
+
+    def test_builds_payload_with_start_image(self):
+        adapter = DashScopeVideoAdapter(build_model("qwen", "wan2.6-i2v-flash"))
+
+        payload = adapter._build_payload(
+            VideoGenerationRequest(
+                prompt="A futuristic city",
+                start_image=ImageContent(base64="cmVm", format="png"),
+            )
+        )
+
+        assert payload["input"]["img_url"] == "data:image/png;base64,cmVm"
+
+    def test_uses_image_to_video_endpoint_for_start_image(self):
+        adapter = DashScopeVideoAdapter(build_model("qwen", "wan2.6-i2v-flash"))
+        adapter.client = SimpleNamespace(
+            create_task=AsyncMock(return_value={"output": {"task_id": "task-1"}})
+        )
+        adapter.get_status = AsyncMock(
+            return_value=VideoGenerationResponse(
+                task_id="task-1",
+                status=TaskStatus.PENDING,
+                model="wan2.6-i2v-flash",
+            )
+        )
+
+        asyncio.run(
+            adapter.generate(
+                VideoGenerationRequest(
+                    prompt="A futuristic city",
+                    start_image=ImageContent(base64="cmVm", format="png"),
+                )
+            )
+        )
+
+        _, kwargs = adapter.client.create_task.await_args
+        assert kwargs["path"] == "/services/aigc/video-generation/video-synthesis"
+
+    def test_rejects_start_image_for_text_video_model(self):
+        adapter = DashScopeVideoAdapter(build_model("qwen", "wan2.1-t2v-plus"))
+
+        with pytest.raises(InvalidRequestError):
+            adapter._build_payload(
+                VideoGenerationRequest(
+                    prompt="A futuristic city",
+                    start_image=ImageContent(base64="cmVm", format="png"),
+                )
+            )
 
     def test_maps_dashscope_statuses(self):
         adapter = DashScopeVideoAdapter(build_model("qwen", "wan2.1-t2v-plus"))

--- a/backend/tests/llm/test_media_adapters.py
+++ b/backend/tests/llm/test_media_adapters.py
@@ -776,7 +776,10 @@ class TestKlingVideoAdapter:
         assert adapter._encode_task_id("task-1", "text2video") == "task-1"
         assert adapter._encode_task_id("task-1", "image2video") == "image2video:task-1"
         assert adapter._decode_task_id("task-1") == ("text2video", "task-1")
-        assert adapter._decode_task_id("image2video:task-1") == ("image2video", "task-1")
+        assert adapter._decode_task_id("image2video:task-1") == (
+            "image2video",
+            "task-1",
+        )
 
     def test_maps_kling_statuses(self):
         adapter = KlingVideoAdapter(build_model("kling", "kling-v1"))
@@ -923,7 +926,9 @@ class TestSiliconFlowVideoAdapter:
         assert payload["image_size"] == "1280x720"
 
     def test_builds_payload_with_start_image(self):
-        adapter = SiliconFlowVideoAdapter(build_model("siliconflow", "Wan-AI/Wan2.2-I2V-A14B"))
+        adapter = SiliconFlowVideoAdapter(
+            build_model("siliconflow", "Wan-AI/Wan2.2-I2V-A14B")
+        )
 
         payload = adapter._build_payload(
             VideoGenerationRequest(

--- a/backend/tests/llm/test_media_builtin_tools.py
+++ b/backend/tests/llm/test_media_builtin_tools.py
@@ -240,6 +240,119 @@ async def test_generate_image_normalizes_inline_base64_to_backend_url():
     assert image_payload["file_path"] is None
 
 
+
+@pytest.mark.anyio
+async def test_generate_video_passes_selected_start_image_reference():
+    agent = SimpleNamespace(
+        enable_video_generation=True,
+        video_generation_config={
+            "default_model_ref": "siliconflow/Wan2.1-T2V-14B",
+            "default_duration": 5,
+            "max_duration": 10,
+            "default_aspect_ratio": "16:9",
+            "poll_interval_ms": 1,
+            "poll_timeout_s": 1,
+        },
+    )
+    response = VideoGenerationResponse(
+        task_id="vid_123",
+        status=TaskStatus.COMPLETED,
+        model="siliconflow/Wan2.1-T2V-14B",
+        video=VideoContent(url="https://example.com/video.mp4", format="mp4"),
+    )
+
+    with (
+        patch(
+            "app.llm.tools.builtin.media.model_manager.generate_video",
+            AsyncMock(return_value=response),
+        ) as mock_generate,
+        patch(
+            "app.llm.tools.builtin.media.media_asset_service.normalize_video",
+            AsyncMock(return_value=VideoContent(url="/api/v1/upload/files/generated-videos/out.mp4")),
+        ),
+    ):
+        result = await generate_video(
+            prompt="Animate the second upload",
+            start_image_index=2,
+            current_images=[
+                {"url": "data:image/png;base64,Zmlyc3Q="},
+                {"url": "data:image/webp;base64,c2Vjb25k"},
+            ],
+            agent=agent,
+        )
+
+    request = mock_generate.await_args.args[0]
+    assert result.display_result["success"] is True
+    assert request.start_image is not None
+    assert request.start_image.base64 == "c2Vjb25k"
+    assert request.start_image.format == "webp"
+    assert request.start_image.url is None
+
+
+@pytest.mark.anyio
+async def test_generate_video_rejects_out_of_range_start_image_index():
+    agent = SimpleNamespace(
+        enable_video_generation=True,
+        video_generation_config={
+            "default_model_ref": "siliconflow/Wan2.1-T2V-14B",
+            "default_duration": 5,
+            "max_duration": 10,
+            "default_aspect_ratio": "16:9",
+            "poll_interval_ms": 1,
+            "poll_timeout_s": 1,
+        },
+    )
+
+    with patch(
+        "app.llm.tools.builtin.media.model_manager.generate_video",
+        AsyncMock(),
+    ) as mock_generate:
+        result = await generate_video(
+            prompt="Animate image 3",
+            start_image_index=3,
+            current_images=[{"url": "data:image/png;base64,cmVm"}],
+            agent=agent,
+        )
+
+    mock_generate.assert_not_awaited()
+    assert result.display_result["success"] is False
+    assert "out of range" in result.display_result["error"]
+
+
+@pytest.mark.anyio
+async def test_generate_video_reports_unsupported_start_image_reference():
+    agent = SimpleNamespace(
+        enable_video_generation=True,
+        video_generation_config={
+            "default_model_ref": "siliconflow/Wan2.1-T2V-14B",
+            "default_duration": 5,
+            "max_duration": 10,
+            "default_aspect_ratio": "16:9",
+            "poll_interval_ms": 1,
+            "poll_timeout_s": 1,
+        },
+    )
+
+    with patch(
+        "app.llm.tools.builtin.media.model_manager.generate_video",
+        AsyncMock(
+            side_effect=ValueError(
+                "The selected video model does not support uploaded images as starting-frame references yet"
+            )
+        ),
+    ) as mock_generate:
+        result = await generate_video(
+            prompt="Animate reference",
+            start_image_index=1,
+            current_images=[{"url": "data:image/png;base64,cmVm"}],
+            agent=agent,
+        )
+
+    mock_generate.assert_awaited_once()
+    assert result.display_result["success"] is False
+    assert "does not support uploaded images" in result.display_result["error"]
+
+
 def test_build_media_llm_summaries_are_compact():
     image_summary = build_image_llm_result(
         "A detailed portrait of a cat under moonlight",
@@ -280,6 +393,9 @@ def test_media_tools_do_not_expose_model_override_parameter():
     assert image_tool is not None
     assert video_tool is not None
     assert all(param.name != "model_ref" for param in image_tool.parameters)
+    schema = video_tool.to_openai_schema()
+    properties = schema["function"]["parameters"]["properties"]
+    assert properties["start_image_index"]["type"] == "integer"
     assert all(param.name != "model_ref" for param in video_tool.parameters)
 
 
@@ -428,13 +544,260 @@ async def test_generate_image_gpt_image_quality_falls_back_to_model_ref_suffix()
     assert request.quality == "medium"
 
 
+
+@pytest.mark.anyio
+async def test_generate_image_uses_selected_uploaded_image_reference():
+    agent = SimpleNamespace(
+        enable_image_generation=True,
+        image_generation_config={
+            "default_model_ref": "google/gemini-2.5-flash-image",
+            "default_width": 1024,
+            "default_height": 1024,
+            "max_images": 4,
+            "allow_reference_images": True,
+        },
+    )
+    response = ImageGenerationResponse(
+        images=[GeneratedImage(image=ImageContent(url="https://example.com/out.png"))],
+        model="google/gemini-2.5-flash-image",
+    )
+
+    with (
+        patch(
+            "app.llm.tools.builtin.media.model_manager.generate_image",
+            AsyncMock(return_value=response),
+        ) as mock_generate,
+        patch(
+            "app.llm.tools.builtin.media.media_asset_service.normalize_image",
+            AsyncMock(return_value=ImageContent(url="/api/v1/upload/files/generated-images/out.png")),
+        ),
+    ):
+        result = await generate_image(
+            prompt="Use the second image as reference",
+            reference_image_indexes=[2],
+            current_images=[
+                {"url": "data:image/png;base64,Zmlyc3Q="},
+                {"url": "data:image/jpeg;base64,c2Vjb25k"},
+            ],
+            agent=agent,
+        )
+
+    request = mock_generate.await_args.args[0]
+    assert result.display_result["success"] is True
+    assert len(request.images) == 1
+    assert request.images[0].base64 == "c2Vjb25k"
+    assert request.images[0].format == "jpg"
+    assert request.images[0].url is None
+
+
+@pytest.mark.anyio
+async def test_generate_image_deduplicates_reference_indexes_in_order():
+    agent = SimpleNamespace(
+        enable_image_generation=True,
+        image_generation_config={
+            "default_model_ref": "google/gemini-2.5-flash-image",
+            "default_width": 1024,
+            "default_height": 1024,
+            "max_images": 4,
+            "allow_reference_images": True,
+        },
+    )
+    response = ImageGenerationResponse(
+        images=[GeneratedImage(image=ImageContent(url="https://example.com/out.png"))],
+        model="google/gemini-2.5-flash-image",
+    )
+
+    with (
+        patch(
+            "app.llm.tools.builtin.media.model_manager.generate_image",
+            AsyncMock(return_value=response),
+        ) as mock_generate,
+        patch(
+            "app.llm.tools.builtin.media.media_asset_service.normalize_image",
+            AsyncMock(return_value=ImageContent(url="/api/v1/upload/files/generated-images/out.png")),
+        ),
+    ):
+        await generate_image(
+            prompt="Use selected images",
+            reference_image_indexes=[2, 2, 1],
+            current_images=[
+                {"url": "data:image/png;base64,Zmlyc3Q="},
+                {"url": "data:image/webp;base64,c2Vjb25k"},
+            ],
+            agent=agent,
+        )
+
+    request = mock_generate.await_args.args[0]
+    assert [image.base64 for image in request.images] == ["c2Vjb25k", "Zmlyc3Q="]
+    assert [image.format for image in request.images] == ["webp", "png"]
+
+
+@pytest.mark.anyio
+async def test_generate_image_rejects_reference_image_conflict():
+    agent = SimpleNamespace(
+        enable_image_generation=True,
+        image_generation_config={
+            "default_model_ref": "google/gemini-2.5-flash-image",
+            "default_width": 1024,
+            "default_height": 1024,
+            "max_images": 4,
+            "allow_reference_images": True,
+        },
+    )
+
+    with patch(
+        "app.llm.tools.builtin.media.model_manager.generate_image",
+        AsyncMock(),
+    ) as mock_generate:
+        result = await generate_image(
+            prompt="Use reference",
+            images=[{"url": "https://example.com/ref.png"}],
+            reference_image_indexes=[1],
+            current_images=[{"url": "data:image/png;base64,cmVm"}],
+            agent=agent,
+        )
+
+    mock_generate.assert_not_awaited()
+    assert result.display_result["success"] is False
+    assert "not both" in result.display_result["error"]
+
+
+@pytest.mark.anyio
+async def test_generate_image_rejects_reference_index_out_of_range():
+    agent = SimpleNamespace(
+        enable_image_generation=True,
+        image_generation_config={
+            "default_model_ref": "google/gemini-2.5-flash-image",
+            "default_width": 1024,
+            "default_height": 1024,
+            "max_images": 4,
+            "allow_reference_images": True,
+        },
+    )
+
+    with patch(
+        "app.llm.tools.builtin.media.model_manager.generate_image",
+        AsyncMock(),
+    ) as mock_generate:
+        result = await generate_image(
+            prompt="Use image 3",
+            reference_image_indexes=[3],
+            current_images=[{"url": "data:image/png;base64,cmVm"}],
+            agent=agent,
+        )
+
+    mock_generate.assert_not_awaited()
+    assert result.display_result["success"] is False
+    assert "out of range" in result.display_result["error"]
+
+
+@pytest.mark.anyio
+async def test_generate_image_preserves_explicit_images_input():
+    agent = SimpleNamespace(
+        enable_image_generation=True,
+        image_generation_config={
+            "default_model_ref": "google/gemini-2.5-flash-image",
+            "default_width": 1024,
+            "default_height": 1024,
+            "max_images": 4,
+            "allow_reference_images": True,
+        },
+    )
+    response = ImageGenerationResponse(
+        images=[GeneratedImage(image=ImageContent(url="https://example.com/out.png"))],
+        model="google/gemini-2.5-flash-image",
+    )
+
+    with (
+        patch(
+            "app.llm.tools.builtin.media.model_manager.generate_image",
+            AsyncMock(return_value=response),
+        ) as mock_generate,
+        patch(
+            "app.llm.tools.builtin.media.media_asset_service.normalize_image",
+            AsyncMock(return_value=ImageContent(url="/api/v1/upload/files/generated-images/out.png")),
+        ),
+    ):
+        await generate_image(
+            prompt="Use explicit reference",
+            images=[{"url": "https://example.com/ref.png"}],
+            agent=agent,
+        )
+
+    request = mock_generate.await_args.args[0]
+    assert len(request.images) == 1
+    assert request.images[0].url == "https://example.com/ref.png"
+
+
+@pytest.mark.anyio
+async def test_generate_image_rejects_reference_indexes_when_disabled():
+    agent = SimpleNamespace(
+        enable_image_generation=True,
+        image_generation_config={
+            "default_model_ref": "google/gemini-2.5-flash-image",
+            "default_width": 1024,
+            "default_height": 1024,
+            "max_images": 4,
+            "allow_reference_images": False,
+        },
+    )
+
+    with patch(
+        "app.llm.tools.builtin.media.model_manager.generate_image",
+        AsyncMock(),
+    ) as mock_generate:
+        result = await generate_image(
+            prompt="Use reference",
+            reference_image_indexes=[1],
+            current_images=[{"url": "data:image/png;base64,cmVm"}],
+            agent=agent,
+        )
+
+    mock_generate.assert_not_awaited()
+    assert result.display_result["success"] is False
+    assert result.display_result["error"] == "Reference images are disabled for this agent"
+
+
+@pytest.mark.anyio
+async def test_generate_image_rejects_unusable_uploaded_reference_image():
+    agent = SimpleNamespace(
+        enable_image_generation=True,
+        image_generation_config={
+            "default_model_ref": "google/gemini-2.5-flash-image",
+            "default_width": 1024,
+            "default_height": 1024,
+            "max_images": 4,
+            "allow_reference_images": True,
+        },
+    )
+
+    with patch(
+        "app.llm.tools.builtin.media.model_manager.generate_image",
+        AsyncMock(),
+    ) as mock_generate:
+        result = await generate_image(
+            prompt="Use reference",
+            reference_image_indexes=[1],
+            current_images=[{"url": "/api/v1/upload/files/images/2026/05/private.png"}],
+            agent=agent,
+        )
+
+    mock_generate.assert_not_awaited()
+    assert result.display_result["success"] is False
+    assert "does not contain usable image data" in result.display_result["error"]
+
+
 def test_generate_image_schema_includes_items_for_images_array():
     register_media_tools()
     image_tool = tool_registry.get_tool("generate_image")
     assert image_tool is not None
 
     schema = image_tool.to_openai_schema()
-    images_prop = schema["function"]["parameters"]["properties"]["images"]
+    properties = schema["function"]["parameters"]["properties"]
+    images_prop = properties["images"]
+    reference_indexes_prop = properties["reference_image_indexes"]
     assert images_prop["type"] == "array"
     assert "items" in images_prop
     assert images_prop["items"] == {"type": "object"}
+    assert reference_indexes_prop["type"] == "array"
+    assert reference_indexes_prop["items"] == {"type": "integer"}

--- a/backend/tests/llm/test_media_builtin_tools.py
+++ b/backend/tests/llm/test_media_builtin_tools.py
@@ -287,7 +287,6 @@ async def test_generate_image_normalizes_inline_base64_to_backend_url():
     assert image_payload["file_path"] is None
 
 
-
 @pytest.mark.anyio
 async def test_generate_video_passes_selected_start_image_reference():
     agent = SimpleNamespace(
@@ -315,7 +314,11 @@ async def test_generate_video_passes_selected_start_image_reference():
         ) as mock_generate,
         patch(
             "app.llm.tools.builtin.media.media_asset_service.normalize_video",
-            AsyncMock(return_value=VideoContent(url="/api/v1/upload/files/generated-videos/out.mp4")),
+            AsyncMock(
+                return_value=VideoContent(
+                    url="/api/v1/upload/files/generated-videos/out.mp4"
+                )
+            ),
         ),
     ):
         result = await generate_video(
@@ -591,7 +594,6 @@ async def test_generate_image_gpt_image_quality_falls_back_to_model_ref_suffix()
     assert request.quality == "medium"
 
 
-
 @pytest.mark.anyio
 async def test_generate_image_uses_selected_uploaded_image_reference():
     agent = SimpleNamespace(
@@ -616,7 +618,11 @@ async def test_generate_image_uses_selected_uploaded_image_reference():
         ) as mock_generate,
         patch(
             "app.llm.tools.builtin.media.media_asset_service.normalize_image",
-            AsyncMock(return_value=ImageContent(url="/api/v1/upload/files/generated-images/out.png")),
+            AsyncMock(
+                return_value=ImageContent(
+                    url="/api/v1/upload/files/generated-images/out.png"
+                )
+            ),
         ),
     ):
         result = await generate_image(
@@ -661,7 +667,11 @@ async def test_generate_image_deduplicates_reference_indexes_in_order():
         ) as mock_generate,
         patch(
             "app.llm.tools.builtin.media.media_asset_service.normalize_image",
-            AsyncMock(return_value=ImageContent(url="/api/v1/upload/files/generated-images/out.png")),
+            AsyncMock(
+                return_value=ImageContent(
+                    url="/api/v1/upload/files/generated-images/out.png"
+                )
+            ),
         ),
     ):
         await generate_image(
@@ -762,7 +772,11 @@ async def test_generate_image_preserves_explicit_images_input():
         ) as mock_generate,
         patch(
             "app.llm.tools.builtin.media.media_asset_service.normalize_image",
-            AsyncMock(return_value=ImageContent(url="/api/v1/upload/files/generated-images/out.png")),
+            AsyncMock(
+                return_value=ImageContent(
+                    url="/api/v1/upload/files/generated-images/out.png"
+                )
+            ),
         ),
     ):
         await generate_image(
@@ -802,7 +816,9 @@ async def test_generate_image_rejects_reference_indexes_when_disabled():
 
     mock_generate.assert_not_awaited()
     assert result.display_result["success"] is False
-    assert result.display_result["error"] == "Reference images are disabled for this agent"
+    assert (
+        result.display_result["error"] == "Reference images are disabled for this agent"
+    )
 
 
 @pytest.mark.anyio

--- a/backend/tests/llm/test_media_builtin_tools.py
+++ b/backend/tests/llm/test_media_builtin_tools.py
@@ -194,6 +194,53 @@ async def test_generate_image_uses_legacy_size_default_when_width_height_missing
 
 
 @pytest.mark.anyio
+async def test_generate_image_clamps_num_images_to_agent_limit():
+    agent = SimpleNamespace(
+        enable_image_generation=True,
+        image_generation_config={
+            "default_model_ref": "openai/gpt-image-1",
+            "default_width": 1024,
+            "default_height": 1024,
+            "max_images": 1,
+            "allow_reference_images": True,
+        },
+    )
+    response = ImageGenerationResponse(
+        images=[
+            GeneratedImage(
+                image=ImageContent(url="https://example.com/cat.png", format="png"),
+            )
+        ],
+        model="gpt-image-1",
+    )
+
+    with (
+        patch(
+            "app.llm.tools.builtin.media.model_manager.generate_image",
+            AsyncMock(return_value=response),
+        ) as mock_generate,
+        patch(
+            "app.llm.tools.builtin.media.media_asset_service.normalize_image",
+            AsyncMock(
+                return_value=ImageContent(
+                    url="/api/v1/upload/files/generated-images/2026/03/cat.png",
+                    format="png",
+                )
+            ),
+        ),
+    ):
+        result = await generate_image(
+            prompt="A cat portrait",
+            num_images=4,
+            agent=agent,
+        )
+
+    request = mock_generate.await_args.args[0]
+    assert request.num_images == 1
+    assert result.display_result["success"] is True
+
+
+@pytest.mark.anyio
 async def test_generate_image_normalizes_inline_base64_to_backend_url():
     agent = SimpleNamespace(
         enable_image_generation=True,

--- a/backend/tests/services/test_chat_context_file_uploads.py
+++ b/backend/tests/services/test_chat_context_file_uploads.py
@@ -70,6 +70,34 @@ async def test_current_upload_content_is_appended_to_current_user_message():
 
 
 @pytest.mark.anyio
+async def test_non_vision_upload_content_uses_reference_labels_without_image_parts():
+    messages, _ = await _build_messages_with_file_content(
+        agent=_agent(),
+        conversation=_conversation(),
+        user_message="Use the last image as a drawing reference.",
+        file_content=None,
+        user_locale="en",
+        history_override=[],
+        current_images=[
+            {"url": "data:image/png;base64,first"},
+            {"url": "data:image/png;base64,last"},
+        ],
+        model_supports_vision=False,
+        current_user_message_id=None,
+        include_current_user_message=True,
+        exclude_message_ids=None,
+        history_before_message_created_at=None,
+    )
+
+    assert messages[-1].role == MessageRole.USER
+    assert messages[-1].content == (
+        "Use the last image as a drawing reference.\n\n"
+        "Uploaded image #1: available as a reference image.\n"
+        "Uploaded image #2: available as a reference image."
+    )
+
+
+@pytest.mark.anyio
 async def test_vision_upload_content_preserves_image_parts():
     messages, _ = await _build_messages_with_file_content(
         agent=_agent(),
@@ -90,9 +118,11 @@ async def test_vision_upload_content_preserves_image_parts():
     assert isinstance(content, list)
     assert content[0].type == ContentType.TEXT
     assert content[0].text == "Describe this."
-    assert content[1].type == ContentType.IMAGE
-    assert content[2].type == ContentType.TEXT
-    assert content[2].text == "<uploaded_files>\nDocument content\n</uploaded_files>"
+    assert content[1].type == ContentType.TEXT
+    assert content[1].text == "Uploaded image #1:"
+    assert content[2].type == ContentType.IMAGE
+    assert content[3].type == ContentType.TEXT
+    assert content[3].text == "<uploaded_files>\nDocument content\n</uploaded_files>"
 
 
 @pytest.mark.anyio

--- a/backend/tests/services/test_chat_tool_executor.py
+++ b/backend/tests/services/test_chat_tool_executor.py
@@ -169,6 +169,29 @@ class TestChatToolExecutor:
         }
 
     @pytest.mark.anyio
+    async def test_execute_tool_call_passes_current_images_to_registered_tool(self):
+        async def handler(current_images=None):
+            return {"current_images": current_images}
+
+        previous_tool = tool_registry.get_tool("current_image_probe")
+        tool_registry.register(
+            name="current_image_probe",
+            description="Probe current images",
+        )(handler)
+        try:
+            result = await execute_tool_call(
+                "current_image_probe",
+                {},
+                current_images=[{"url": "data:image/png;base64,cmVm"}],
+            )
+        finally:
+            tool_registry.unregister("current_image_probe")
+            if previous_tool is not None:
+                tool_registry.register_tool(previous_tool)
+
+        assert result == {"current_images": [{"url": "data:image/png;base64,cmVm"}]}
+
+    @pytest.mark.anyio
     async def test_execute_custom_code_tool_passes_session_to_sandbox_runtime(self):
         tool = SimpleNamespace(
             config={"language": "python", "code": "return {'value': 42}"},

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -2,6 +2,14 @@
 
 ## Active
 
+- **agent-message-version-branch-aware-context** — Complete. Make Agent message version switching branch-aware and prevent stale session memory from leaking previous-version context. See `docs/plan/agent-message-version-branch-aware-context.md`
+  - [x] 1. Design docs and implementation index
+  - [x] 2. Message branch schema and migration
+  - [x] 3. Branch helper service and active path activation
+  - [x] 4. Chat regenerate/switch-version branch behavior
+  - [x] 5. Branch-aware history and session memory guards
+  - [x] 6. Validation and regression checks
+
 - **agent-reference-image-inputs** — In progress. Let Agent media generation tools use selected uploaded chat images as reference inputs via indexed references and backend base64 conversion. See `docs/plan/agent-reference-image-inputs.md`
   - [x] 1. Design docs and implementation index
   - [x] 2. Uploaded image labeling and tool context plumbing

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -2,6 +2,20 @@
 
 ## Active
 
+- **agent-reference-image-inputs** — In progress. Let Agent media generation tools use selected uploaded chat images as reference inputs via indexed references and backend base64 conversion. See `docs/plan/agent-reference-image-inputs.md`
+  - [x] 1. Design docs and implementation index
+  - [x] 2. Uploaded image labeling and tool context plumbing
+  - [x] 3. Image generation indexed reference resolution and i18n
+  - [x] 4. Tests and backend validation
+  - [x] 5. Video start-image entrypoint and explicit unsupported-provider failure
+  - [x] 6. SiliconFlow video start-image support
+  - [x] 7. Runway video start-image support
+  - [x] 8. DashScope video start-image support
+  - [x] 9. Kling video start-image support
+  - [x] 10. Luma video start-image support
+  - [x] 11. Pika video start-image support
+  - [x] 12. Volcengine video start-image support
+
 - **auth-layout-switcher** — Complete. Add a configurable centered/split authentication page layout, managed from admin site settings. See `docs/plan/auth-layout-switcher.md`
   - [x] 1. Design docs and implementation index
   - [x] 2. Public site setting and admin general settings UI

--- a/docs/plan/agent-message-version-branch-aware-context.md
+++ b/docs/plan/agent-message-version-branch-aware-context.md
@@ -1,0 +1,100 @@
+# Agent Message Version Branch-Aware Context Design Document
+
+## Background & Goals
+
+- Problem to solve: Agent message versions are currently managed as a flat list with `parent_id`, `is_active`, and `version_number`. Switching a historical version uses linear `created_at` deactivation, so descendant replies that belong to the selected version are not restored. Regenerated replies can also see stale previous-version content through conversation-scoped session memory summaries.
+- Success criteria:
+  - Version switching activates the selected version and its descendant branch when present.
+  - Regeneration uses only the branch prefix before the regenerated assistant message.
+  - Session memory summaries are not injected when their source is outside the current branch or after the context cutoff.
+  - Existing frontend version controls keep working after conversation reload.
+
+## High-Level Design
+
+- Add explicit branch lineage to `Message` with `branch_parent_id`.
+- Keep `parent_id` as the version-group root pointer.
+- Keep `is_active` as the materialized current visible branch path for compatibility with existing API response logic.
+- Centralize branch operations in a backend service so conversation retrieval, prompt context building, version switching, and session memory use the same active-branch semantics.
+
+## Implementation Plan
+
+### Stage 1: Planning docs
+
+- **Files modified**: `docs/IMPLEMENTATION_PLAN.md`, `docs/plan/agent-message-version-branch-aware-context.md`
+- **Specific logic**: Track implementation stages and verification expectations.
+- **Validation**: Confirm the plan index links to this file and stage 1 is checked.
+
+### Stage 2: Message branch schema and migration
+
+- **Files modified**: `backend/app/models/agent.py`, `backend/app/core/init_data.py`, `backend/app/main.py`
+- **Specific logic**:
+  - Add nullable `Message.branch_parent_id`.
+  - Add an idempotent startup migration to add the column and indexes.
+  - Backfill current active canonical messages into a linear branch per conversation.
+  - Backfill inactive version children so alternatives inherit the root message predecessor.
+- **Validation**: Startup migration is idempotent and does not fail when `messages` does not exist.
+
+### Stage 3: Branch helper service
+
+- **Files modified**: `backend/app/services/message_branching.py`
+- **Specific logic**:
+  - Resolve version roots and groups.
+  - Return active visible messages in branch order.
+  - Build prefix path before a message.
+  - Follow descendant branch from a selected version.
+  - Activate exactly one branch path and its round support messages.
+  - Check whether a message belongs to the active branch.
+- **Validation**: Unit-level helper tests or focused script-created objects confirm path activation and descendant selection.
+
+### Stage 4: Chat creation, regenerate, and switch-version
+
+- **Files modified**: `backend/app/api/v1/endpoints/chat.py`
+- **Specific logic**:
+  - Set `branch_parent_id` for user, assistant, and round support messages.
+  - Regenerated assistant versions inherit the old version's `branch_parent_id`.
+  - `switch_message_version` activates prefix + target descendant path instead of timestamp-deactivating later messages.
+  - Stale session memory after branch changes when needed.
+- **Validation**: Switching between two assistant versions restores each version's own continuation path.
+
+### Stage 5: Branch-aware history and memory
+
+- **Files modified**: `backend/app/api/v1/endpoints/agents.py`, `backend/app/api/v1/admin/endpoints/conversations.py`, `backend/app/services/chat_context.py`, `backend/app/services/session_memory.py`
+- **Specific logic**:
+  - Use the shared active-branch helper for conversation responses and model context history.
+  - Apply cutoffs only inside the active branch.
+  - Skip session memory injection if the snapshot source is not on the active branch or falls after the prompt cutoff.
+  - Extract session memory from branch-aware history only.
+- **Validation**: A stale summary containing a sentinel from an inactive branch does not appear in prepared model messages.
+
+### Stage 6: Validation and regression checks
+
+- **Files modified**: tests as needed under `backend/tests/`.
+- **Specific logic**:
+  - Add focused tests for branch switching, regeneration context exclusion, session memory guard, version counts, and round tool-step activation.
+- **Validation**:
+  - `uv run ruff check .`
+  - `uv run mypy app/`
+  - `uv run pytest` or targeted tests if the full suite is too large.
+  - Frontend `bun run lint` / `bun run build` only if frontend files change.
+
+## Testing Strategy
+
+- Happy path tests:
+  - Create A1 v1 with continuation, regenerate A1 v2 with a different continuation, then switch both ways and verify visible messages.
+  - Regenerate an assistant message and verify the new prompt contains the preceding user message but not the old assistant content.
+- Error path tests:
+  - Reject switching to a version outside the current message's version group.
+  - Skip stale session memory when source message is inactive or outside branch.
+- Regression scope:
+  - Existing message version list API.
+  - Conversation detail payload and `version_count` computation.
+  - Tool-call rounds nested under canonical assistant messages.
+
+## Risks & Mitigation
+
+- Old hidden branches cannot be perfectly reconstructed from existing data. Backfill preserves current active paths and makes new branch operations correct going forward.
+- Round step messages can disappear if only canonical messages are activated. Activation must include non-canonical messages for active round IDs.
+- Session memory is conversation-scoped. Guard injection by branch membership and stale snapshots after branch switches.
+- Multiple endpoints query active messages. Use the shared helper to avoid divergent behavior.
+
+Rollback plan: remove branch-aware endpoint logic and fall back to existing `is_active` queries; keep the nullable `branch_parent_id` column unused if rollback is needed.

--- a/docs/plan/agent-reference-image-inputs.md
+++ b/docs/plan/agent-reference-image-inputs.md
@@ -1,0 +1,174 @@
+# Agent Reference Image Inputs Design Document
+
+## Background & Goals
+
+Agent chat can already send uploaded images to vision-capable chat models, and the image-generation tool already has a low-level `images` input. The missing link is letting the Agent select the correct uploaded chat image and pass it to generation safely.
+
+Success criteria:
+
+- Uploaded chat images are visible to the LLM with stable 1-based labels.
+- `generate_image` can reference selected uploaded images through indexes instead of receiving every upload.
+- Selected chat images are converted to base64-backed `ImageContent`, not local or private URLs.
+- Existing text-only image generation and explicit `images` tool inputs keep working.
+- Video reference-image support remains explicitly out of scope for this patch.
+
+## High-Level Design
+
+The current chat request persists images on the user message and passes them into `build_vision_content()`. This change adds labels beside those image parts, passes the current image list as hidden tool context, and lets `generate_image` resolve `reference_image_indexes` into provider-safe image references.
+
+Flow:
+
+1. User uploads images in chat.
+2. Chat context presents them as `Uploaded image #N:` plus image content.
+3. The LLM calls `generate_image` with `reference_image_indexes` for only the images it needs.
+4. The backend resolves those indexes against current chat images.
+5. Data URLs are converted to `ImageContent(base64=..., format=...)` before `model_manager.generate_image()`.
+
+## Implementation Plan
+
+### Stage 1: Uploaded image labels and tool context
+
+- **Files modified**: `backend/app/services/chat_context.py`, `backend/app/api/v1/endpoints/chat_tools.py`, `backend/app/api/v1/endpoints/chat.py`
+- **Specific logic**:
+  - Add `Uploaded image #N:` text markers before each image part in `build_vision_content()`.
+  - Preserve MIME-derived format when converting data URLs to base64 `ImageContent`.
+  - Add optional `current_images` to `execute_tool_call()` and pass it through `tool_registry.execute()`.
+  - Pass `chat_in.images` at all chat tool execution call sites.
+- **Validation**: Unit test context/tool forwarding and inspect generated tool call execution inputs.
+
+### Stage 2: Image generation indexed reference resolution
+
+- **Files modified**: `backend/app/llm/tools/builtin/media.py`
+- **Specific logic**:
+  - Add `reference_image_indexes` and hidden `current_images` parameters to `generate_image()`.
+  - Add tool schema guidance for indexed references.
+  - Resolve 1-based indexes, deduplicate, validate range, and convert selected data URLs to base64 `ImageContent`.
+  - Keep explicit `images` compatibility, but make explicit `images` and indexes mutually exclusive.
+  - Apply existing `allow_reference_images` behavior to both forms.
+- **Validation**: Mock `model_manager.generate_image()` and assert only selected images are passed as base64 references.
+
+### Stage 3: Localized errors
+
+- **Files modified**: `backend/app/core/i18n_legacy.py`, `backend/app/locales/en/LC_MESSAGES/messages.po`, `backend/app/locales/zh/LC_MESSAGES/messages.po`
+- **Specific logic**:
+  - Add localized errors for conflicting reference inputs, missing uploads, out-of-range indexes, and unusable uploaded images.
+- **Validation**: Tool-level tests assert localized errors appear in media tool failure payloads.
+
+### Stage 4: Tests and validation
+
+- **Files modified**: `backend/tests/llm/test_media_builtin_tools.py`, `backend/tests/services/test_chat_tool_executor.py`
+- **Specific logic**:
+  - Cover data URL format parsing, index selection, deduplication, validation failures, and current image context forwarding.
+- **Validation**:
+  - `uv run pytest backend/tests/llm/test_media_builtin_tools.py backend/tests/services/test_chat_tool_executor.py`
+  - `uv run ruff check` on touched backend Python files.
+
+### Stage 5: Video start-image entrypoint
+
+- **Files modified**: `backend/app/llm/types/video.py`, `backend/app/llm/tools/builtin/media.py`, `backend/app/llm/adapters/video/*`, backend i18n catalogs
+- **Specific logic**:
+  - Add `VideoGenerationRequest.start_image` for a selected uploaded image used as a first-frame/reference input.
+  - Add `generate_video(start_image_index=...)` so the Agent can express a video reference-image intent with the same indexed upload mechanism.
+  - Resolve the selected chat upload to base64 `ImageContent`; do not pass local/private URLs.
+  - Add a shared video adapter guard that returns a localized unsupported error when a provider receives `start_image` but has not implemented support.
+- **Validation**:
+  - Tool tests cover start image selection and explicit unsupported-provider failure.
+  - Existing text-only video generation remains unchanged.
+
+### Stage 6: SiliconFlow video start-image support
+
+- **Files modified**: `backend/app/llm/adapters/video/siliconflow.py`, `backend/tests/llm/test_media_adapters.py`
+- **Specific logic**:
+  - Enable `VideoGenerationRequest.start_image` only for documented SiliconFlow I2V models.
+  - Convert `ImageContent` to a data URI and send it as the `/video/submit` `image` field.
+  - Keep text-to-video payloads unchanged and keep unsupported errors for non-I2V models.
+- **Validation**: Unit test payload construction with a base64 data URI and confirm text-only SiliconFlow generation omits `image`.
+
+### Stage 7: Runway video start-image support
+
+- **Files modified**: `backend/app/llm/adapters/video/runway.py`, `backend/tests/llm/test_media_adapters.py`
+- **Specific logic**:
+  - Branch `_build_request()` to use Runway image-to-video when `start_image` is present.
+  - Send the selected image as `promptImage` using a data URI and validate against documented image-to-video model IDs.
+  - Keep generic task polling through the existing Runway client.
+- **Validation**: Unit test endpoint selection, `promptImage` data URI payloads, unsupported model rejection, and unchanged text-to-video requests.
+
+### Stage 8: DashScope video start-image support
+
+- **Files modified**: `backend/app/llm/adapters/video/dashscope.py`, `backend/app/llm/adapters/dashscope_video_client.py`, `backend/tests/llm/test_media_adapters.py`
+- **Specific logic**:
+  - Add an image-to-video request branch for Wan I2V models.
+  - Send the selected image as `input.img_url` using a `data:{mime};base64,...` value.
+  - Preserve the existing text-to-video endpoint and async status handling.
+- **Validation**: Unit test the I2V endpoint/payload branch, invalid model failure, and unchanged text-only DashScope payloads.
+
+### Stage 9: Kling video start-image support
+
+- **Files modified**: `backend/app/llm/adapters/video/kling.py`, `backend/app/llm/adapters/kling_client.py`, `backend/tests/llm/test_media_adapters.py`
+- **Specific logic**:
+  - Branch from `/v1/videos/text2video` to the documented image-to-video endpoint when `start_image` is present.
+  - Send the selected image in the documented image field as provider-compatible base64.
+  - Update status polling so it uses the matching text-to-video or image-to-video task path.
+- **Validation**: Unit test create/status path selection, image base64 payloads, and text-to-video regression behavior.
+
+### Stage 10: Luma video start-image support
+
+- **Files modified**: `backend/app/llm/adapters/video/luma.py`, `backend/tests/llm/test_media_adapters.py`
+- **Specific logic**:
+  - Treat direct Luma as URL-only because its current API requires CDN image URLs for keyframes.
+  - Do not send base64 chat uploads directly to Luma.
+  - Add support only when a selected image can be converted to an approved public asset URL; otherwise keep the localized unsupported failure.
+- **Validation**: Unit test that base64-only chat uploads still fail clearly, and that a supported public URL path builds `keyframes.frame0` when the prerequisite asset flow exists.
+
+### Stage 11: Pika video start-image support
+
+- **Files modified**: `backend/app/llm/adapters/video/pika.py`, `backend/tests/llm/test_media_adapters.py`
+- **Specific logic**:
+  - Send `start_image` as a provider-safe data URI in the direct Pika `image_url` field by default.
+  - Allow `config.start_image_field` to override the field name for deployments whose Pika-compatible endpoint expects a different key.
+  - Keep text-to-video payloads unchanged when no `start_image` is present.
+- **Validation**: Unit tests assert default `image_url` payload construction and configured field override behavior.
+
+### Stage 12: Volcengine video start-image support
+
+- **Files modified**: `backend/app/llm/adapters/video/volcengine.py`, `backend/tests/llm/test_media_adapters.py`
+- **Specific logic**:
+  - Use the existing Volcengine content-array request shape for Seedance-style multimodal input.
+  - Add the selected image as an `image_url` content item with a provider-safe data URI.
+  - Keep existing text content payloads unchanged.
+- **Validation**: Unit test the image content payload and unchanged text-only Volcengine payloads.
+
+## Testing Strategy
+
+Happy path:
+
+- One selected uploaded data URL becomes one base64 `ImageContent`.
+- Multiple selected indexes preserve user order after deduplication.
+- Text-only image generation still sends no references.
+- Existing explicit `images` input still works.
+
+Error path:
+
+- Both explicit `images` and `reference_image_indexes` are rejected.
+- Out-of-range reference indexes are rejected.
+- Indexes without current uploaded images are rejected.
+- Invalid uploaded image data is rejected.
+
+Regression scope:
+
+- Existing chat vision messages still include image content.
+- Existing media tool result rendering is unchanged.
+- Existing video generation behavior is unchanged.
+
+## Risks & Mitigation
+
+- The LLM may still omit indexes. Mitigation: add clear image labels and tool parameter guidance; do not auto-inject all images.
+- Some image providers ignore `request.images`. Mitigation: keep provider scope unchanged and rely on existing Google/SiliconFlow support first.
+- Base64 references can be large. Mitigation: pass only selected indexes, not every uploaded image.
+- Video references are provider-specific. Mitigation: do not enable them until the video request schema and adapters support explicit semantics.
+
+Rollback plan:
+
+- Remove `reference_image_indexes` from `generate_image` schema/signature.
+- Stop forwarding `current_images` from chat execution.
+- Revert image labels and MIME format preservation in `build_vision_content()`.

--- a/frontend/app/(dashboard)/teams/_components/team-detail-dialog.tsx
+++ b/frontend/app/(dashboard)/teams/_components/team-detail-dialog.tsx
@@ -302,7 +302,7 @@ export function TeamDetailDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="sm:max-w-3xl max-h-[90vh]">
+        <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-hidden grid-rows-[auto_minmax(0,1fr)]">
           {isLoading ? (
             <div className="space-y-4 py-4">
               <div className="flex items-center gap-4">
@@ -338,7 +338,7 @@ export function TeamDetailDialog({
                 </div>
               </DialogHeader>
               
-              <Tabs defaultValue="members" className="w-full">
+              <Tabs defaultValue="members" className="min-h-0 w-full overflow-hidden">
                 {canManageTeam ? (
                   <TabsList className="grid w-full grid-cols-2">
                     <TabsTrigger value="members" className="flex items-center gap-2">
@@ -359,10 +359,10 @@ export function TeamDetailDialog({
                   </TabsList>
                 )}
                 
-                <TabsContent value="members" className="mt-4 space-y-4">
+                <TabsContent value="members" className="mt-4 flex min-h-0 flex-col gap-4 overflow-hidden">
                   {/* 成员列表 */}
-                  <div>
-                    <div className="flex items-center justify-between mb-3">
+                  <div className="flex min-h-0 flex-1 flex-col">
+                    <div className="mb-3 flex items-center justify-between">
                       <h3 className="font-medium">{t('members')} ({team.members.length})</h3>
                       <PermissionGuard permission="team:manage">
                         <Popover open={addMemberOpen} onOpenChange={setAddMemberOpen}>
@@ -455,7 +455,7 @@ export function TeamDetailDialog({
                       </PermissionGuard>
                     </div>
                   
-                  <ScrollArea className="h-64">
+                  <ScrollArea className="min-h-0 flex-1">
                     <div className="space-y-2">
                       {team.members.map((member) => (
                         <div
@@ -557,7 +557,7 @@ export function TeamDetailDialog({
               </TabsContent>
 
               {canManageTeam && (
-                <TabsContent value="models" className="mt-4">
+                <TabsContent value="models" className="mt-4 min-h-0 overflow-hidden">
                   <TeamModelsTab teamId={teamId!} />
                 </TabsContent>
               )}

--- a/frontend/app/(dashboard)/teams/_components/team-models-tab.tsx
+++ b/frontend/app/(dashboard)/teams/_components/team-models-tab.tsx
@@ -283,7 +283,7 @@ export function TeamModelsTab({ teamId }: TeamModelsTabProps) {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="flex h-full min-h-0 flex-col space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
         <h3 className="font-medium">
@@ -299,7 +299,7 @@ export function TeamModelsTab({ teamId }: TeamModelsTabProps) {
                 </Button>
               }
             />
-            <PopoverContent className="w-80 p-0" align="end">
+            <PopoverContent className="w-80 max-h-[min(28rem,calc(100vh-8rem))] overflow-hidden p-0 flex flex-col" align="end">
               <div className="p-3 border-b space-y-2">
                 <div className="relative">
                   <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -323,7 +323,7 @@ export function TeamModelsTab({ teamId }: TeamModelsTabProps) {
                   </div>
                 )}
               </div>
-              <ScrollArea className="h-64">
+              <ScrollArea className="min-h-0 flex-1">
                 {filteredModels.length === 0 ? (
                   <div className="p-4 text-center text-muted-foreground text-sm">
                     {availableModels.length === 0
@@ -380,7 +380,7 @@ export function TeamModelsTab({ teamId }: TeamModelsTabProps) {
           <p className="text-sm">{t('addModelHint')}</p>
         </div>
       ) : (
-        <div className="border rounded-md overflow-x-auto">
+        <div className="min-h-0 flex-1 overflow-auto rounded-md border">
           <Table>
             <TableHeader>
               <TableRow>

--- a/frontend/hooks/use-chat.ts
+++ b/frontend/hooks/use-chat.ts
@@ -1126,9 +1126,12 @@ export function useChat(options: UseChatOptions): UseChatReturn {
       setError(null)
       setStatus('loading')
 
-      // Update message to loading state
-      setMessages((prev) =>
-        prev.map((msg) => {
+      // Update message to loading state and remove descendants from the stale branch
+      setMessages((prev) => {
+        const targetIndex = prev.findIndex((msg) => msg.id === messageId)
+        if (targetIndex === -1) return prev
+
+        return prev.slice(0, targetIndex + 1).map((msg) => {
           if (msg.id !== messageId) return msg
 
           const nextMetadata = { ...msg.metadata }
@@ -1142,7 +1145,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
             metadata: { ...nextMetadata, isLoading: true, isManuallyStopped: false },
           }
         })
-      )
+      })
 
       streamingStateRef.current = {
         assistantMessageId: messageId,

--- a/frontend/lib/api/agents.ts
+++ b/frontend/lib/api/agents.ts
@@ -406,6 +406,7 @@ export interface Message {
   steps?: MessageRoundStep[] | null
   // Version fields
   parent_id?: string | null
+  branch_parent_id?: string | null
   is_active?: boolean
   version_number?: number
   version_count?: number


### PR DESCRIPTION
## Summary
- Add branch parent tracking for agent chat messages and startup backfill.
- Activate version switches/regenerations as branch paths, including descendant messages and tool-round steps.
- Guard conversation session memory and frontend regenerate state from stale branch context.

## Test plan
- [x] uv run python -m py_compile app/api/v1/endpoints/chat.py app/services/chat_context.py app/services/message_branching.py app/services/session_memory.py app/core/init_data.py app/main.py app/models/agent.py app/schemas/agent.py
- [x] uv run ruff check .
- [x] cd frontend && bun run lint
- [x] cd frontend && bun run build
- [ ] uv run mypy app/ (fails on existing app/llm/adapters/video/runway.py type error)
- [ ] PYTHONPATH=. uv run pytest (collection fails on existing workflow/sandbox import issues)

Closes #179