### PR TITLE
Fix agent message version branch context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ uploads/
 # ai
 CLAUDE.md
 .claude
+.codegraph/
 
 # Celery beat schedule files
 backend/celerybeat-schedule

--- a/backend/app/api/v1/admin/endpoints/conversations.py
+++ b/backend/app/api/v1/admin/endpoints/conversations.py
@@ -31,6 +31,7 @@ from app.schemas.response import (
     success,
 )
 from app.api.v1.endpoints.chat import build_message_round_payloads
+from app.services.message_branching import get_visible_conversation_messages
 
 
 router = APIRouter()
@@ -483,11 +484,8 @@ async def get_conversation_detail(
                     status_code=404,
                 )
 
-    # Get only active messages
-    messages = await Message.filter(
-        conversation_id=conversation.id,
-        is_active=True,
-    ).order_by("created_at")
+    # Get visible branch messages
+    messages = await get_visible_conversation_messages(conversation.id)
 
     # Batch calculate version counts
     root_ids = set()

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -51,6 +51,7 @@ from app.services.auto_notification import AutoNotificationService
 from app.models.notification import AutoNotificationType
 from app.core.i18n import t
 from app.api.v1.endpoints.chat import build_message_round_payloads
+from app.services.message_branching import get_visible_conversation_messages
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -1057,10 +1058,7 @@ async def get_conversation(
             status_code=404,
         )
 
-    messages = await Message.filter(
-        conversation_id=conversation.id,
-        is_active=True,
-    ).order_by("created_at")
+    messages = await get_visible_conversation_messages(conversation.id)
 
     # Batch calculate version counts to avoid N+1 queries
     # Get all parent_ids we need to count

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -61,6 +61,15 @@ from app.services.chat_context import (
     prepare_model_context,
     retry_prepare_model_context,
 )
+from app.services.message_branching import (
+    activate_conversation_branch,
+    find_descendant_branch_from,
+    get_last_active_canonical_message,
+    get_prefix_path_before,
+    get_version_count as get_branch_version_count,
+    get_version_root_id,
+    stale_session_memory_if_source_outside_active_branch,
+)
 
 # Import helper functions from modules
 from app.api.v1.endpoints.chat_helpers import (
@@ -250,6 +259,11 @@ async def get_or_create_conversation(
     )
 
     return conversation
+
+
+async def get_next_user_branch_parent_id(conversation: Conversation) -> UUID | None:
+    last_message = await get_last_active_canonical_message(conversation.id)
+    return last_message.id if last_message else None
 
 
 async def update_message_stats(agent: Agent, token_usage: dict | None = None):
@@ -986,6 +1000,7 @@ async def chat(
 
     round_id = uuid4()
     next_round_index = 1
+    user_branch_parent_id = await get_next_user_branch_parent_id(conversation)
 
     # Save user message with images and file_urls
     user_msg = await Message.create(
@@ -997,6 +1012,7 @@ async def chat(
         if chat_in.file_urls
         else None,
         rag_context=rag_contexts if rag_contexts else None,
+        branch_parent_id=user_branch_parent_id,
         round_id=round_id,
         round_index=0,
         round_role=MessageRoundRole.USER_INPUT,
@@ -1353,6 +1369,7 @@ async def chat(
             },
             duration_ms=duration_ms,
             tool_calls=final_tool_calls,
+            branch_parent_id=user_msg.id,
             round_id=round_id,
             round_index=next_round_index,
             round_role=MessageRoundRole.ASSISTANT_FINAL,
@@ -1386,6 +1403,11 @@ async def chat(
         # Update agent stats atomically
         await Agent.filter(id=agent.id).update(message_count=F("message_count") + 2)
 
+        branch_prefix = await get_prefix_path_before(user_msg)
+        await activate_conversation_branch(
+            conversation.id,
+            [*branch_prefix, user_msg, assistant_msg],
+        )
         enqueue_session_memory_extraction(agent, conversation, assistant_msg)
 
         return success(
@@ -1558,6 +1580,9 @@ async def chat_stream(
 
                     round_id = uuid4()
                     next_round_index = 1
+                    user_branch_parent_id = await get_next_user_branch_parent_id(
+                        conversation
+                    )
 
                     # Save user message with images and file_urls
                     user_msg = await Message.create(
@@ -1571,6 +1596,7 @@ async def chat_stream(
                         if chat_in.file_urls
                         else None,
                         rag_context=rag_contexts if rag_contexts else None,
+                        branch_parent_id=user_branch_parent_id,
                         round_id=round_id,
                         round_index=0,
                         round_role=MessageRoundRole.USER_INPUT,
@@ -1582,6 +1608,7 @@ async def chat_stream(
                         conversation=conversation,
                         role=MessageRole.ASSISTANT,
                         content="",  # Will be updated
+                        branch_parent_id=user_msg.id,
                         round_id=round_id,
                         round_index=0,
                         round_role=MessageRoundRole.ASSISTANT_FINAL,
@@ -2299,6 +2326,11 @@ async def chat_stream(
                         "completion": output_tokens,
                     }
                     await assistant_msg.save()
+                    branch_prefix = await get_prefix_path_before(user_msg)
+                    await activate_conversation_branch(
+                        conversation.id,
+                        [*branch_prefix, user_msg, assistant_msg],
+                    )
                     enqueue_session_memory_extraction(
                         agent, conversation, assistant_msg
                     )
@@ -2649,8 +2681,8 @@ async def switch_message_version(
         )
 
     # Verify target version belongs to the same version group
-    root_id = message.parent_id or message.id
-    target_root_id = target_version.parent_id or target_version.id
+    root_id = get_version_root_id(message)
+    target_root_id = get_version_root_id(target_version)
     if root_id != target_root_id:
         raise BusinessError(
             code=ResponseCode.BAD_REQUEST,
@@ -2658,45 +2690,13 @@ async def switch_message_version(
             status_code=400,
         )
 
-    # Deactivate all versions in this group
-    await Message.filter(id=root_id).update(is_active=False)
-    await Message.filter(parent_id=root_id).update(is_active=False)
-
-    # Activate the target version
-    target_version.is_active = True
-    await target_version.save()
-
-    # Get the root message to use its created_at for deactivating subsequent messages
-    root_message = await Message.filter(id=root_id).first()
-    if root_message:
-        # Get all tool_call_ids from the target version
-        target_tool_call_ids = set()
-        if target_version.tool_calls:
-            for tc in target_version.tool_calls:
-                if isinstance(tc, dict) and "id" in tc:
-                    target_tool_call_ids.add(tc["id"])
-
-        # Deactivate all messages after the root message in the conversation
-        # EXCEPT the target version itself and tool messages that belong to it
-        messages_to_deactivate = await Message.filter(
-            conversation_id=message.conversation_id,
-            created_at__gt=root_message.created_at,
-            is_active=True,
-        ).all()
-
-        for msg in messages_to_deactivate:
-            # Keep the target version itself
-            if msg.id == target_version.id:
-                continue
-            # Keep tool messages that belong to the target version
-            if (
-                msg.role == MessageRole.TOOL
-                and msg.tool_call_id in target_tool_call_ids
-            ):
-                continue
-            # Deactivate all other messages
-            msg.is_active = False
-            await msg.save()
+    prefix = await get_prefix_path_before(target_version)
+    descendant_branch = await find_descendant_branch_from(target_version)
+    await activate_conversation_branch(
+        message.conversation_id,
+        [*prefix, *descendant_branch],
+    )
+    await stale_session_memory_if_source_outside_active_branch(message.conversation_id)
 
     return success(
         data=await build_message_out_with_versions(
@@ -2757,17 +2757,14 @@ async def regenerate_message(
             status_code=404,
         )
 
-    # Find the user message before this assistant message
-    # We need to get the active user message that preceded this response
-    user_message = (
-        await Message.filter(
-            conversation_id=conversation.id,
-            role=MessageRole.USER,
-            created_at__lt=message.created_at,
-            is_active=True,
-        )
-        .order_by("-created_at")
-        .first()
+    prefix_for_message = await get_prefix_path_before(message)
+    user_message = next(
+        (
+            item
+            for item in reversed(prefix_for_message)
+            if item.role == MessageRole.USER
+        ),
+        None,
     )
 
     if not user_message:
@@ -2798,6 +2795,26 @@ async def regenerate_message(
                 FinishReason,
             )
 
+            async def activate_regenerated_path() -> None:
+                if not new_message:
+                    return
+                prefix = await get_prefix_path_before(new_message)
+                await activate_conversation_branch(
+                    conversation.id,
+                    [*prefix, new_message],
+                )
+                await stale_session_memory_if_source_outside_active_branch(
+                    conversation.id
+                )
+
+            async def restore_original_path() -> None:
+                prefix = await get_prefix_path_before(message)
+                descendant_branch = await find_descendant_branch_from(message)
+                await activate_conversation_branch(
+                    conversation.id,
+                    [*prefix, *descendant_branch],
+                )
+
             # Get streaming configuration
             streaming_config = get_streaming_config(agent)
             global_timeout = streaming_config["global_timeout"]
@@ -2826,17 +2843,15 @@ async def regenerate_message(
                     from app.models.agent import RAGMode
 
                     # Determine the root message ID for versioning
-                    root_id = message.parent_id or message.id
+                    root_id = get_version_root_id(message)
 
                     # Get current version count
-                    current_version_count = (
-                        await Message.filter(parent_id=root_id).count() + 1
-                    )
+                    current_version_count = await get_branch_version_count(message)
                     new_version_number = current_version_count + 1
-
-                    # Deactivate all versions in this group
-                    await Message.filter(id=root_id).update(is_active=False)
-                    await Message.filter(parent_id=root_id).update(is_active=False)
+                    branch_parent_id = message.branch_parent_id
+                    if branch_parent_id is None:
+                        prefix = await get_prefix_path_before(message)
+                        branch_parent_id = prefix[-1].id if prefix else None
 
                     round_id = uuid4()
                     next_round_index = 1
@@ -2849,6 +2864,7 @@ async def regenerate_message(
                         parent_id=root_id,
                         is_active=True,
                         version_number=new_version_number,
+                        branch_parent_id=branch_parent_id,
                         round_id=round_id,
                         round_index=0,
                         round_role=MessageRoundRole.ASSISTANT_FINAL,
@@ -2942,6 +2958,7 @@ async def regenerate_message(
                             )
                             new_message.created_at = now_utc()
                             await new_message.save()
+                            await activate_regenerated_path()
                             return
 
                         # If we need to send heartbeat
@@ -3313,6 +3330,7 @@ async def regenerate_message(
                                     ],
                                     parent_id=new_message.parent_id or new_message.id,
                                     version_number=new_version_number,
+                                    branch_parent_id=new_message.id,
                                     round_id=round_id,
                                     round_index=assistant_step_index,
                                     round_role=MessageRoundRole.ASSISTANT_STEP,
@@ -3329,6 +3347,7 @@ async def regenerate_message(
                                     tool_name=tool_name,
                                     parent_id=new_message.parent_id or new_message.id,
                                     version_number=new_version_number,
+                                    branch_parent_id=new_message.id,
                                     round_id=round_id,
                                     round_index=tool_step_index,
                                     round_role=MessageRoundRole.TOOL_RESULT,
@@ -3448,6 +3467,14 @@ async def regenerate_message(
                         "completion": output_tokens,
                     }
                     await new_message.save()
+                    prefix = await get_prefix_path_before(new_message)
+                    await activate_conversation_branch(
+                        conversation.id,
+                        [*prefix, new_message],
+                    )
+                    await stale_session_memory_if_source_outside_active_branch(
+                        conversation.id
+                    )
                     enqueue_session_memory_extraction(agent, conversation, new_message)
 
                     # Update agent and team stats for regenerated message
@@ -3483,11 +3510,11 @@ async def regenerate_message(
                         fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                     )
                     if preserved_partial:
-                        await Message.filter(id=message.id).update(is_active=False)
+                        await activate_regenerated_path()
                     else:
                         if new_message_id:
                             await Message.filter(id=new_message_id).delete()
-                        await Message.filter(id=message.id).update(is_active=True)
+                        await restore_original_path()
                     logger.warning("Quota exceeded during regenerate: %s", e)
                     yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.MODEL_QUOTA_EXCEEDED, 'msg': t('model_quota_exceeded'), 'quota_type': e.quota_type})}\n\n"
                 except LLMError:
@@ -3500,11 +3527,11 @@ async def regenerate_message(
                         fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                     )
                     if preserved_partial:
-                        await Message.filter(id=message.id).update(is_active=False)
+                        await activate_regenerated_path()
                     else:
                         if new_message_id:
                             await Message.filter(id=new_message_id).delete()
-                        await Message.filter(id=message.id).update(is_active=True)
+                        await restore_original_path()
                     logger.exception("LLM error during regenerate")
                     yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t(GENERIC_STREAM_ERROR_KEY)})}\n\n"
                 except StreamIdleTimeoutError:
@@ -3517,11 +3544,11 @@ async def regenerate_message(
                         fallback_content=t("stream_timeout_exceeded"),
                     )
                     if preserved_partial:
-                        await Message.filter(id=message.id).update(is_active=False)
+                        await activate_regenerated_path()
                     else:
                         if new_message_id:
                             await Message.filter(id=new_message_id).delete()
-                        await Message.filter(id=message.id).update(is_active=True)
+                        await restore_original_path()
                     logger.warning(
                         "Regenerate stream idle timeout (%ss) for message %s",
                         idle_timeout,
@@ -3538,11 +3565,11 @@ async def regenerate_message(
                         fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                     )
                     if preserved_partial:
-                        await Message.filter(id=message.id).update(is_active=False)
+                        await activate_regenerated_path()
                     else:
                         if new_message_id:
                             await Message.filter(id=new_message_id).delete()
-                        await Message.filter(id=message.id).update(is_active=True)
+                        await restore_original_path()
                     logger.exception("Unexpected error during regenerate")
                     yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t(GENERIC_STREAM_ERROR_KEY)})}\n\n"
 
@@ -3560,10 +3587,10 @@ async def regenerate_message(
                 fallback_content=t("stream_timeout_exceeded"),
             )
             if preserved_partial:
-                await Message.filter(id=message.id).update(is_active=False)
+                await activate_regenerated_path()
             elif new_message_id:
                 await Message.filter(id=new_message_id).delete()
-                await Message.filter(id=message.id).update(is_active=True)
+                await restore_original_path()
             # Send timeout error event
             yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t('stream_timeout_exceeded'), 'timeout': global_timeout})}\n\n"
         except asyncio.CancelledError:
@@ -3585,9 +3612,10 @@ async def regenerate_message(
                     or new_message.tool_calls
                 ):
                     await new_message.save()
+                    await activate_regenerated_path()
                 else:
                     await Message.filter(id=new_message.id).delete()
-                    await Message.filter(id=message.id).update(is_active=True)
+                    await restore_original_path()
             return
 
         except Exception as exc:
@@ -3601,10 +3629,10 @@ async def regenerate_message(
                 fallback_content=t(GENERIC_STREAM_ERROR_KEY),
             )
             if preserved_partial:
-                await Message.filter(id=message.id).update(is_active=False)
+                await activate_regenerated_path()
             elif new_message_id:
                 await Message.filter(id=new_message_id).delete()
-                await Message.filter(id=message.id).update(is_active=True)
+                await restore_original_path()
             yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t(GENERIC_STREAM_ERROR_KEY)})}\n\n"
             return
 

--- a/backend/app/api/v1/endpoints/conversations.py
+++ b/backend/app/api/v1/endpoints/conversations.py
@@ -31,6 +31,7 @@ from app.schemas.response import (
     success,
 )
 from app.api.v1.endpoints.chat import build_message_round_payloads
+from app.services.message_branching import get_visible_conversation_messages
 
 
 router = APIRouter()
@@ -485,10 +486,7 @@ async def get_conversation_detail(
                     status_code=404,
                 )
 
-    messages = await Message.filter(
-        conversation_id=conversation.id,
-        is_active=True,
-    ).order_by("created_at")
+    messages = await get_visible_conversation_messages(conversation.id)
 
     # Batch calculate version counts
     root_ids = set()

--- a/backend/app/api/v1/endpoints/embed.py
+++ b/backend/app/api/v1/endpoints/embed.py
@@ -29,6 +29,7 @@ from app.models.workflow import Workflow, WorkflowStatus
 from app.schemas.agent import ChatRequest, EmbedAgentInfo
 from app.api.v1.endpoints.chat import build_message_round_payloads
 from app.schemas.response import BusinessError, ResponseCode, success
+from app.services.message_branching import get_visible_conversation_messages
 
 logger = logging.getLogger(__name__)
 
@@ -232,8 +233,6 @@ async def get_embed_conversation_messages(
     user, api_key = auth_result
     agent = await _get_embed_agent(agent_id, api_key, request)
 
-    from app.models.agent import Message
-
     conversation = await Conversation.filter(
         id=conversation_id,
         agent_id=agent.id,
@@ -247,10 +246,7 @@ async def get_embed_conversation_messages(
             status_code=404,
         )
 
-    messages = await Message.filter(
-        conversation=conversation,
-        is_active=True,
-    ).order_by("created_at")
+    messages = await get_visible_conversation_messages(conversation.id)
 
     return success(
         data=await build_message_round_payloads(messages),

--- a/backend/app/core/init_data.py
+++ b/backend/app/core/init_data.py
@@ -516,6 +516,82 @@ async def init_message_round_fields():
     logger.info("Message round metadata migration complete")
 
 
+async def init_message_branch_parent_field():
+    """
+    Add branch_parent_id to messages and backfill a best-effort visible branch.
+    Must be called BEFORE Tortoise.generate_schemas() to avoid schema mismatch.
+    """
+    logger.info("Initializing message branch parent field...")
+
+    conn = Tortoise.get_connection("default")
+
+    _, tables = await conn.execute_query("""
+        SELECT table_name FROM information_schema.tables
+        WHERE table_name = 'messages' AND table_schema = 'public'
+    """)
+
+    if not tables:
+        logger.info(
+            "Messages table does not exist yet, skipping branch parent migration"
+        )
+        return
+
+    await conn.execute_query("""
+        ALTER TABLE messages
+        ADD COLUMN IF NOT EXISTS branch_parent_id UUID NULL
+    """)
+    await conn.execute_query("""
+        CREATE INDEX IF NOT EXISTS idx_messages_conversation_branch_parent
+        ON messages (conversation_id, branch_parent_id)
+    """)
+
+    await conn.execute_query("""
+        WITH active_canonical AS (
+            SELECT
+                id,
+                LAG(id) OVER (PARTITION BY conversation_id ORDER BY created_at, id) AS previous_id
+            FROM messages
+            WHERE is_active = TRUE
+              AND (round_id IS NULL OR is_round_canonical = TRUE)
+        )
+        UPDATE messages AS m
+        SET branch_parent_id = active_canonical.previous_id
+        FROM active_canonical
+        WHERE m.id = active_canonical.id
+          AND m.branch_parent_id IS NULL
+    """)
+
+    await conn.execute_query("""
+        UPDATE messages AS m
+        SET branch_parent_id = root.branch_parent_id
+        FROM messages AS root
+        WHERE m.parent_id = root.id
+          AND m.branch_parent_id IS NULL
+    """)
+
+    await conn.execute_query("""
+        WITH round_canonical AS (
+            SELECT DISTINCT ON (conversation_id, round_id)
+                conversation_id,
+                round_id,
+                id AS canonical_id
+            FROM messages
+            WHERE round_id IS NOT NULL
+              AND is_round_canonical = TRUE
+            ORDER BY conversation_id, round_id, created_at, id
+        )
+        UPDATE messages AS m
+        SET branch_parent_id = round_canonical.canonical_id
+        FROM round_canonical
+        WHERE m.conversation_id = round_canonical.conversation_id
+          AND m.round_id = round_canonical.round_id
+          AND m.is_round_canonical = FALSE
+          AND m.branch_parent_id IS NULL
+    """)
+
+    logger.info("Message branch parent migration complete")
+
+
 async def init_conversation_session_memory_table():
     """Create the conversation_session_memories table if it does not exist."""
     logger.info("Initializing conversation session memory table...")

--- a/backend/app/core/init_data.py
+++ b/backend/app/core/init_data.py
@@ -524,11 +524,18 @@ async def init_message_branch_parent_field():
     logger.info("Initializing message branch parent field...")
 
     conn = Tortoise.get_connection("default")
+    dialect = getattr(getattr(conn, "capabilities", None), "dialect", "")
+    is_sqlite = dialect == "sqlite" or "sqlite" in conn.__class__.__name__.lower()
 
-    _, tables = await conn.execute_query("""
-        SELECT table_name FROM information_schema.tables
-        WHERE table_name = 'messages' AND table_schema = 'public'
-    """)
+    if is_sqlite:
+        _, tables = await conn.execute_query("""
+            SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'messages'
+        """)
+    else:
+        _, tables = await conn.execute_query("""
+            SELECT table_name FROM information_schema.tables
+            WHERE table_name = 'messages' AND table_schema = 'public'
+        """)
 
     if not tables:
         logger.info(
@@ -536,10 +543,24 @@ async def init_message_branch_parent_field():
         )
         return
 
-    await conn.execute_query("""
-        ALTER TABLE messages
-        ADD COLUMN IF NOT EXISTS branch_parent_id UUID NULL
-    """)
+    if is_sqlite:
+        _, columns = await conn.execute_query("PRAGMA table_info(messages)")
+        column_exists = any(
+            (column.get("name") if isinstance(column, dict) else column[1])
+            == "branch_parent_id"
+            for column in columns
+        )
+        if not column_exists:
+            await conn.execute_query("""
+                ALTER TABLE messages
+                ADD COLUMN branch_parent_id CHAR(36) NULL
+            """)
+    else:
+        await conn.execute_query("""
+            ALTER TABLE messages
+            ADD COLUMN IF NOT EXISTS branch_parent_id UUID NULL
+        """)
+
     await conn.execute_query("""
         CREATE INDEX IF NOT EXISTS idx_messages_conversation_branch_parent
         ON messages (conversation_id, branch_parent_id)
@@ -571,20 +592,24 @@ async def init_message_branch_parent_field():
 
     await conn.execute_query("""
         WITH round_canonical AS (
-            SELECT DISTINCT ON (conversation_id, round_id)
+            SELECT
                 conversation_id,
                 round_id,
-                id AS canonical_id
+                id AS canonical_id,
+                ROW_NUMBER() OVER (
+                    PARTITION BY conversation_id, round_id
+                    ORDER BY created_at, id
+                ) AS rn
             FROM messages
             WHERE round_id IS NOT NULL
               AND is_round_canonical = TRUE
-            ORDER BY conversation_id, round_id, created_at, id
         )
         UPDATE messages AS m
         SET branch_parent_id = round_canonical.canonical_id
         FROM round_canonical
         WHERE m.conversation_id = round_canonical.conversation_id
           AND m.round_id = round_canonical.round_id
+          AND round_canonical.rn = 1
           AND m.is_round_canonical = FALSE
           AND m.branch_parent_id IS NULL
     """)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -64,6 +64,7 @@ async def lifespan(app: FastAPI):
         init_agent_context_compression_config,
         init_message_manual_stop_field,
         init_message_round_fields,
+        init_message_branch_parent_field,
         init_conversation_session_memory_table,
         init_agent_user_input_request,
         init_agent_hide_tool_calls_field,
@@ -125,6 +126,11 @@ async def lifespan(app: FastAPI):
         await init_message_round_fields()
     except Exception as e:
         logger.warning(f"Message round metadata migration failed: {e}")
+
+    try:
+        await init_message_branch_parent_field()
+    except Exception as e:
+        logger.warning(f"Message branch parent migration failed: {e}")
 
     try:
         await init_conversation_session_memory_table()

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -389,6 +389,10 @@ class Message(models.Model):
     version_number = fields.IntField(
         default=1, description="Version number within the group"
     )
+    branch_parent_id = fields.UUIDField(
+        null=True,
+        description="Previous visible message version in the conversation branch",
+    )
 
     # Attachments (for user messages with images/files)
     images: list | None = fields.JSONField(

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -832,6 +832,7 @@ class MessageOut(BaseModel):
     steps: list[MessageRoundStep] | None = None
     # Version info
     parent_id: UUID | None = None
+    branch_parent_id: UUID | None = None
     is_active: bool = True
     version_number: int = 1
     version_count: int = 1  # Total versions in this group

--- a/backend/app/services/chat_context.py
+++ b/backend/app/services/chat_context.py
@@ -28,6 +28,10 @@ from app.models.agent import (
     Message as ConversationMessage,
     MessageRole as ConversationMessageRole,
 )
+from app.services.message_branching import (
+    get_visible_conversation_messages,
+    is_message_on_active_branch,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -972,6 +976,7 @@ async def _apply_session_memory_compaction(
     recent_raw_turns: int = DEFAULT_RECENT_RAW_TURNS,
     recent_tool_turns: int = DEFAULT_RECENT_TOOL_TURNS,
     protected_indexes: set[int] | None = None,
+    before_created_at=None,
 ) -> tuple[list[Message], bool, set[int]]:
     """
     Apply conversation-scoped session memory compaction.
@@ -989,7 +994,16 @@ async def _apply_session_memory_compaction(
     protected_indexes = protected_indexes or set()
     try:
         snapshot = await get_ready_session_memory(conversation.id)
-        if not snapshot or not snapshot.summary_text:
+        if not snapshot or not snapshot.summary_text or not snapshot.source_message_id:
+            cloned_messages, cloned_protected_indexes = _clone_messages(
+                messages, protected_indexes
+            )
+            return cloned_messages, False, cloned_protected_indexes
+        if not await is_message_on_active_branch(
+            conversation.id,
+            snapshot.source_message_id,
+            before_created_at=before_created_at,
+        ):
             cloned_messages, cloned_protected_indexes = _clone_messages(
                 messages, protected_indexes
             )
@@ -1213,18 +1227,11 @@ async def _build_messages_with_file_content(
             )
         return messages, protected_indexes
 
-    history_query = ConversationMessage.filter(
-        conversation_id=conversation.id,
-        is_active=True,
+    history = await get_visible_conversation_messages(
+        conversation.id,
+        before_created_at=history_before_message_created_at,
+        exclude_message_ids=exclude_message_ids,
     )
-    if history_before_message_created_at is not None:
-        history_query = history_query.filter(
-            created_at__lt=history_before_message_created_at
-        )
-    if exclude_message_ids:
-        history_query = history_query.exclude(id__in=list(exclude_message_ids))
-
-    history = await history_query.order_by("created_at")
     historical_file_content_tasks = {
         msg.id: asyncio.create_task(
             _build_file_content_for_user_message(
@@ -1558,6 +1565,7 @@ async def _apply_micro_compaction(
     policy_used: str = DEFAULT_COMPACTION_POLICY,
     trigger_budget: int | None = None,
     protected_indexes: set[int] | None = None,
+    before_created_at=None,
 ) -> tuple[list[Message], CompressionMeta, set[int]]:
     protected_indexes = protected_indexes or set()
     before_tokens = _estimate_message_tokens(
@@ -1623,6 +1631,7 @@ async def _apply_micro_compaction(
         recent_raw_turns=recent_raw_turns,
         recent_tool_turns=recent_tool_turns,
         protected_indexes=tool_protected_indexes,
+        before_created_at=before_created_at,
     )
     after_tokens = _estimate_message_tokens(
         session_memory_messages,
@@ -2066,6 +2075,7 @@ async def prepare_model_context(
             policy_used=policy_used,
             trigger_budget=thresholds.trigger_input_budget,
             protected_indexes=base_protected_indexes,
+            before_created_at=history_before_message_created_at,
         )
         compression.file_content_trimmed = file_content_trimmed
         if file_content_trimmed and "trim_file_content" not in (

--- a/backend/app/services/message_branching.py
+++ b/backend/app/services/message_branching.py
@@ -61,12 +61,24 @@ async def get_last_active_canonical_message(conversation_id: UUID) -> Message | 
 
 async def get_prefix_path_before(message: Message) -> list[Message]:
     if message.branch_parent_id:
-        path = await get_active_canonical_path(message.conversation_id)
+        all_messages = await Message.filter(conversation_id=message.conversation_id).all()
+        message_by_id = {item.id: item for item in all_messages}
         prefix: list[Message] = []
-        for item in path:
-            prefix.append(item)
-            if item.id == message.branch_parent_id:
-                return prefix
+        current_id = message.branch_parent_id
+        seen: set[UUID] = set()
+
+        while current_id and current_id not in seen:
+            current = message_by_id.get(current_id)
+            if not current:
+                break
+            seen.add(current_id)
+            if _is_canonical_visible(current):
+                prefix.append(current)
+            current_id = current.branch_parent_id
+
+        if prefix:
+            prefix.reverse()
+            return prefix
 
     path = await get_active_canonical_path(message.conversation_id)
     return [item for item in path if item.created_at < message.created_at]

--- a/backend/app/services/message_branching.py
+++ b/backend/app/services/message_branching.py
@@ -61,7 +61,9 @@ async def get_last_active_canonical_message(conversation_id: UUID) -> Message | 
 
 async def get_prefix_path_before(message: Message) -> list[Message]:
     if message.branch_parent_id:
-        all_messages = await Message.filter(conversation_id=message.conversation_id).all()
+        all_messages = await Message.filter(
+            conversation_id=message.conversation_id
+        ).all()
         message_by_id = {item.id: item for item in all_messages}
         prefix: list[Message] = []
         current_id = message.branch_parent_id
@@ -115,9 +117,7 @@ async def activate_conversation_branch(
 ) -> None:
     canonical_ids = [message.id for message in canonical_path]
     round_ids = [
-        message.round_id
-        for message in canonical_path
-        if message.round_id is not None
+        message.round_id for message in canonical_path if message.round_id is not None
     ]
 
     active_ids = set(canonical_ids)

--- a/backend/app/services/message_branching.py
+++ b/backend/app/services/message_branching.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from uuid import UUID
+
+from tortoise.expressions import Q
+
+from app.models.agent import (
+    ConversationSessionMemory,
+    ConversationSessionMemoryStatus,
+    Message,
+)
+
+
+def get_version_root_id(message: Message) -> UUID:
+    return message.parent_id or message.id
+
+
+async def get_message_version_group(message: Message) -> list[Message]:
+    root_id = get_version_root_id(message)
+    versions = await Message.filter(Q(id=root_id) | Q(parent_id=root_id)).all()
+    versions.sort(key=lambda item: item.version_number)
+    return versions
+
+
+async def get_version_count(message: Message) -> int:
+    root_id = get_version_root_id(message)
+    return await Message.filter(Q(id=root_id) | Q(parent_id=root_id)).count()
+
+
+def _is_canonical_visible(message: Message) -> bool:
+    return message.round_id is None or message.is_round_canonical
+
+
+async def get_active_canonical_path(conversation_id: UUID) -> list[Message]:
+    messages = await Message.filter(
+        conversation_id=conversation_id,
+        is_active=True,
+    ).order_by("created_at", "id")
+    return [message for message in messages if _is_canonical_visible(message)]
+
+
+async def get_visible_conversation_messages(
+    conversation_id: UUID,
+    *,
+    before_created_at=None,
+    exclude_message_ids: Iterable[UUID] | None = None,
+) -> list[Message]:
+    query = Message.filter(conversation_id=conversation_id, is_active=True)
+    if before_created_at is not None:
+        query = query.filter(created_at__lt=before_created_at)
+    if exclude_message_ids:
+        query = query.exclude(id__in=list(exclude_message_ids))
+    return await query.order_by("created_at", "id")
+
+
+async def get_last_active_canonical_message(conversation_id: UUID) -> Message | None:
+    path = await get_active_canonical_path(conversation_id)
+    return path[-1] if path else None
+
+
+async def get_prefix_path_before(message: Message) -> list[Message]:
+    if message.branch_parent_id:
+        path = await get_active_canonical_path(message.conversation_id)
+        prefix: list[Message] = []
+        for item in path:
+            prefix.append(item)
+            if item.id == message.branch_parent_id:
+                return prefix
+
+    path = await get_active_canonical_path(message.conversation_id)
+    return [item for item in path if item.created_at < message.created_at]
+
+
+async def _select_descendant_child(parent: Message) -> Message | None:
+    children = await Message.filter(
+        conversation_id=parent.conversation_id,
+        branch_parent_id=parent.id,
+    ).order_by("-is_active", "-created_at", "-id")
+    for child in children:
+        if _is_canonical_visible(child):
+            return child
+    return None
+
+
+async def find_descendant_branch_from(message: Message) -> list[Message]:
+    branch = [message]
+    current = message
+    seen = {message.id}
+    while True:
+        child = await _select_descendant_child(current)
+        if not child or child.id in seen:
+            break
+        branch.append(child)
+        seen.add(child.id)
+        current = child
+    return branch
+
+
+async def activate_conversation_branch(
+    conversation_id: UUID,
+    canonical_path: Iterable[Message],
+) -> None:
+    canonical_ids = [message.id for message in canonical_path]
+    round_ids = [
+        message.round_id
+        for message in canonical_path
+        if message.round_id is not None
+    ]
+
+    active_ids = set(canonical_ids)
+    if round_ids:
+        round_steps = await Message.filter(
+            conversation_id=conversation_id,
+            round_id__in=round_ids,
+            is_round_canonical=False,
+        ).all()
+        active_ids.update(message.id for message in round_steps)
+
+    await Message.filter(conversation_id=conversation_id).update(is_active=False)
+    if active_ids:
+        await Message.filter(id__in=list(active_ids)).update(is_active=True)
+
+
+async def is_message_on_active_branch(
+    conversation_id: UUID,
+    message_id: UUID,
+    *,
+    before_created_at=None,
+) -> bool:
+    query = Message.filter(
+        conversation_id=conversation_id,
+        id=message_id,
+        is_active=True,
+    )
+    if before_created_at is not None:
+        query = query.filter(created_at__lt=before_created_at)
+    return await query.exists()
+
+
+async def stale_session_memory_if_source_outside_active_branch(
+    conversation_id: UUID,
+) -> None:
+    snapshot = await ConversationSessionMemory.filter(
+        conversation_id=conversation_id,
+        status=ConversationSessionMemoryStatus.READY,
+    ).first()
+    if not snapshot or not snapshot.source_message_id:
+        return
+    if await is_message_on_active_branch(conversation_id, snapshot.source_message_id):
+        return
+    snapshot.status = ConversationSessionMemoryStatus.STALE
+    await snapshot.save(update_fields=["status", "updated_at"])

--- a/backend/app/services/session_memory.py
+++ b/backend/app/services/session_memory.py
@@ -22,6 +22,10 @@ from app.models.agent import (
     MessageRole,
 )
 from app.models.model import TeamModel
+from app.services.message_branching import (
+    get_visible_conversation_messages,
+    is_message_on_active_branch,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -100,9 +104,12 @@ async def extract_session_memory_for_message(
     source_message = await Message.filter(
         id=source_uuid,
         conversation_id=conversation_uuid,
-        is_active=True,
     ).first()
-    if not source_message or source_message.role != MessageRole.ASSISTANT:
+    if (
+        not source_message
+        or source_message.role != MessageRole.ASSISTANT
+        or not await is_message_on_active_branch(conversation_uuid, source_uuid)
+    ):
         logger.warning(
             "Skip session memory extraction: source message %s invalid for "
             "conversation %s",
@@ -111,11 +118,15 @@ async def extract_session_memory_for_message(
         )
         return {"status": "skipped", "reason": "invalid_source_message"}
 
-    history = await Message.filter(
-        conversation_id=conversation_uuid,
-        is_active=True,
-        created_at__lte=source_message.created_at,
-    ).order_by("created_at")
+    history = await get_visible_conversation_messages(
+        conversation_uuid,
+        before_created_at=None,
+    )
+    history = [
+        message
+        for message in history
+        if message.created_at <= source_message.created_at
+    ]
 
     turn_blocks = _split_turn_blocks(history)
     min_turns = int(compression_config.get("session_memory_min_turns", 4) or 4)

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -2,6 +2,14 @@
 
 ## Active
 
+- **agent-message-version-branch-aware-context** — Complete. Make Agent message version switching branch-aware and prevent stale session memory from leaking previous-version context. See `docs/plan/agent-message-version-branch-aware-context.md`
+  - [x] 1. Design docs and implementation index
+  - [x] 2. Message branch schema and migration
+  - [x] 3. Branch helper service and active path activation
+  - [x] 4. Chat regenerate/switch-version branch behavior
+  - [x] 5. Branch-aware history and session memory guards
+  - [x] 6. Validation and regression checks
+
 - **auth-layout-switcher** — Complete. Add a configurable centered/split authentication page layout, managed from admin site settings. See `docs/plan/auth-layout-switcher.md`
   - [x] 1. Design docs and implementation index
   - [x] 2. Public site setting and admin general settings UI

--- a/docs/plan/agent-message-version-branch-aware-context.md
+++ b/docs/plan/agent-message-version-branch-aware-context.md
@@ -1,0 +1,100 @@
+# Agent Message Version Branch-Aware Context Design Document
+
+## Background & Goals
+
+- Problem to solve: Agent message versions are currently managed as a flat list with `parent_id`, `is_active`, and `version_number`. Switching a historical version uses linear `created_at` deactivation, so descendant replies that belong to the selected version are not restored. Regenerated replies can also see stale previous-version content through conversation-scoped session memory summaries.
+- Success criteria:
+  - Version switching activates the selected version and its descendant branch when present.
+  - Regeneration uses only the branch prefix before the regenerated assistant message.
+  - Session memory summaries are not injected when their source is outside the current branch or after the context cutoff.
+  - Existing frontend version controls keep working after conversation reload.
+
+## High-Level Design
+
+- Add explicit branch lineage to `Message` with `branch_parent_id`.
+- Keep `parent_id` as the version-group root pointer.
+- Keep `is_active` as the materialized current visible branch path for compatibility with existing API response logic.
+- Centralize branch operations in a backend service so conversation retrieval, prompt context building, version switching, and session memory use the same active-branch semantics.
+
+## Implementation Plan
+
+### Stage 1: Planning docs
+
+- **Files modified**: `docs/IMPLEMENTATION_PLAN.md`, `docs/plan/agent-message-version-branch-aware-context.md`
+- **Specific logic**: Track implementation stages and verification expectations.
+- **Validation**: Confirm the plan index links to this file and stage 1 is checked.
+
+### Stage 2: Message branch schema and migration
+
+- **Files modified**: `backend/app/models/agent.py`, `backend/app/core/init_data.py`, `backend/app/main.py`
+- **Specific logic**:
+  - Add nullable `Message.branch_parent_id`.
+  - Add an idempotent startup migration to add the column and indexes.
+  - Backfill current active canonical messages into a linear branch per conversation.
+  - Backfill inactive version children so alternatives inherit the root message predecessor.
+- **Validation**: Startup migration is idempotent and does not fail when `messages` does not exist.
+
+### Stage 3: Branch helper service
+
+- **Files modified**: `backend/app/services/message_branching.py`
+- **Specific logic**:
+  - Resolve version roots and groups.
+  - Return active visible messages in branch order.
+  - Build prefix path before a message.
+  - Follow descendant branch from a selected version.
+  - Activate exactly one branch path and its round support messages.
+  - Check whether a message belongs to the active branch.
+- **Validation**: Unit-level helper tests or focused script-created objects confirm path activation and descendant selection.
+
+### Stage 4: Chat creation, regenerate, and switch-version
+
+- **Files modified**: `backend/app/api/v1/endpoints/chat.py`
+- **Specific logic**:
+  - Set `branch_parent_id` for user, assistant, and round support messages.
+  - Regenerated assistant versions inherit the old version's `branch_parent_id`.
+  - `switch_message_version` activates prefix + target descendant path instead of timestamp-deactivating later messages.
+  - Stale session memory after branch changes when needed.
+- **Validation**: Switching between two assistant versions restores each version's own continuation path.
+
+### Stage 5: Branch-aware history and memory
+
+- **Files modified**: `backend/app/api/v1/endpoints/agents.py`, `backend/app/api/v1/admin/endpoints/conversations.py`, `backend/app/services/chat_context.py`, `backend/app/services/session_memory.py`
+- **Specific logic**:
+  - Use the shared active-branch helper for conversation responses and model context history.
+  - Apply cutoffs only inside the active branch.
+  - Skip session memory injection if the snapshot source is not on the active branch or falls after the prompt cutoff.
+  - Extract session memory from branch-aware history only.
+- **Validation**: A stale summary containing a sentinel from an inactive branch does not appear in prepared model messages.
+
+### Stage 6: Validation and regression checks
+
+- **Files modified**: tests as needed under `backend/tests/`.
+- **Specific logic**:
+  - Add focused tests for branch switching, regeneration context exclusion, session memory guard, version counts, and round tool-step activation.
+- **Validation**:
+  - `uv run ruff check .`
+  - `uv run mypy app/`
+  - `uv run pytest` or targeted tests if the full suite is too large.
+  - Frontend `bun run lint` / `bun run build` only if frontend files change.
+
+## Testing Strategy
+
+- Happy path tests:
+  - Create A1 v1 with continuation, regenerate A1 v2 with a different continuation, then switch both ways and verify visible messages.
+  - Regenerate an assistant message and verify the new prompt contains the preceding user message but not the old assistant content.
+- Error path tests:
+  - Reject switching to a version outside the current message's version group.
+  - Skip stale session memory when source message is inactive or outside branch.
+- Regression scope:
+  - Existing message version list API.
+  - Conversation detail payload and `version_count` computation.
+  - Tool-call rounds nested under canonical assistant messages.
+
+## Risks & Mitigation
+
+- Old hidden branches cannot be perfectly reconstructed from existing data. Backfill preserves current active paths and makes new branch operations correct going forward.
+- Round step messages can disappear if only canonical messages are activated. Activation must include non-canonical messages for active round IDs.
+- Session memory is conversation-scoped. Guard injection by branch membership and stale snapshots after branch switches.
+- Multiple endpoints query active messages. Use the shared helper to avoid divergent behavior.
+
+Rollback plan: remove branch-aware endpoint logic and fall back to existing `is_active` queries; keep the nullable `branch_parent_id` column unused if rollback is needed.

--- a/frontend/hooks/use-chat.ts
+++ b/frontend/hooks/use-chat.ts
@@ -1126,9 +1126,12 @@ export function useChat(options: UseChatOptions): UseChatReturn {
       setError(null)
       setStatus('loading')
 
-      // Update message to loading state
-      setMessages((prev) =>
-        prev.map((msg) => {
+      // Update message to loading state and remove descendants from the stale branch
+      setMessages((prev) => {
+        const targetIndex = prev.findIndex((msg) => msg.id === messageId)
+        if (targetIndex === -1) return prev
+
+        return prev.slice(0, targetIndex + 1).map((msg) => {
           if (msg.id !== messageId) return msg
 
           const nextMetadata = { ...msg.metadata }
@@ -1142,7 +1145,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
             metadata: { ...nextMetadata, isLoading: true, isManuallyStopped: false },
           }
         })
-      )
+      })
 
       streamingStateRef.current = {
         assistantMessageId: messageId,

--- a/frontend/lib/api/agents.ts
+++ b/frontend/lib/api/agents.ts
@@ -406,6 +406,7 @@ export interface Message {
   steps?: MessageRoundStep[] | null
   // Version fields
   parent_id?: string | null
+  branch_parent_id?: string | null
   is_active?: boolean
   version_number?: number
   version_count?: number


### PR DESCRIPTION
## Summary
- Add branch parent tracking for agent chat messages and startup backfill.
- Activate version switches/regenerations as branch paths, including descendant messages and tool-round steps.
- Guard conversation session memory and frontend regenerate state from stale branch context.

## Test plan
- [x] uv run python -m py_compile app/api/v1/endpoints/chat.py app/services/chat_context.py app/services/message_branching.py app/services/session_memory.py app/core/init_data.py app/main.py app/models/agent.py app/schemas/agent.py
- [x] uv run ruff check .
- [x] cd frontend && bun run lint
- [x] cd frontend && bun run build
- [ ] uv run mypy app/ (fails on existing app/llm/adapters/video/runway.py type error)
- [ ] PYTHONPATH=. uv run pytest (collection fails on existing workflow/sandbox import issues)

Closes #179