### PR TITLE
Fix: Show only model names in media generation selectors

### DIFF
--- a/frontend/app/(platform)/app/apps/[id]/_components/agent-orchestration-form.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/_components/agent-orchestration-form.tsx
@@ -147,7 +147,7 @@ const DEFAULT_VIDEO_GENERATION_CONFIG: VideoGenerationConfig = {
 const DEFAULT_MEDIA_MODEL_VALUE = '__default__'
 
 function getMediaModelOptionLabel(teamModel: TeamModel) {
-  return teamModel.model.name
+  return teamModel?.model?.name ?? ''
 }
 
 function getMediaModelSelectLabel(

--- a/frontend/app/(platform)/app/apps/[id]/_components/agent-orchestration-form.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/_components/agent-orchestration-form.tsx
@@ -147,7 +147,7 @@ const DEFAULT_VIDEO_GENERATION_CONFIG: VideoGenerationConfig = {
 const DEFAULT_MEDIA_MODEL_VALUE = '__default__'
 
 function getMediaModelOptionLabel(teamModel: TeamModel) {
-  return `${teamModel.model.name} · ${teamModel.model.provider}/${teamModel.model.model_id}`
+  return teamModel.model.name
 }
 
 function getMediaModelSelectLabel(

--- a/frontend/i18n/types/activities.ts
+++ b/frontend/i18n/types/activities.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.949Z
+// GENERATED — 2026-05-27T18:15:45.235Z
 // Source: i18n/en/activities.json
 export type ActivitiesMessages = {
   activities: {

--- a/frontend/i18n/types/agents.ts
+++ b/frontend/i18n/types/agents.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.953Z
+// GENERATED — 2026-05-27T18:15:45.237Z
 // Source: i18n/en/agents.json
 export type AgentsMessages = {
   agents: {

--- a/frontend/i18n/types/apiKeys.ts
+++ b/frontend/i18n/types/apiKeys.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.954Z
+// GENERATED — 2026-05-27T18:15:45.238Z
 // Source: i18n/en/apiKeys.json
 export type ApiKeysMessages = {
   apiKeys: {

--- a/frontend/i18n/types/apps.ts
+++ b/frontend/i18n/types/apps.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.954Z
+// GENERATED — 2026-05-27T18:15:45.238Z
 // Source: i18n/en/apps.json
 export type AppsMessages = {
   apps: {

--- a/frontend/i18n/types/auth.ts
+++ b/frontend/i18n/types/auth.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.955Z
+// GENERATED — 2026-05-27T18:15:45.239Z
 // Source: i18n/en/auth.json
 export type AuthMessages = {
   auth: {

--- a/frontend/i18n/types/chat.ts
+++ b/frontend/i18n/types/chat.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.955Z
+// GENERATED — 2026-05-27T18:15:45.240Z
 // Source: i18n/en/chat.json
 export type ChatMessages = {
   chat: {

--- a/frontend/i18n/types/common.ts
+++ b/frontend/i18n/types/common.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.956Z
+// GENERATED — 2026-05-27T18:15:45.240Z
 // Source: i18n/en/common.json
 export type CommonMessages = {
   common: {

--- a/frontend/i18n/types/conversations.ts
+++ b/frontend/i18n/types/conversations.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.956Z
+// GENERATED — 2026-05-27T18:15:45.241Z
 // Source: i18n/en/conversations.json
 export type ConversationsMessages = {
   conversations: {

--- a/frontend/i18n/types/dashboard.ts
+++ b/frontend/i18n/types/dashboard.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.957Z
+// GENERATED — 2026-05-27T18:15:45.242Z
 // Source: i18n/en/dashboard.json
 export type DashboardMessages = {
   dashboard: {

--- a/frontend/i18n/types/embed.ts
+++ b/frontend/i18n/types/embed.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.957Z
+// GENERATED — 2026-05-27T18:15:45.243Z
 // Source: i18n/en/embed.json
 export type EmbedMessages = {
   embed: {

--- a/frontend/i18n/types/errors.ts
+++ b/frontend/i18n/types/errors.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.957Z
+// GENERATED — 2026-05-27T18:15:45.243Z
 // Source: i18n/en/errors.json
 export type ErrorsMessages = {
   errors: {

--- a/frontend/i18n/types/knowledgeBases.ts
+++ b/frontend/i18n/types/knowledgeBases.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.958Z
+// GENERATED — 2026-05-27T18:15:45.244Z
 // Source: i18n/en/knowledgeBases.json
 export type KnowledgeBasesMessages = {
   knowledgeBases: {

--- a/frontend/i18n/types/memories.ts
+++ b/frontend/i18n/types/memories.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.958Z
+// GENERATED — 2026-05-27T18:15:45.244Z
 // Source: i18n/en/memories.json
 export type MemoriesMessages = {
   memories: {

--- a/frontend/i18n/types/models.ts
+++ b/frontend/i18n/types/models.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.959Z
+// GENERATED — 2026-05-27T18:15:45.245Z
 // Source: i18n/en/models.json
 export type ModelsMessages = {
   models: {

--- a/frontend/i18n/types/nav.ts
+++ b/frontend/i18n/types/nav.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.959Z
+// GENERATED — 2026-05-27T18:15:45.245Z
 // Source: i18n/en/nav.json
 export type NavMessages = {
   nav: {

--- a/frontend/i18n/types/notifications.ts
+++ b/frontend/i18n/types/notifications.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.959Z
+// GENERATED — 2026-05-27T18:15:45.246Z
 // Source: i18n/en/notifications.json
 export type NotificationsMessages = {
   notifications: {

--- a/frontend/i18n/types/permissions.ts
+++ b/frontend/i18n/types/permissions.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.959Z
+// GENERATED — 2026-05-27T18:15:45.246Z
 // Source: i18n/en/permissions.json
 export type PermissionsMessages = {
   permissions: {

--- a/frontend/i18n/types/platform.ts
+++ b/frontend/i18n/types/platform.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.960Z
+// GENERATED — 2026-05-27T18:15:45.247Z
 // Source: i18n/en/platform.json
 export type PlatformMessages = {
   platform: {

--- a/frontend/i18n/types/promptGenerator.ts
+++ b/frontend/i18n/types/promptGenerator.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.960Z
+// GENERATED — 2026-05-27T18:15:45.247Z
 // Source: i18n/en/promptGenerator.json
 export type PromptGeneratorMessages = {
   promptGenerator: {

--- a/frontend/i18n/types/publicChat.ts
+++ b/frontend/i18n/types/publicChat.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.961Z
+// GENERATED — 2026-05-27T18:15:45.247Z
 // Source: i18n/en/publicChat.json
 export type PublicChatMessages = {
   publicChat: {

--- a/frontend/i18n/types/roles.ts
+++ b/frontend/i18n/types/roles.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.961Z
+// GENERATED — 2026-05-27T18:15:45.248Z
 // Source: i18n/en/roles.json
 export type RolesMessages = {
   roles: {

--- a/frontend/i18n/types/run.ts
+++ b/frontend/i18n/types/run.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.961Z
+// GENERATED — 2026-05-27T18:15:45.248Z
 // Source: i18n/en/run.json
 export type RunMessages = {
   run: {

--- a/frontend/i18n/types/settings.ts
+++ b/frontend/i18n/types/settings.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.961Z
+// GENERATED — 2026-05-27T18:15:45.248Z
 // Source: i18n/en/settings.json
 export type SettingsMessages = {
   settings: {

--- a/frontend/i18n/types/siteSettings.ts
+++ b/frontend/i18n/types/siteSettings.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.962Z
+// GENERATED — 2026-05-27T18:15:45.249Z
 // Source: i18n/en/siteSettings.json
 export type SiteSettingsMessages = {
   siteSettings: {

--- a/frontend/i18n/types/sso.ts
+++ b/frontend/i18n/types/sso.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.962Z
+// GENERATED — 2026-05-27T18:15:45.250Z
 // Source: i18n/en/sso.json
 export type SsoMessages = {
   sso: {

--- a/frontend/i18n/types/teams.ts
+++ b/frontend/i18n/types/teams.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.962Z
+// GENERATED — 2026-05-27T18:15:45.250Z
 // Source: i18n/en/teams.json
 export type TeamsMessages = {
   teams: {

--- a/frontend/i18n/types/tools.ts
+++ b/frontend/i18n/types/tools.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.963Z
+// GENERATED — 2026-05-27T18:15:45.251Z
 // Source: i18n/en/tools.json
 export type ToolsMessages = {
   tools: {

--- a/frontend/i18n/types/users.ts
+++ b/frontend/i18n/types/users.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.963Z
+// GENERATED — 2026-05-27T18:15:45.251Z
 // Source: i18n/en/users.json
 export type UsersMessages = {
   users: {

--- a/frontend/i18n/types/workflow.ts
+++ b/frontend/i18n/types/workflow.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-19T18:46:49.964Z
+// GENERATED — 2026-05-27T18:15:45.253Z
 // Source: i18n/en/workflow.json
 export type WorkflowMessages = {
   workflow: {


### PR DESCRIPTION
Closes clouisle/Clouisle#176

## Summary

* Changed image and video generation model selectors to display only model display names
* Removed provider/model_id from the dropdown labels in agent orchestration UI

## Changes

* Modified `getMediaModelOptionLabel()` in `agent-orchestration-form.tsx` to return only `teamModel.model.name`

## Linear

clouisle/Clouisle#176