### PR TITLE
fix: optimize streaming timeout strategy for AI conversations (YUN-72)

### DIFF
--- a/.codegraph/daemon.pid
+++ b/.codegraph/daemon.pid
@@ -1,6 +1,0 @@
-{
-  "pid": 23488,
-  "version": "0.9.5",
-  "socketPath": "/Users/yunhai/Documents/CodeData/Project/Clouisle/.codegraph/daemon.sock",
-  "startedAt": 1779808670494
-}

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -2450,6 +2450,7 @@ async def chat_stream(
                         "Stream idle timeout (%ss) for conversation %s",
                         idle_timeout,
                         conversation.id,
+                        extra={"timeout_type": "idle", "timeout_seconds": idle_timeout},
                     )
                     await persist_partial_round_error(
                         assistant_msg,
@@ -2475,7 +2476,10 @@ async def chat_stream(
         except TimeoutError:
             # Global timeout
             logger.warning(
-                f"Stream global timeout ({global_timeout}s) for conversation {conversation.id}"
+                "Stream global timeout (%ss) for conversation %s",
+                global_timeout,
+                conversation.id,
+                extra={"timeout_type": "global", "timeout_seconds": global_timeout},
             )
             await persist_partial_round_error(
                 assistant_msg,
@@ -3572,6 +3576,7 @@ async def regenerate_message(
                         "Regenerate stream idle timeout (%ss) for message %s",
                         idle_timeout,
                         message_id,
+                        extra={"timeout_type": "idle", "timeout_seconds": idle_timeout},
                     )
                     yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t('stream_timeout_exceeded'), 'timeout': idle_timeout})}\n\n"
                 except Exception:
@@ -3595,7 +3600,10 @@ async def regenerate_message(
         except TimeoutError:
             # Global timeout
             logger.warning(
-                f"Regenerate stream global timeout ({global_timeout}s) for message {message_id}"
+                "Regenerate stream global timeout (%ss) for message %s",
+                global_timeout,
+                message_id,
+                extra={"timeout_type": "global", "timeout_seconds": global_timeout},
             )
             preserved_partial = await persist_partial_round_error(
                 new_message,

--- a/backend/app/api/v1/endpoints/chat_helpers/config.py
+++ b/backend/app/api/v1/endpoints/chat_helpers/config.py
@@ -2,8 +2,17 @@
 Configuration utilities for chat.
 """
 
-from app.models.agent import Agent
 from app.core.config import settings
+from app.models.agent import Agent
+
+
+def _has_tool_runtime(agent: Agent) -> bool:
+    return bool(
+        agent.tools_config
+        or agent.enable_memory
+        or agent.enable_image_generation
+        or agent.enable_video_generation
+    )
 
 
 def get_language_instruction(user_locale: str | None = None) -> str:
@@ -41,8 +50,14 @@ def get_streaming_config(agent: Agent) -> dict:
     """Get streaming configuration from agent or use defaults."""
     config = agent.streaming_config or {}
 
+    global_timeout_default = (
+        settings.STREAM_GLOBAL_TIMEOUT_WITH_TOOLS
+        if _has_tool_runtime(agent)
+        else settings.STREAM_GLOBAL_TIMEOUT
+    )
+
     return {
-        "global_timeout": config.get("global_timeout", settings.STREAM_GLOBAL_TIMEOUT),
+        "global_timeout": config.get("global_timeout", global_timeout_default),
         "heartbeat_interval": config.get(
             "heartbeat_interval", settings.STREAM_HEARTBEAT_INTERVAL
         ),

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -71,9 +71,16 @@ class Settings(BaseSettings):
         return f"postgres://{data.get('POSTGRES_USER')}:{data.get('POSTGRES_PASSWORD')}@{data.get('POSTGRES_SERVER')}:{data.get('POSTGRES_PORT')}/{data.get('POSTGRES_DB')}"
 
     # Streaming timeouts (seconds)
-    STREAM_GLOBAL_TIMEOUT: int = 1800  # 30 minutes
+    STREAM_GLOBAL_TIMEOUT: int = 3600  # 60 minutes
     STREAM_HEARTBEAT_INTERVAL: int = 15  # 15 seconds
-    STREAM_IDLE_TIMEOUT: int = 90  # max seconds between model stream chunks
+    STREAM_IDLE_TIMEOUT: int = 180  # max seconds between model stream chunks
+
+    # LLM HTTP client timeouts (seconds)
+    STREAM_HTTP_CONNECT_TIMEOUT: int = 10
+    STREAM_HTTP_READ_TIMEOUT: int = 200
+    STREAM_HTTP_REASONING_READ_TIMEOUT: int = 300
+    STREAM_HTTP_WRITE_TIMEOUT: int = 10
+    STREAM_GLOBAL_TIMEOUT_WITH_TOOLS: int = 5400  # 90 minutes
 
     # Tool execution timeouts (seconds)
     STREAM_TOOL_TIMEOUT_HTTP: int = 30

--- a/backend/app/llm/adapters/chat/anthropic_adapter.py
+++ b/backend/app/llm/adapters/chat/anthropic_adapter.py
@@ -299,7 +299,7 @@ class AnthropicAdapter(BaseChatAdapter):
         client = AsyncAnthropic(
             api_key=self.api_key,
             base_url=self.base_url,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:
@@ -456,7 +456,7 @@ class AnthropicAdapter(BaseChatAdapter):
         client = AsyncAnthropic(
             api_key=self.api_key,
             base_url=self.base_url,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:

--- a/backend/app/llm/adapters/chat/base.py
+++ b/backend/app/llm/adapters/chat/base.py
@@ -127,7 +127,9 @@ class BaseChatAdapter(ABC):
     def timeout(self) -> int:
         """超时时间"""
         timeout = self.get_effective_param("timeout")
-        return int(timeout) if timeout is not None else settings.STREAM_HTTP_READ_TIMEOUT
+        return (
+            int(timeout) if timeout is not None else settings.STREAM_HTTP_READ_TIMEOUT
+        )
 
     @property
     def model_uses_reasoning_timeout(self) -> bool:

--- a/backend/app/llm/adapters/chat/base.py
+++ b/backend/app/llm/adapters/chat/base.py
@@ -10,6 +10,9 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from typing import Any
 
+import httpx
+
+from app.core.config import settings
 from app.llm.types import (
     Message,
     ChatResponse,
@@ -124,7 +127,43 @@ class BaseChatAdapter(ABC):
     def timeout(self) -> int:
         """超时时间"""
         timeout = self.get_effective_param("timeout")
-        return int(timeout) if timeout is not None else 60
+        return int(timeout) if timeout is not None else settings.STREAM_HTTP_READ_TIMEOUT
+
+    @property
+    def model_uses_reasoning_timeout(self) -> bool:
+        model_id = self.model_id.lower()
+        return bool(
+            self.thinking_enabled
+            or self.reasoning_effort
+            or model_id.startswith(("o1", "o3", "o4"))
+            or "reasoning" in model_id
+        )
+
+    @property
+    def http_read_timeout(self) -> float:
+        read_timeout = self.get_effective_param("read_timeout")
+        legacy_timeout = self.get_effective_param("timeout")
+        if read_timeout is not None or legacy_timeout is not None:
+            return float(read_timeout or legacy_timeout)
+        if self.model_uses_reasoning_timeout:
+            return float(settings.STREAM_HTTP_REASONING_READ_TIMEOUT)
+        return float(settings.STREAM_HTTP_READ_TIMEOUT)
+
+    @property
+    def http_timeout(self) -> httpx.Timeout:
+        """HTTP 客户端超时配置"""
+        connect_timeout = self.get_effective_param("connect_timeout")
+        write_timeout = self.get_effective_param("write_timeout")
+        return httpx.Timeout(
+            connect=float(connect_timeout)
+            if connect_timeout is not None
+            else settings.STREAM_HTTP_CONNECT_TIMEOUT,
+            read=self.http_read_timeout,
+            write=float(write_timeout)
+            if write_timeout is not None
+            else settings.STREAM_HTTP_WRITE_TIMEOUT,
+            pool=None,
+        )
 
     def get_effective_thinking(self, **kwargs: Any) -> bool | dict[str, Any] | None:
         """获取 thinking 配置，优先 default_params，再回退 config"""

--- a/backend/app/llm/adapters/chat/base.py
+++ b/backend/app/llm/adapters/chat/base.py
@@ -143,8 +143,10 @@ class BaseChatAdapter(ABC):
     def http_read_timeout(self) -> float:
         read_timeout = self.get_effective_param("read_timeout")
         legacy_timeout = self.get_effective_param("timeout")
-        if read_timeout is not None or legacy_timeout is not None:
-            return float(read_timeout or legacy_timeout)
+        if read_timeout is not None:
+            return float(read_timeout)
+        if legacy_timeout is not None:
+            return float(legacy_timeout)
         if self.model_uses_reasoning_timeout:
             return float(settings.STREAM_HTTP_REASONING_READ_TIMEOUT)
         return float(settings.STREAM_HTTP_READ_TIMEOUT)

--- a/backend/app/llm/adapters/chat/deepseek_adapter.py
+++ b/backend/app/llm/adapters/chat/deepseek_adapter.py
@@ -161,7 +161,7 @@ class DeepSeekAdapter(BaseChatAdapter):
         client = AsyncOpenAI(
             api_key=self.api_key,
             base_url=self.base_url or self.DEFAULT_BASE_URL,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:
@@ -258,7 +258,7 @@ class DeepSeekAdapter(BaseChatAdapter):
         client = AsyncOpenAI(
             api_key=self.api_key,
             base_url=self.base_url or self.DEFAULT_BASE_URL,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:

--- a/backend/app/llm/adapters/chat/moonshot_adapter.py
+++ b/backend/app/llm/adapters/chat/moonshot_adapter.py
@@ -130,7 +130,7 @@ class MoonshotAdapter(BaseChatAdapter):
         client = AsyncOpenAI(
             api_key=self.api_key,
             base_url=self.base_url or self.DEFAULT_BASE_URL,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:
@@ -230,7 +230,7 @@ class MoonshotAdapter(BaseChatAdapter):
         client = AsyncOpenAI(
             api_key=self.api_key,
             base_url=self.base_url or self.DEFAULT_BASE_URL,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:

--- a/backend/app/llm/adapters/chat/ollama_adapter.py
+++ b/backend/app/llm/adapters/chat/ollama_adapter.py
@@ -130,7 +130,7 @@ class OllamaAdapter(BaseChatAdapter):
         client = AsyncOpenAI(
             api_key=self.api_key or "ollama",
             base_url=self.base_url or self.DEFAULT_BASE_URL,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:
@@ -224,7 +224,7 @@ class OllamaAdapter(BaseChatAdapter):
         client = AsyncOpenAI(
             api_key=self.api_key or "ollama",
             base_url=self.base_url or self.DEFAULT_BASE_URL,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:

--- a/backend/app/llm/adapters/chat/openai_adapter.py
+++ b/backend/app/llm/adapters/chat/openai_adapter.py
@@ -122,7 +122,7 @@ class OpenAIAdapter(BaseChatAdapter):
         client = AsyncOpenAI(
             api_key=self.api_key,
             base_url=self.base_url,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:
@@ -220,7 +220,7 @@ class OpenAIAdapter(BaseChatAdapter):
         client = AsyncOpenAI(
             api_key=self.api_key,
             base_url=self.base_url,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:

--- a/backend/app/llm/adapters/chat/openai_compatible_adapter.py
+++ b/backend/app/llm/adapters/chat/openai_compatible_adapter.py
@@ -190,7 +190,7 @@ class OpenAICompatibleAdapter(BaseChatAdapter):
         client = AsyncOpenAI(
             api_key=api_key,
             base_url=base_url,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:
@@ -305,7 +305,7 @@ class OpenAICompatibleAdapter(BaseChatAdapter):
         client = AsyncOpenAI(
             api_key=api_key,
             base_url=base_url,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:

--- a/backend/app/llm/adapters/chat/xai_adapter.py
+++ b/backend/app/llm/adapters/chat/xai_adapter.py
@@ -140,7 +140,7 @@ class XAIAdapter(BaseChatAdapter):
         client = AsyncOpenAI(
             api_key=self.api_key,
             base_url=self.base_url or self.DEFAULT_BASE_URL,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:
@@ -235,7 +235,7 @@ class XAIAdapter(BaseChatAdapter):
         client = AsyncOpenAI(
             api_key=self.api_key,
             base_url=self.base_url or self.DEFAULT_BASE_URL,
-            timeout=self.timeout,
+            timeout=self.http_timeout,
         )
 
         try:

--- a/docs/analysis/timeout-analysis.md
+++ b/docs/analysis/timeout-analysis.md
@@ -1,0 +1,511 @@
+# AI 流式生成对话超时时间分析报告
+
+## 问题概述
+
+本文档详细分析 Clouisle 项目中 AI 流式对话的超时实现策略，评估当前方案是否为最优解，并记录已落地的分阶段修复。
+
+## 当前超时实现架构
+
+### 1. 超时配置层级
+
+当前系统实现了**三层超时机制**：
+
+#### 1.1 全局配置层 (`backend/app/core/config.py`)
+
+```python
+# Streaming timeouts (seconds)
+STREAM_GLOBAL_TIMEOUT: int = 3600  # 60 minutes - 整个对话的最大时长
+STREAM_HEARTBEAT_INTERVAL: int = 15  # 15 seconds - 心跳间隔
+STREAM_IDLE_TIMEOUT: int = 180  # max seconds between model stream chunks - 模型流空闲超时
+
+# LLM HTTP client timeouts (seconds)
+STREAM_HTTP_CONNECT_TIMEOUT: int = 10
+STREAM_HTTP_READ_TIMEOUT: int = 200
+STREAM_HTTP_REASONING_READ_TIMEOUT: int = 300
+STREAM_HTTP_WRITE_TIMEOUT: int = 10
+STREAM_GLOBAL_TIMEOUT_WITH_TOOLS: int = 5400  # 90 minutes
+
+# Tool execution timeouts (seconds)
+STREAM_TOOL_TIMEOUT_HTTP: int = 30   # HTTP 工具超时
+STREAM_TOOL_TIMEOUT_CODE: int = 60   # 代码执行超时
+STREAM_TOOL_TIMEOUT_MCP: int = 60    # MCP 工具超时
+STREAM_TOOL_TIMEOUT_DOWNLOAD: int = 60  # 下载超时
+```
+
+#### 1.2 Agent 配置层 (`get_streaming_config`)
+
+Agent 可以通过 `streaming_config` 字段覆盖全局配置：
+
+```python
+def get_streaming_config(agent: Agent) -> dict:
+    """Get streaming configuration from agent or use defaults."""
+    config = agent.streaming_config or {}
+    
+    return {
+        "global_timeout": config.get("global_timeout", settings.STREAM_GLOBAL_TIMEOUT),
+        "heartbeat_interval": config.get("heartbeat_interval", settings.STREAM_HEARTBEAT_INTERVAL),
+        "idle_timeout": config.get("idle_timeout", settings.STREAM_IDLE_TIMEOUT),
+        "tool_timeouts": {...}
+    }
+```
+
+#### 1.3 模型适配器层 (`BaseChatAdapter.http_timeout`)
+
+每个模型适配器可以配置自己的 HTTP 客户端超时：
+
+```python
+@property
+def http_timeout(self) -> httpx.Timeout:
+    """HTTP 客户端超时配置"""
+    connect_timeout = self.get_effective_param("connect_timeout")
+    read_timeout = self.get_effective_param("read_timeout")
+    write_timeout = self.get_effective_param("write_timeout")
+    legacy_timeout = self.get_effective_param("timeout")
+    return httpx.Timeout(
+        connect=float(connect_timeout) if connect_timeout is not None else settings.STREAM_HTTP_CONNECT_TIMEOUT,
+        read=float(read_timeout or legacy_timeout) if read_timeout is not None or legacy_timeout is not None else settings.STREAM_HTTP_READ_TIMEOUT,
+        write=float(write_timeout) if write_timeout is not None else settings.STREAM_HTTP_WRITE_TIMEOUT,
+        pool=None,
+    )
+```
+
+### 2. 超时实现机制
+
+#### 2.1 全局超时 (Global Timeout)
+
+**位置**: `backend/app/api/v1/endpoints/chat.py:1563`
+
+```python
+async with asyncio.timeout(global_timeout):  # 默认 1800 秒
+    # 整个流式对话逻辑
+```
+
+**作用**: 
+- 限制整个对话的最大时长（包括多轮工具调用）
+- 超时后触发 `TimeoutError`，保存部分内容并返回错误
+
+**问题**:
+- ✅ 能防止无限挂起
+- ⚠️ 30 分钟对于复杂任务可能不够（多轮工具调用、大量代码执行）
+- ⚠️ 超时后用户体验较差，只能看到错误消息
+
+#### 2.2 空闲超时 (Idle Timeout)
+
+**位置**: `backend/app/api/v1/endpoints/chat_helpers/stream_utils.py:39`
+
+```python
+async def iter_with_idle_timeout(
+    iterable: AsyncIterable[T],
+    timeout_seconds: float,  # 默认 90 秒
+    activity_predicate: Callable[[T], bool] | None = None,
+) -> AsyncIterator[T]:
+    iterator = iterable.__aiter__()
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise StreamIdleTimeoutError
+        try:
+            item = await asyncio.wait_for(iterator.__anext__(), timeout=remaining)
+        except StopAsyncIteration:
+            return
+        except TimeoutError as e:
+            raise StreamIdleTimeoutError from e
+        # 如果有活动（activity_predicate 返回 True），重置 deadline
+        if activity_predicate is None or activity_predicate(item):
+            deadline = time.monotonic() + timeout_seconds
+        yield item
+```
+
+**作用**:
+- 监控模型流的活跃度
+- 如果连续 90 秒没有有效输出（token、reasoning、tool_calls），触发超时
+- 每次有活动时重置计时器
+
+**活动判断逻辑** (`_is_model_stream_activity`):
+```python
+def _is_model_stream_activity(chunk: ChatStreamChunk) -> bool:
+    delta = chunk.delta
+    return bool(
+        delta.content
+        or delta.reasoning_content
+        or delta.tool_calls
+        or delta.stream_activity
+        or chunk.finish_reason
+    )
+```
+
+**问题**:
+- ✅ 能检测模型卡死或网络中断
+- ⚠️ **90 秒可能过短**：某些模型在思考复杂问题时可能长时间不输出
+- ⚠️ 与全局超时存在重叠，可能导致混淆
+
+#### 2.3 HTTP 客户端超时 (Model API Timeout)
+
+**位置**: `backend/app/llm/adapters/chat/openai_adapter.py`
+
+```python
+client = AsyncOpenAI(
+    api_key=self.api_key,
+    base_url=self.base_url,
+    timeout=self.timeout,  # 默认 60 秒
+)
+```
+
+**作用**:
+- 限制单次 HTTP 请求的超时时间
+- 由 OpenAI SDK 内部的 httpx 客户端处理
+
+**问题**:
+- ⚠️ **60 秒对于流式调用可能不合适**：流式调用是长连接，不应该有固定的总超时
+- ⚠️ 这个超时应该是**连接超时**或**读取超时**，而不是总超时
+- ⚠️ 与空闲超时功能重叠
+
+#### 2.4 心跳机制 (Heartbeat)
+
+**位置**: `backend/app/api/v1/endpoints/chat.py:1701-1728`
+
+```python
+(should_continue, new_last_event_time) = await send_heartbeat_if_needed(
+    last_event_time, heartbeat_interval, request
+)
+if not should_continue:
+    # 客户端断开，保存当前状态并退出
+    assistant_msg.is_manually_stopped = True
+    await assistant_msg.save()
+    return
+```
+
+**作用**:
+- 每 15 秒检查客户端是否断开
+- 如果断开，立即停止生成，保存部分内容
+
+**问题**:
+- ✅ 能及时检测客户端断开，节省资源
+- ✅ 实现合理
+
+## 问题分析
+
+### 问题 1: 超时层级混乱，职责不清
+
+当前有 **4 个不同的超时**：
+1. **全局超时** (1800s) - 整个对话
+2. **空闲超时** (90s) - 模型流活跃度
+3. **HTTP 客户端超时** (60s) - 单次 API 请求
+4. **工具超时** (30-60s) - 工具执行
+
+**问题**:
+- HTTP 客户端超时 (60s) < 空闲超时 (90s)，可能导致在空闲超时触发前就被 HTTP 超时中断
+- 空闲超时和 HTTP 客户端超时功能重叠
+- 用户和开发者难以理解哪个超时会先触发
+
+### 问题 2: 空闲超时 90 秒可能过短
+
+**场景**:
+- 某些模型（如 o1、o3）在处理复杂问题时，可能长时间处于"思考"状态而不输出 token
+- 如果模型 API 本身没有返回 `stream_activity` 心跳，90 秒后会被误判为超时
+
+**建议**:
+- 将空闲超时提高到 **180-300 秒**
+- 或者根据模型类型动态调整（推理模型更长，普通模型更短）
+
+### 问题 3: HTTP 客户端超时配置不当
+
+**当前问题**:
+```python
+client = AsyncOpenAI(
+    timeout=self.timeout,  # 60 秒
+)
+```
+
+OpenAI SDK 的 `timeout` 参数实际上是 `httpx.Timeout` 对象，支持细粒度配置：
+- `connect`: 连接超时
+- `read`: 读取超时（两次数据之间的间隔）
+- `write`: 写入超时
+- `pool`: 连接池超时
+
+**当前实现的问题**:
+- 使用单一的 60 秒作为所有超时，不够灵活
+- 对于流式调用，应该使用**读取超时**而不是总超时
+
+**正确的配置应该是**:
+```python
+import httpx
+
+client = AsyncOpenAI(
+    timeout=httpx.Timeout(
+        connect=10.0,      # 连接超时 10 秒
+        read=90.0,         # 读取超时 90 秒（与空闲超时一致）
+        write=10.0,        # 写入超时 10 秒
+        pool=None,         # 连接池不超时
+    )
+)
+```
+
+### 问题 4: 全局超时 30 分钟可能不够
+
+**场景**:
+- 复杂的多轮工具调用任务（如代码生成、测试、调试）
+- 大量文件处理
+- 长时间运行的代码执行
+
+**建议**:
+- 提高到 **60 分钟 (3600s)**
+- 或者允许 Agent 级别配置更长的超时
+
+### 问题 5: 超时错误处理不够友好
+
+**当前实现**:
+```python
+except StreamIdleTimeoutError:
+    logger.warning("Stream idle timeout (%ss) for conversation %s", idle_timeout, conversation.id)
+    await persist_partial_round_error(...)
+    yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'msg': t('stream_timeout_exceeded'), 'timeout': idle_timeout})}\n\n"
+```
+
+**问题**:
+- 用户只能看到"超时"错误，不知道是哪种超时
+- 没有提供重试或恢复的选项
+- 部分内容虽然保存了，但用户体验不佳
+
+## 最优解建议
+
+### 方案 1: 简化超时层级（推荐）
+
+**目标**: 减少超时层级，明确职责
+
+#### 1.1 保留的超时
+
+1. **全局超时** (Global Timeout)
+   - 默认值: **3600 秒 (60 分钟)**
+   - 作用: 防止整个对话无限挂起
+   - 可配置: Agent 级别可覆盖
+
+2. **读取超时** (Read Timeout)
+   - 默认值: **180 秒 (3 分钟)**
+   - 作用: 检测模型 API 连接中断或卡死
+   - 位置: HTTP 客户端层
+   - 配置方式:
+     ```python
+     timeout=httpx.Timeout(
+         connect=10.0,
+         read=180.0,  # 读取超时
+         write=10.0,
+     )
+     ```
+
+3. **工具超时** (Tool Timeout)
+   - 保持现有配置 (30-60s)
+   - 作用: 限制单个工具执行时间
+
+#### 1.2 移除的超时
+
+- **移除空闲超时** (`iter_with_idle_timeout`)
+  - 理由: 功能与 HTTP 读取超时重叠
+  - 替代: 依赖 HTTP 客户端的读取超时
+
+#### 1.3 配置示例
+
+```python
+# backend/app/core/config.py
+class Settings(BaseSettings):
+    # Streaming timeouts (seconds)
+    STREAM_GLOBAL_TIMEOUT: int = 3600  # 60 minutes (提高)
+    STREAM_HEARTBEAT_INTERVAL: int = 15  # 15 seconds
+    
+    # HTTP client timeouts (seconds)
+    STREAM_HTTP_CONNECT_TIMEOUT: int = 10  # 连接超时
+    STREAM_HTTP_READ_TIMEOUT: int = 180    # 读取超时（新增）
+    STREAM_HTTP_WRITE_TIMEOUT: int = 10    # 写入超时
+    
+    # Tool execution timeouts (seconds)
+    STREAM_TOOL_TIMEOUT_HTTP: int = 30
+    STREAM_TOOL_TIMEOUT_CODE: int = 60
+    STREAM_TOOL_TIMEOUT_MCP: int = 60
+    STREAM_TOOL_TIMEOUT_DOWNLOAD: int = 60
+```
+
+```python
+# backend/app/llm/adapters/chat/base.py
+@property
+def http_timeout(self) -> httpx.Timeout:
+    """HTTP 客户端超时配置"""
+    from app.core.config import settings
+    
+    return httpx.Timeout(
+        connect=settings.STREAM_HTTP_CONNECT_TIMEOUT,
+        read=settings.STREAM_HTTP_READ_TIMEOUT,
+        write=settings.STREAM_HTTP_WRITE_TIMEOUT,
+        pool=None,
+    )
+```
+
+```python
+# backend/app/llm/adapters/chat/openai_adapter.py
+client = AsyncOpenAI(
+    api_key=self.api_key,
+    base_url=self.base_url,
+    timeout=self.http_timeout,  # 使用细粒度超时配置
+)
+```
+
+### 方案 2: 保留空闲超时但优化（备选）
+
+如果需要保留空闲超时（用于更精细的控制），建议：
+
+1. **提高空闲超时到 180 秒**
+2. **HTTP 读取超时设置为 200 秒**（略高于空闲超时）
+3. **明确优先级**: 空闲超时 < HTTP 读取超时 < 全局超时
+
+### 方案 3: 动态超时（高级）
+
+根据不同场景动态调整超时：
+
+```python
+def get_dynamic_timeout(agent: Agent, has_tools: bool) -> dict:
+    """根据 Agent 配置动态计算超时"""
+    base_timeout = 3600  # 基础 60 分钟
+    
+    # 如果启用了工具，增加超时
+    if has_tools:
+        base_timeout += 1800  # 额外 30 分钟
+    
+    # 如果是推理模型（o1/o3），增加读取超时
+    read_timeout = 180
+    if agent.model_id and ("o1" in agent.model_id or "o3" in agent.model_id):
+        read_timeout = 300  # 5 分钟
+    
+    return {
+        "global_timeout": base_timeout,
+        "read_timeout": read_timeout,
+    }
+```
+
+## 实施建议
+
+### 优先级 P0（立即修复）
+
+1. **修复 HTTP 客户端超时配置**
+   - 将单一的 60 秒超时改为细粒度的 `httpx.Timeout`
+   - 设置合理的读取超时（180 秒）
+
+2. **提高全局超时到 60 分钟**
+   - 避免复杂任务被过早中断
+
+### 优先级 P1（短期优化）
+
+3. **移除或优化空闲超时**
+   - 方案 A: 移除 `iter_with_idle_timeout`，依赖 HTTP 读取超时
+   - 方案 B: 提高空闲超时到 180 秒，并确保 HTTP 读取超时更高
+
+4. **改进超时错误提示**
+   - 区分不同类型的超时
+   - 提供更友好的错误消息和重试建议
+
+### 优先级 P2（长期优化）
+
+5. **实现动态超时**
+   - 根据模型类型、工具配置动态调整
+   - 提供 Agent 级别的超时配置 UI
+
+6. **添加超时监控和告警**
+   - 记录超时事件到日志
+   - 统计超时率，优化默认值
+
+## 测试建议
+
+### 测试场景
+
+1. **正常流式对话**
+   - 验证不会被误超时
+
+2. **长时间思考的模型**
+   - 使用 o1/o3 模型，验证不会在思考时超时
+
+3. **多轮工具调用**
+   - 验证复杂任务不会被全局超时中断
+
+4. **网络中断模拟**
+   - 验证读取超时能正确检测并处理
+
+5. **客户端断开**
+   - 验证心跳机制能及时检测并停止生成
+
+### 测试方法
+
+```python
+# 模拟慢速模型响应
+async def slow_model_stream():
+    yield chunk1
+    await asyncio.sleep(150)  # 模拟 150 秒无输出
+    yield chunk2
+
+# 验证超时行为
+with pytest.raises(StreamIdleTimeoutError):
+    async for chunk in iter_with_idle_timeout(slow_model_stream(), timeout_seconds=90):
+        pass
+```
+
+## 总结
+
+### 当前实现的问题
+
+1. ❌ 超时层级过多，职责不清
+2. ❌ HTTP 客户端超时配置不当（应使用细粒度配置）
+3. ❌ 空闲超时 90 秒可能过短
+4. ❌ 全局超时 30 分钟可能不够
+5. ❌ 超时错误处理不够友好
+
+### 推荐方案
+
+**采用方案 2（保留空闲超时但优化，已落地）**:
+- 全局超时: **3600 秒 (60 分钟)**
+- 应用层空闲超时: **180 秒 (3 分钟)**
+- HTTP 读取超时: **200 秒**，略高于应用层空闲超时，确保应用层能先给出可控错误
+- HTTP 连接/写入超时: **10 秒**
+- 保持工具超时不变
+
+### 已完成阶段
+
+1. ✅ **P0: HTTP 客户端超时配置**
+   - `backend/app/llm/adapters/chat/base.py` 新增 `http_timeout`，使用 `httpx.Timeout` 区分 connect/read/write。
+   - 所有 OpenAI-compatible/Anthropic/Ollama 等聊天适配器已从 `self.timeout` 切换到 `self.http_timeout`。
+   - 旧的 `timeout` 模型参数继续作为 `read_timeout` 兼容入口。
+
+2. ✅ **P0: 全局超时默认值**
+   - `STREAM_GLOBAL_TIMEOUT` 从 1800 秒提高到 3600 秒。
+
+3. ✅ **P1: 空闲超时默认值与优先级**
+   - `STREAM_IDLE_TIMEOUT` 从 90 秒提高到 180 秒。
+   - `STREAM_HTTP_READ_TIMEOUT` 设为 200 秒，避免 HTTP SDK 在应用层空闲超时前抢先失败。
+
+### 后续可选阶段
+
+1. ✅ **P2: 动态超时**
+   - 推理模型或显式开启 thinking/reasoning 的模型默认使用 300 秒 HTTP read timeout。
+   - 启用工具、记忆、图片生成或视频生成的 Agent 默认使用 5400 秒全局超时。
+   - 显式配置的 `global_timeout`、`read_timeout` 或旧 `timeout` 仍优先。
+
+2. ✅ **P2: 基础监控字段**
+   - stream 与 regenerate 的 idle/global timeout 日志已补充 `timeout_type` 和 `timeout_seconds`，便于按类型统计。
+
+3. **后续可选：前端错误提示细化**
+   - SSE error payload 仍沿用统一 `stream_timeout_exceeded` 文案。
+   - 如果要在 UI 明确区分“模型空闲超时”和“整轮任务超时”，可在 error payload 中新增 `timeout_type`。
+
+4. **后续可选：指标面板**
+   - 将日志中的 `timeout_type` 汇总到监控系统，按 provider/model/agent 统计超时率。
+
+### 预期收益
+
+1. ✅ 减少超时相关的误报
+2. ✅ 提高复杂任务的成功率
+3. ✅ 简化配置和维护
+4. ✅ 更好的用户体验
+
+---
+
+**文档版本**: 1.0  
+**创建时间**: 2026-05-28  
+**作者**: Claude (Opus 4.7)  
+**相关 Issue**: YUN-72

--- a/docs/plan/admin-observability-dashboard.md
+++ b/docs/plan/admin-observability-dashboard.md
@@ -1,0 +1,1485 @@
+# 后台管理员可观测性面板设计文档
+
+## 背景与目标
+
+### 问题
+当前系统缺乏对 AI 对话和工作流运行的可观测性，管理员无法：
+1. 了解超时发生的频率和类型分布
+2. 监控 Agent/Workflow 的性能表现（响应时间分位数）
+3. 追踪系统吞吐量和负载趋势
+4. 快速定位性能瓶颈和异常
+
+### 目标
+在后台管理面板新增**可观测性 (Observability)** 标签页，提供：
+1. **超时监控**：按类型、Agent、模型统计超时事件
+2. **性能分析**：P50/P90/P95/P99 响应时间分位数
+3. **吞吐量监控**：QPS/TPS、并发数、成功率
+4. **趋势分析**：时间序列图表，支持自定义时间范围
+
+## 高层设计
+
+### 1. 数据架构
+
+#### 1.1 数据源
+- **现有数据**：
+  - `Message` 表：`duration_ms`, `created_at`, `conversation_id`, `round_status`
+  - `Conversation` 表：`agent_id`, `created_at`, `message_count`
+  - `Agent` 表：`id`, `name`, `model_id`
+  - 日志系统：timeout 日志中的 `timeout_type`, `timeout_seconds`
+
+- **新增数据**：
+  - 时序指标表（可选，用于高性能查询）
+  - 或直接从现有表聚合（初期方案）
+
+#### 1.2 指标定义
+
+**超时指标**：
+- `timeout_count`：超时事件总数
+- `timeout_rate`：超时率 = 超时数 / 总请求数
+- 按维度分组：`timeout_type` (idle/global), `agent_id`, `model_id`, `team_id`
+
+**性能指标**：
+- `duration_p50/p90/p95/p99`：响应时间分位数（毫秒）
+- `first_token_latency_p50/p90/p95`：首 token 延迟（毫秒）
+- 按维度分组：`agent_id`, `model_id`, `team_id`, `has_tools`
+
+**吞吐量指标**：
+- `qps`：每秒查询数（Queries Per Second）
+- `tps`：每秒事务数（Transactions Per Second，这里指完整对话轮次）
+- `concurrent_conversations`：并发对话数
+- `success_rate`：成功率 = 成功数 / 总数
+
+**资源指标**：
+- `token_usage_total`：总 token 消耗
+- `token_usage_rate`：每秒 token 消耗
+- `avg_tokens_per_message`：平均每条消息 token 数
+
+### 2. 前端界面设计
+
+#### 2.1 页面结构
+
+```
+后台管理 (Dashboard)
+├── 概览 (Overview)
+├── 用户管理 (Users)
+├── 团队管理 (Teams)
+├── 模型管理 (Models)
+├── 系统设置 (Settings)
+└── 可观测性 (Observability) ← 新增
+    ├── 概览 (Overview)
+    ├── 系统健康 (System Health) ← 新增
+    ├── Agent 性能 (Agent Performance)
+    ├── Workflow 性能 (Workflow Performance)
+    ├── 超时分析 (Timeout Analysis)
+    └── 系统吞吐 (System Throughput)
+```
+
+#### 2.2 子页面详细设计
+
+##### 2.2.1 概览 (Overview)
+
+**布局**：4 个关键指标卡片 + 2 个趋势图
+
+**关键指标卡片**：
+1. **总请求数**
+   - 今日/本周/本月总请求数
+   - 环比增长率
+   
+2. **平均响应时间**
+   - P50 响应时间
+   - 与昨日对比
+
+3. **超时率**
+   - 今日超时率
+   - 超时类型分布（饼图）
+
+4. **系统吞吐量**
+   - 当前 QPS
+   - 峰值 QPS（今日）
+
+**趋势图**：
+1. **请求量趋势**（折线图）
+   - X 轴：时间（小时/天）
+   - Y 轴：请求数
+   - 可切换：今日/本周/本月
+
+2. **响应时间趋势**（折线图）
+   - X 轴：时间
+   - Y 轴：P50/P90/P95（多条线）
+
+##### 2.2.2 系统健康 (System Health)
+
+**布局**：6 个基础设施状态卡片 + 系统资源趋势图
+
+**基础设施状态卡片**：
+
+1. **CPU 使用率**
+   - 实时 CPU 使用率（百分比）
+   - 状态指示：正常（<70%）、警告（70-90%）、危险（>90%）
+   - 最近 1 小时平均值
+   - 核心数和架构信息
+
+2. **内存使用**
+   - 实时内存使用率（百分比）
+   - 已用/总量（GB）
+   - 状态指示：正常（<80%）、警告（80-90%）、危险（>90%）
+   - 最近 1 小时平均值
+
+3. **数据库状态**
+   - 连接状态：🟢 正常 / 🔴 异常
+   - 活跃连接数 / 最大连接数
+   - 查询队列长度
+   - 最近 1 小时慢查询数（>1s）
+   - 数据库大小
+
+4. **Redis 状态**
+   - 连接状态：🟢 正常 / 🔴 异常
+   - 内存使用率
+   - 命中率（hit rate）
+   - 每秒操作数（ops/sec）
+   - 连接数
+
+5. **Worker 状态**
+   - Celery Worker 状态：🟢 正常 / 🔴 异常
+   - 活跃 Worker 数
+   - 任务队列长度
+   - 待处理任务数
+   - 最近 1 小时任务失败率
+
+6. **磁盘 I/O**
+   - 读写速率（MB/s）
+   - IOPS
+   - 磁盘使用率
+
+**系统资源趋势图**：
+
+1. **CPU 使用率趋势**（折线图）
+   - X 轴：时间（最近 24 小时，按分钟）
+   - Y 轴：CPU 使用率 %
+   - 标注危险阈值线（90%）
+
+2. **内存使用趋势**（面积图）
+   - X 轴：时间
+   - Y 轴：内存使用量（GB）
+   - 展示已用和总量
+
+3. **数据库性能趋势**（组合图）
+   - 左轴：活跃连接数（折线）
+   - 右轴：查询延迟 P50/P95（折线）
+
+4. **Redis 性能趋势**（折线图）
+   - 命中率 %
+   - 每秒操作数
+   - 内存使用率 %
+
+**详细监控表格**：
+
+**数据库慢查询列表**：
+
+| 时间 | 查询摘要 | 耗时 (ms) | 表名 | 影响行数 |
+|------|---------|----------|------|---------|
+| 14:32 | SELECT * FROM messages WHERE... | 1,250 | messages | 5000 |
+
+**Worker 任务队列**：
+
+| 队列名称 | 待处理 | 活跃 | 失败 | 平均耗时 |
+|---------|--------|------|------|---------|
+| default | 12 | 3 | 0 | 2.5s |
+| high_priority | 0 | 1 | 0 | 1.2s |
+
+##### 2.2.3 Agent 性能 (Agent Performance)
+
+**筛选器**：
+- 时间范围：今日/本周/本月/自定义
+- Agent 选择：下拉多选
+- 团队选择：下拉多选
+
+**表格**：Agent 性能排行
+
+| Agent 名称 | 请求数 | P50 (ms) | P90 (ms) | P95 (ms) | P99 (ms) | 超时率 | 成功率 | 平均 Token |
+|-----------|--------|----------|----------|----------|----------|--------|--------|-----------|
+| 客服助手   | 1,234  | 850      | 2,100    | 3,500    | 5,200    | 0.5%   | 99.2%  | 1,250     |
+| 代码助手   | 856    | 1,200    | 4,500    | 8,000    | 12,000   | 2.1%   | 97.5%  | 3,400     |
+
+**详情图表**（点击 Agent 展开）：
+1. **响应时间分布**（直方图）
+2. **时间序列**（折线图）：P50/P90/P95 随时间变化
+3. **超时事件时间线**（散点图）：标注每次超时发生时间和类型
+
+##### 2.2.4 Workflow 性能 (Workflow Performance)
+
+**类似 Agent 性能，额外维度**：
+- 节点执行时间分布
+- 节点失败率
+- 平均节点数
+
+**表格**：Workflow 性能排行
+
+| Workflow 名称 | 执行次数 | P50 (ms) | P90 (ms) | P95 (ms) | 超时率 | 成功率 | 平均节点数 |
+|--------------|---------|----------|----------|----------|--------|--------|-----------|
+| 数据处理流程  | 456     | 3,200    | 8,500    | 12,000   | 1.2%   | 98.5%  | 5.2       |
+
+##### 2.2.5 超时分析 (Timeout Analysis)
+
+**筛选器**：
+- 时间范围
+- 超时类型：idle/global
+- Agent/Workflow
+- 模型
+
+**可视化**：
+1. **超时类型分布**（饼图）
+   - idle timeout: 65%
+   - global timeout: 35%
+
+2. **超时趋势**（折线图）
+   - X 轴：时间
+   - Y 轴：超时次数
+   - 分组：按超时类型
+
+3. **超时热力图**（热力图）
+   - X 轴：小时（0-23）
+   - Y 轴：星期（周一-周日）
+   - 颜色深度：超时次数
+
+4. **Top 超时 Agent**（条形图）
+   - 按超时次数排序
+
+**详细事件列表**：
+
+| 时间 | Agent/Workflow | 超时类型 | 超时阈值 | 实际耗时 | 模型 | 对话 ID |
+|------|---------------|---------|---------|---------|------|---------|
+| 2026-05-28 14:32 | 客服助手 | idle | 180s | 185s | gpt-4 | conv-123 |
+
+##### 2.2.6 系统吞吐 (System Throughput)
+
+**实时指标**（大数字卡片）：
+1. **当前 QPS**
+   - 实时更新（每 5 秒）
+   
+2. **当前并发数**
+   - 正在进行的对话数
+
+3. **今日峰值 QPS**
+   - 发生时间
+
+**趋势图**：
+1. **QPS 趋势**（折线图）
+   - 最近 24 小时，按分钟聚合
+   - 标注峰值点
+
+2. **TPS 趋势**（折线图）
+   - 完整对话轮次/秒
+
+3. **并发数趋势**（面积图）
+   - 并发对话数随时间变化
+
+4. **成功率趋势**（折线图）
+   - 成功率 % 随时间变化
+
+### 3. 后端 API 设计
+
+#### 3.1 API 端点
+
+**基础路径**：`/api/v1/admin/observability`
+
+##### 3.1.1 概览指标
+
+```
+GET /api/v1/admin/observability/overview
+Query:
+  - time_range: today|week|month|custom
+  - start_time: ISO8601 (if custom)
+  - end_time: ISO8601 (if custom)
+
+Response:
+{
+  "total_requests": 12345,
+  "total_requests_growth": 15.2,  // 环比增长 %
+  "avg_response_time_p50": 850,
+  "avg_response_time_p50_change": -5.3,  // 与昨日对比 %
+  "timeout_rate": 0.8,
+  "timeout_distribution": {
+    "idle": 65,
+    "global": 35
+  },
+  "current_qps": 12.5,
+  "peak_qps": 45.2,
+  "peak_qps_time": "2026-05-28T14:32:00Z"
+}
+```
+
+##### 3.1.2 请求量趋势
+
+```
+GET /api/v1/admin/observability/request-trend
+Query:
+  - time_range: today|week|month|custom
+  - start_time: ISO8601
+  - end_time: ISO8601
+  - granularity: hour|day
+
+Response:
+{
+  "data": [
+    {"timestamp": "2026-05-28T00:00:00Z", "count": 234},
+    {"timestamp": "2026-05-28T01:00:00Z", "count": 189},
+    ...
+  ]
+}
+```
+
+##### 3.1.3 响应时间趋势
+
+```
+GET /api/v1/admin/observability/response-time-trend
+Query:
+  - time_range: today|week|month|custom
+  - start_time: ISO8601
+  - end_time: ISO8601
+  - granularity: hour|day
+
+Response:
+{
+  "data": [
+    {
+      "timestamp": "2026-05-28T00:00:00Z",
+      "p50": 850,
+      "p90": 2100,
+      "p95": 3500,
+      "p99": 5200
+    },
+    ...
+  ]
+}
+```
+
+##### 3.1.4 Agent 性能列表
+
+```
+GET /api/v1/admin/observability/agents
+Query:
+  - time_range: today|week|month|custom
+  - start_time: ISO8601
+  - end_time: ISO8601
+  - agent_ids: comma-separated UUIDs (optional)
+  - team_ids: comma-separated UUIDs (optional)
+  - sort_by: requests|p50|p90|p95|timeout_rate
+  - sort_order: asc|desc
+  - page: int
+  - page_size: int
+
+Response:
+{
+  "total": 45,
+  "page": 1,
+  "page_size": 20,
+  "data": [
+    {
+      "agent_id": "uuid",
+      "agent_name": "客服助手",
+      "team_name": "客服团队",
+      "request_count": 1234,
+      "p50": 850,
+      "p90": 2100,
+      "p95": 3500,
+      "p99": 5200,
+      "timeout_count": 6,
+      "timeout_rate": 0.5,
+      "success_count": 1224,
+      "success_rate": 99.2,
+      "avg_tokens": 1250
+    },
+    ...
+  ]
+}
+```
+
+##### 3.1.5 Agent 详细时间序列
+
+```
+GET /api/v1/admin/observability/agents/{agent_id}/timeseries
+Query:
+  - time_range: today|week|month|custom
+  - start_time: ISO8601
+  - end_time: ISO8601
+  - granularity: hour|day
+
+Response:
+{
+  "agent_id": "uuid",
+  "agent_name": "客服助手",
+  "data": [
+    {
+      "timestamp": "2026-05-28T00:00:00Z",
+      "request_count": 45,
+      "p50": 820,
+      "p90": 2050,
+      "p95": 3400,
+      "timeout_count": 0
+    },
+    ...
+  ]
+}
+```
+
+##### 3.1.6 超时事件列表
+
+```
+GET /api/v1/admin/observability/timeouts
+Query:
+  - time_range: today|week|month|custom
+  - start_time: ISO8601
+  - end_time: ISO8601
+  - timeout_type: idle|global (optional)
+  - agent_ids: comma-separated UUIDs (optional)
+  - model_ids: comma-separated UUIDs (optional)
+  - page: int
+  - page_size: int
+
+Response:
+{
+  "total": 123,
+  "page": 1,
+  "page_size": 20,
+  "data": [
+    {
+      "timestamp": "2026-05-28T14:32:15Z",
+      "agent_id": "uuid",
+      "agent_name": "客服助手",
+      "timeout_type": "idle",
+      "timeout_threshold": 180,
+      "actual_duration": 185,
+      "model_id": "uuid",
+      "model_name": "gpt-4",
+      "conversation_id": "uuid"
+    },
+    ...
+  ]
+}
+```
+
+##### 3.1.7 系统吞吐量实时指标
+
+```
+GET /api/v1/admin/observability/throughput/realtime
+
+Response:
+{
+  "current_qps": 12.5,
+  "current_concurrent": 34,
+  "today_peak_qps": 45.2,
+  "today_peak_qps_time": "2026-05-28T14:32:00Z"
+}
+```
+
+##### 3.1.8 QPS/TPS 趋势
+
+```
+GET /api/v1/admin/observability/throughput/trend
+Query:
+  - time_range: today|week|month|custom
+  - start_time: ISO8601
+  - end_time: ISO8601
+  - granularity: minute|hour|day
+
+Response:
+{
+  "data": [
+    {
+      "timestamp": "2026-05-28T14:00:00Z",
+      "qps": 12.5,
+      "tps": 8.3,
+      "concurrent": 34,
+      "success_rate": 99.2
+    },
+    ...
+  ]
+}
+```
+
+##### 3.1.9 系统健康实时状态
+
+```
+GET /api/v1/admin/observability/system/health
+
+Response:
+{
+  "cpu": {
+    "usage_percent": 45.2,
+    "cores": 8,
+    "architecture": "x86_64",
+    "status": "normal",  // normal | warning | danger
+    "avg_1h": 42.5
+  },
+  "memory": {
+    "usage_percent": 68.5,
+    "used_gb": 12.4,
+    "total_gb": 16.0,
+    "status": "normal",
+    "avg_1h": 65.2
+  },
+  "database": {
+    "status": "healthy",  // healthy | unhealthy
+    "active_connections": 15,
+    "max_connections": 100,
+    "query_queue_length": 0,
+    "slow_queries_1h": 2,
+    "database_size_gb": 2.5
+  },
+  "redis": {
+    "status": "healthy",
+    "memory_usage_percent": 35.2,
+    "hit_rate": 92.5,
+    "ops_per_sec": 1250,
+    "connected_clients": 25
+  },
+  "worker": {
+    "status": "healthy",  // healthy | unhealthy
+    "active_workers": 3,
+    "queue_length": 12,
+    "pending_tasks": 8,
+    "failure_rate_1h": 0.5
+  },
+  "disk": {
+    "read_mbps": 45.2,
+    "write_mbps": 23.8,
+    "iops": 850,
+    "usage_percent": 62.3
+  }
+}
+```
+
+##### 3.1.10 系统资源趋势
+
+```
+GET /api/v1/admin/observability/system/trend
+Query:
+  - time_range: today|week|month|custom
+  - start_time: ISO8601
+  - end_time: ISO8601
+  - granularity: minute|hour|day
+
+Response:
+{
+  "data": [
+    {
+      "timestamp": "2026-05-28T14:00:00Z",
+      "cpu_usage": 45.2,
+      "memory_usage": 68.5,
+      "db_active_connections": 15,
+      "db_query_latency_p50": 12.5,
+      "db_query_latency_p95": 45.2,
+      "redis_hit_rate": 92.5,
+      "redis_ops_per_sec": 1250,
+      "disk_read_mbps": 45.2,
+      "disk_write_mbps": 23.8
+    },
+    ...
+  ]
+}
+```
+
+##### 3.1.11 数据库慢查询列表
+
+```
+GET /api/v1/admin/observability/system/slow-queries
+Query:
+  - time_range: today|week|month|custom
+  - start_time: ISO8601
+  - end_time: ISO8601
+  - threshold_ms: int (default: 1000)
+  - page: int
+  - page_size: int
+
+Response:
+{
+  "total": 45,
+  "page": 1,
+  "page_size": 20,
+  "data": [
+    {
+      "timestamp": "2026-05-28T14:32:15Z",
+      "query_hash": "abc123",
+      "query_summary": "SELECT * FROM messages WHERE conversation_id = $1",
+      "duration_ms": 1250,
+      "table_name": "messages",
+      "rows_affected": 5000,
+      "database": "clouisle"
+    },
+    ...
+  ]
+}
+```
+
+##### 3.1.12 Worker 任务队列状态
+
+```
+GET /api/v1/admin/observability/system/workers
+
+Response:
+{
+  "active_workers": 3,
+  "queues": [
+    {
+      "name": "default",
+      "pending": 12,
+      "active": 3,
+      "failed": 0,
+      "avg_duration_ms": 2500
+    },
+    {
+      "name": "high_priority",
+      "pending": 0,
+      "active": 1,
+      "failed": 0,
+      "avg_duration_ms": 1200
+    },
+    {
+      "name": "session_memory",
+      "pending": 5,
+      "active": 0,
+      "failed": 2,
+      "avg_duration_ms": 3500
+    }
+  ]
+}
+```
+
+#### 3.2 数据聚合策略
+
+**实时查询**（< 1 小时）：
+- 直接从 `Message` 表聚合
+- 使用数据库索引优化：`(created_at, agent_id, round_status)`
+
+**历史查询**（> 1 小时）：
+- 方案 A（初期）：从 `Message` 表聚合，加缓存
+- 方案 B（长期）：预聚合到时序指标表，定时任务每小时/每天聚合
+
+**分位数计算**：
+- PostgreSQL：使用 `percentile_cont()` 函数
+- 或应用层计算（从数据库取 `duration_ms` 列表后排序）
+
+### 4. 实施计划
+
+#### 阶段 1：基础设施（1-2 天）
+
+1. **后端 API**
+   - 创建 `/api/v1/admin/observability` 路由模块
+   - 实现概览指标 API
+   - 实现 Agent 性能列表 API
+   - 实现超时事件列表 API
+
+2. **数据库优化**
+   - 添加索引：`Message(created_at, agent_id, round_status)`
+   - 添加索引：`Conversation(created_at, agent_id)`
+
+3. **权限控制**
+   - 仅超级管理员可访问
+   - 添加权限检查中间件
+
+4. **系统健康监控集成**
+   - 集成 `psutil` 库获取系统指标
+   - 实现数据库连接池监控
+   - 实现 Redis 状态监控
+   - 实现 Celery Worker 状态监控
+
+#### 阶段 2：前端界面（2-3 天）
+
+1. **路由和布局**
+   - 添加 `/dashboard/observability` 路由
+   - 创建子页面路由结构
+
+2. **概览页面**
+   - 关键指标卡片组件
+   - 请求量趋势图（使用 recharts）
+   - 响应时间趋势图
+
+3. **系统健康页面**
+   - 基础设施状态卡片组件（CPU、内存、数据库、Redis、Worker、磁盘）
+   - 系统资源趋势图（CPU、内存、数据库性能、Redis 性能）
+   - 慢查询列表表格
+   - Worker 任务队列表格
+
+4. **Agent 性能页面**
+   - 筛选器组件
+   - 性能表格组件
+   - 详情展开面板
+
+5. **超时分析页面**
+   - 超时类型分布饼图
+   - 超时趋势折线图
+   - 超时事件列表
+
+#### 阶段 3：高级功能（2-3 天）
+
+1. **Workflow 性能**
+   - Workflow 性能 API
+   - Workflow 性能页面
+
+2. **系统吞吐**
+   - 实时 QPS/TPS API
+   - 吞吐量趋势页面
+   - WebSocket 实时更新（可选）
+
+3. **导出功能**
+   - CSV 导出
+   - PDF 报告生成（可选）
+
+#### 阶段 4：优化和监控（1-2 天）
+
+1. **性能优化**
+   - 查询缓存（Redis）
+   - 预聚合任务（Celery）
+
+2. **告警功能**（可选）
+   - 超时率阈值告警
+   - 性能下降告警
+   - 邮件/Webhook 通知
+
+3. **系统健康告警**
+   - CPU 使用率超过 90% 告警
+   - 内存使用率超过 90% 告警
+   - 数据库连接池超过 80% 告警
+   - Redis 命中率低于 80% 告警
+   - Worker 任务失败率超过 5% 告警
+
+### 5. 技术栈
+
+**后端**：
+- FastAPI
+- PostgreSQL（聚合查询）
+- Redis（缓存）
+- Celery（预聚合任务，可选）
+- psutil（系统监控）
+- SQLAlchemy（数据库连接池监控）
+
+**前端**：
+- Next.js
+- React
+- Recharts（图表库）
+- TanStack Table（表格）
+- Tailwind CSS
+- WebSocket（实时更新，可选）
+
+### 6. 数据保留策略
+
+**原始数据**：
+- `Message` 表：永久保留（或按团队配置）
+
+**聚合数据**（如果使用预聚合表）：
+- 小时级聚合：保留 30 天
+- 天级聚合：保留 1 年
+- 月级聚合：永久保留
+
+### 7. 安全和权限
+
+**访问控制**：
+- 仅超级管理员（`is_superuser=True`）可访问
+- 团队管理员可查看本团队数据（可选）
+
+**数据脱敏**：
+- 不展示对话内容
+- 只展示统计指标和元数据
+
+**审计日志**：
+- 记录管理员访问可观测性面板的操作
+
+### 8. 测试策略
+
+**单元测试**：
+- API 端点测试
+- 聚合逻辑测试
+- 分位数计算测试
+
+**集成测试**：
+- 端到端 API 测试
+- 前端组件测试
+
+**性能测试**：
+- 大数据量聚合查询性能
+- 并发查询压力测试
+
+### 9. 监控和告警
+
+**系统监控**：
+- API 响应时间
+- 数据库查询性能
+- 缓存命中率
+
+**业务告警**：
+- 超时率超过阈值（如 5%）
+- P95 响应时间超过阈值（如 10s）
+- QPS 异常波动
+
+### 10. 未来扩展
+
+**高级分析**：
+- 异常检测（基于机器学习）
+- 性能预测
+- 成本分析（Token 消耗 × 价格）
+
+**自定义仪表盘**：
+- 用户自定义指标
+- 自定义图表布局
+- 保存和分享仪表盘
+
+**集成外部监控**：
+- Prometheus 导出器
+- Grafana 集成
+- DataDog/New Relic 集成
+
+---
+
+## 附录
+
+### A. 数据库 Schema 变更（可选预聚合表）
+
+```sql
+-- 小时级聚合表
+CREATE TABLE observability_metrics_hourly (
+    id UUID PRIMARY KEY,
+    timestamp TIMESTAMPTZ NOT NULL,
+    agent_id UUID REFERENCES agents(id),
+    team_id UUID REFERENCES teams(id),
+    model_id UUID REFERENCES team_models(id),
+    
+    -- 请求统计
+    request_count INT NOT NULL DEFAULT 0,
+    success_count INT NOT NULL DEFAULT 0,
+    timeout_count INT NOT NULL DEFAULT 0,
+    timeout_idle_count INT NOT NULL DEFAULT 0,
+    timeout_global_count INT NOT NULL DEFAULT 0,
+    
+    -- 响应时间分位数（毫秒）
+    duration_p50 INT,
+    duration_p90 INT,
+    duration_p95 INT,
+    duration_p99 INT,
+    
+    -- Token 统计
+    total_tokens BIGINT NOT NULL DEFAULT 0,
+    
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    
+    UNIQUE(timestamp, agent_id, team_id, model_id)
+);
+
+CREATE INDEX idx_metrics_hourly_timestamp ON observability_metrics_hourly(timestamp);
+CREATE INDEX idx_metrics_hourly_agent ON observability_metrics_hourly(agent_id, timestamp);
+CREATE INDEX idx_metrics_hourly_team ON observability_metrics_hourly(team_id, timestamp);
+```
+
+### B. 前端组件结构
+
+```
+frontend/app/(dashboard)/observability/
+├── layout.tsx                    # 可观测性布局
+├── page.tsx                      # 概览页面
+├── agents/
+│   └── page.tsx                  # Agent 性能页面
+├── workflows/
+│   └── page.tsx                  # Workflow 性能页面
+├── timeouts/
+│   └── page.tsx                  # 超时分析页面
+├── throughput/
+│   └── page.tsx                  # 系统吞吐页面
+└── _components/
+    ├── metric-card.tsx           # 指标卡片
+    ├── trend-chart.tsx           # 趋势图表
+    ├── performance-table.tsx     # 性能表格
+    ├── timeout-heatmap.tsx       # 超时热力图
+    └── time-range-selector.tsx   # 时间范围选择器
+```
+
+### C. API 响应示例
+
+**Agent 性能列表响应**：
+```json
+{
+  "total": 45,
+  "page": 1,
+  "page_size": 20,
+  "data": [
+    {
+      "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+      "agent_name": "客服助手",
+      "team_name": "客服团队",
+      "request_count": 1234,
+      "p50": 850,
+      "p90": 2100,
+      "p95": 3500,
+      "p99": 5200,
+      "timeout_count": 6,
+      "timeout_rate": 0.49,
+      "success_count": 1224,
+      "success_rate": 99.19,
+      "avg_tokens": 1250
+    }
+  ]
+}
+```
+
+---
+
+**文档版本**: 1.0  
+**创建时间**: 2026-05-28  
+**作者**: Claude (Opus 4.7)  
+**相关 Issue**: YUN-72 (超时优化的后续扩展)
+
+---
+
+## 附录 D：系统健康监控实现细节
+
+### D.1 psutil 系统监控
+
+```python
+# backend/app/services/observability/system_monitor.py
+
+import psutil
+from datetime import datetime
+from typing import Dict, Any
+
+def get_cpu_metrics() -> Dict[str, Any]:
+    """获取 CPU 指标"""
+    cpu_percent = psutil.cpu_percent(interval=1)
+    cpu_count = psutil.cpu_count()
+    cpu_freq = psutil.cpu_freq()
+    
+    # 判断状态
+    status = "normal"
+    if cpu_percent >= 90:
+        status = "danger"
+    elif cpu_percent >= 70:
+        status = "warning"
+    
+    return {
+        "usage_percent": cpu_percent,
+        "cores": cpu_count,
+        "architecture": psutil.machine(),
+        "status": status,
+        "avg_1h": get_cpu_avg_1h(),  # 从历史数据计算
+        "frequency_mhz": cpu_freq.current if cpu_freq else None,
+    }
+
+def get_memory_metrics() -> Dict[str, Any]:
+    """获取内存指标"""
+    memory = psutil.virtual_memory()
+    
+    status = "normal"
+    if memory.percent >= 90:
+        status = "danger"
+    elif memory.percent >= 80:
+        status = "warning"
+    
+    return {
+        "usage_percent": memory.percent,
+        "used_gb": round(memory.used / (1024 ** 3), 2),
+        "total_gb": round(memory.total / (1024 ** 3), 2),
+        "available_gb": round(memory.available / (1024 ** 3), 2),
+        "status": status,
+        "avg_1h": get_memory_avg_1h(),
+    }
+
+def get_disk_metrics() -> Dict[str, Any]:
+    """获取磁盘 I/O 指标"""
+    disk_io = psutil.disk_io_counters()
+    disk_usage = psutil.disk_usage('/')
+    
+    return {
+        "read_mbps": round(disk_io.read_bytes / (1024 ** 2), 2) if disk_io else 0,
+        "write_mbps": round(disk_io.write_bytes / (1024 ** 2), 2) if disk_io else 0,
+        "iops": (disk_io.read_count + disk_io.write_count) if disk_io else 0,
+        "usage_percent": disk_usage.percent,
+        "total_gb": round(disk_usage.total / (1024 ** 3), 2),
+        "used_gb": round(disk_usage.used / (1024 ** 3), 2),
+    }
+
+def get_process_metrics() -> Dict[str, Any]:
+    """获取当前进程指标"""
+    process = psutil.Process()
+    
+    return {
+        "pid": process.pid,
+        "memory_mb": round(process.memory_info().rss / (1024 ** 2), 2),
+        "cpu_percent": process.cpu_percent(),
+        "threads": process.num_threads(),
+        "open_files": len(process.open_files()),
+    }
+```
+
+### D.2 数据库连接池监控
+
+```python
+# backend/app/services/observability/db_monitor.py
+
+from tortoise import Tortoise
+from typing import Dict, Any
+
+async def get_database_metrics() -> Dict[str, Any]:
+    """获取数据库指标"""
+    try:
+        # 获取连接池信息
+        conn = Tortoise.get_connection("default")
+        
+        # 查询活跃连接数
+        active_connections_query = """
+            SELECT count(*) as active_connections
+            FROM pg_stat_activity
+            WHERE state = 'active'
+        """
+        active_result = await conn.execute_query(active_connections_query)
+        active_connections = active_result[1][0]['active_connections']
+        
+        # 查询最大连接数
+        max_connections_query = "SHOW max_connections"
+        max_result = await conn.execute_query(max_connections_query)
+        max_connections = int(max_result[1][0]['max_connections'])
+        
+        # 查询数据库大小
+        db_size_query = """
+            SELECT pg_size_pretty(pg_database_size(current_database())) as size,
+                   pg_database_size(current_database()) as size_bytes
+        """
+        size_result = await conn.execute_query(db_size_query)
+        db_size = size_result[1][0]['size']
+        db_size_bytes = size_result[1][0]['size_bytes']
+        
+        # 查询慢查询数（最近 1 小时，耗时 > 1 秒）
+        slow_queries_query = """
+            SELECT count(*) as slow_count
+            FROM pg_stat_statements
+            WHERE mean_exec_time > 1000  -- 毫秒
+              AND last_call >= NOW() - INTERVAL '1 hour'
+        """
+        # 注意：需要安装 pg_stat_statements 扩展
+        # slow_result = await conn.execute_query(slow_queries_query)
+        # slow_queries = slow_result[1][0]['slow_count']
+        slow_queries = 0  # 临时值
+        
+        # 连接状态
+        status = "healthy"
+        if active_connections / max_connections > 0.8:
+            status = "warning"
+        if active_connections / max_connections > 0.95:
+            status = "unhealthy"
+        
+        return {
+            "status": status,
+            "active_connections": active_connections,
+            "max_connections": max_connections,
+            "connection_usage_percent": round(active_connections / max_connections * 100, 2),
+            "query_queue_length": await get_query_queue_length(),
+            "slow_queries_1h": slow_queries,
+            "database_size_gb": round(db_size_bytes / (1024 ** 3), 2),
+            "database_size_pretty": db_size,
+        }
+    except Exception as e:
+        return {
+            "status": "unhealthy",
+            "error": str(e),
+        }
+
+async def get_query_queue_length() -> int:
+    """获取查询队列长度"""
+    try:
+        conn = Tortoise.get_connection("default")
+        query = """
+            SELECT count(*) as queue_length
+            FROM pg_stat_activity
+            WHERE wait_event_type = 'Client'
+              AND state = 'active'
+        """
+        result = await conn.execute_query(query)
+        return result[1][0]['queue_length']
+    except Exception:
+        return 0
+
+async def get_slow_queries(
+    threshold_ms: int = 1000,
+    limit: int = 100
+) -> list[Dict[str, Any]]:
+    """获取慢查询列表"""
+    try:
+        conn = Tortoise.get_connection("default")
+        query = """
+            SELECT 
+                query,
+                calls,
+                mean_exec_time,
+                total_exec_time,
+                rows,
+                last_call
+            FROM pg_stat_statements
+            WHERE mean_exec_time > %s
+            ORDER BY mean_exec_time DESC
+            LIMIT %s
+        """
+        result = await conn.execute_query(query, [threshold_ms, limit])
+        
+        return [
+            {
+                "query_hash": str(hash(row['query']))[:8],
+                "query_summary": row['query'][:200],
+                "duration_ms": round(row['mean_exec_time'], 2),
+                "calls": row['calls'],
+                "total_time_ms": round(row['total_exec_time'], 2),
+                "rows_affected": row['rows'],
+                "last_call": row['last_call'].isoformat() if row['last_call'] else None,
+            }
+            for row in result[1]
+        ]
+    except Exception as e:
+        return []
+```
+
+### D.3 Redis 状态监控
+
+```python
+# backend/app/services/observability/redis_monitor.py
+
+import redis.asyncio as redis
+from typing import Dict, Any
+from app.core.config import settings
+
+async def get_redis_metrics() -> Dict[str, Any]:
+    """获取 Redis 指标"""
+    try:
+        r = redis.from_url(
+            f"redis://:{settings.REDIS_PASSWORD}@{settings.REDIS_HOST}:{settings.REDIS_PORT}/0"
+            if settings.REDIS_PASSWORD
+            else f"redis://{settings.REDIS_HOST}:{settings.REDIS_PORT}/0"
+        )
+        
+        # 获取 INFO 信息
+        info = await r.info()
+        
+        # 内存使用
+        used_memory = info.get('used_memory', 0)
+        max_memory = info.get('maxmemory', 0)
+        memory_usage_percent = (used_memory / max_memory * 100) if max_memory > 0 else 0
+        
+        # 命中率
+        keyspace_hits = info.get('keyspace_hits', 0)
+        keyspace_misses = info.get('keyspace_misses', 0)
+        hit_rate = (keyspace_hits / (keyspace_hits + keyspace_misses) * 100) if (keyspace_hits + keyspace_misses) > 0 else 0
+        
+        # 每秒操作数
+        ops_per_sec = info.get('instantaneous_ops_per_sec', 0)
+        
+        # 连接数
+        connected_clients = info.get('connected_clients', 0)
+        
+        # 状态判断
+        status = "healthy"
+        if memory_usage_percent > 90:
+            status = "warning"
+        if hit_rate < 80:
+            status = "warning"
+        
+        await r.close()
+        
+        return {
+            "status": status,
+            "memory_usage_percent": round(memory_usage_percent, 2),
+            "used_memory_mb": round(used_memory / (1024 ** 2), 2),
+            "max_memory_mb": round(max_memory / (1024 ** 2), 2) if max_memory > 0 else None,
+            "hit_rate": round(hit_rate, 2),
+            "ops_per_sec": ops_per_sec,
+            "connected_clients": connected_clients,
+            "keyspace_hits": keyspace_hits,
+            "keyspace_misses": keyspace_misses,
+            "uptime_seconds": info.get('uptime_in_seconds', 0),
+        }
+    except Exception as e:
+        return {
+            "status": "unhealthy",
+            "error": str(e),
+        }
+```
+
+### D.4 Celery Worker 状态监控
+
+```python
+# backend/app/services/observability/worker_monitor.py
+
+from celery import Celery
+from typing import Dict, Any, List
+from app.core.config import settings
+
+def get_celery_app() -> Celery:
+    """获取 Celery 应用实例"""
+    # 这里需要根据实际 Celery 配置返回实例
+    from app.tasks.celery_app import celery_app
+    return celery_app
+
+async def get_worker_metrics() -> Dict[str, Any]:
+    """获取 Worker 指标"""
+    try:
+        app = get_celery_app()
+        
+        # 获取活跃 Worker
+        inspect = app.control.inspect()
+        
+        # 获取活跃任务
+        active = inspect.active() or {}
+        active_workers = len(active)
+        
+        # 获取预定任务
+        reserved = inspect.reserved() or {}
+        pending_tasks = sum(len(tasks) for tasks in reserved.values())
+        
+        # 获取队列长度
+        queues = await get_queue_lengths()
+        
+        # 获取失败率（最近 1 小时）
+        failure_rate = await get_failure_rate_1h()
+        
+        # 状态判断
+        status = "healthy"
+        if active_workers == 0:
+            status = "unhealthy"
+        if failure_rate > 5:  # 失败率超过 5%
+            status = "warning"
+        
+        return {
+            "status": status,
+            "active_workers": active_workers,
+            "queue_length": sum(q["pending"] for q in queues),
+            "pending_tasks": pending_tasks,
+            "failure_rate_1h": round(failure_rate, 2),
+            "queues": queues,
+        }
+    except Exception as e:
+        return {
+            "status": "unhealthy",
+            "error": str(e),
+        }
+
+async def get_queue_lengths() -> List[Dict[str, Any]]:
+    """获取各队列长度"""
+    try:
+        app = get_celery_app()
+        inspect = app.control.inspect()
+        
+        # 获取各队列的预定任务
+        reserved = inspect.reserved() or {}
+        
+        # 按队列分组统计
+        queue_stats = {}
+        for worker, tasks in reserved.items():
+            for task in tasks:
+                queue = task.get('delivery_info', {}).get('routing_key', 'default')
+                if queue not in queue_stats:
+                    queue_stats[queue] = {
+                        "name": queue,
+                        "pending": 0,
+                        "active": 0,
+                        "failed": 0,
+                        "avg_duration_ms": 0,
+                    }
+                queue_stats[queue]["pending"] += 1
+        
+        # 获取活跃任务
+        active = inspect.active() or {}
+        for worker, tasks in active.items():
+            for task in tasks:
+                queue = task.get('delivery_info', {}).get('routing_key', 'default')
+                if queue in queue_stats:
+                    queue_stats[queue]["active"] += 1
+        
+        return list(queue_stats.values())
+    except Exception as e:
+        return []
+
+async def get_failure_rate_1h() -> float:
+    """获取最近 1 小时的任务失败率"""
+    try:
+        # 这里需要从数据库或 Redis 查询任务历史
+        # 示例：查询最近 1 小时的任务统计
+        # total_tasks = ...
+        # failed_tasks = ...
+        # return (failed_tasks / total_tasks * 100) if total_tasks > 0 else 0
+        return 0.5  # 临时返回值
+    except Exception:
+        return 0.0
+```
+
+### D.5 综合系统健康 API
+
+```python
+# backend/app/api/v1/admin/endpoints/observability.py
+
+@router.get("/system/health")
+async def get_system_health(
+    current_user: User = Depends(deps.get_current_superuser),
+) -> Response:
+    """获取系统健康状态"""
+    from app.services.observability import system_monitor, db_monitor, redis_monitor, worker_monitor
+    
+    # 并行获取各项指标
+    cpu_metrics = system_monitor.get_cpu_metrics()
+    memory_metrics = system_monitor.get_memory_metrics()
+    disk_metrics = system_monitor.get_disk_metrics()
+    
+    db_metrics = await db_monitor.get_database_metrics()
+    redis_metrics = await redis_monitor.get_redis_metrics()
+    worker_metrics = await worker_monitor.get_worker_metrics()
+    
+    return success(data={
+        "cpu": cpu_metrics,
+        "memory": memory_metrics,
+        "disk": disk_metrics,
+        "database": db_metrics,
+        "redis": redis_metrics,
+        "worker": worker_metrics,
+    })
+
+@router.get("/system/slow-queries")
+async def get_slow_queries(
+    time_range: Literal["today", "week", "month", "custom"] = Query("today"),
+    start_time: datetime | None = Query(None),
+    end_time: datetime | None = Query(None),
+    threshold_ms: int = Query(1000, ge=100),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    current_user: User = Depends(deps.get_current_superuser),
+) -> Response:
+    """获取慢查询列表"""
+    from app.services.observability import db_monitor
+    
+    queries = await db_monitor.get_slow_queries(threshold_ms=threshold_ms)
+    
+    # 分页
+    total = len(queries)
+    start_idx = (page - 1) * page_size
+    end_idx = start_idx + page_size
+    paginated_queries = queries[start_idx:end_idx]
+    
+    return success(data={
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "data": paginated_queries,
+    })
+
+@router.get("/system/workers")
+async def get_worker_status(
+    current_user: User = Depends(deps.get_current_superuser),
+) -> Response:
+    """获取 Worker 状态"""
+    from app.services.observability import worker_monitor
+    
+    worker_metrics = await worker_monitor.get_worker_metrics()
+    
+    return success(data=worker_metrics)
+```
+
+### D.6 前端组件实现示例
+
+```typescript
+// frontend/app/(dashboard)/observability/_components/system-health-card.tsx
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Progress } from "@/components/ui/progress"
+
+interface SystemHealthCardProps {
+  title: string
+  icon: React.ReactNode
+  value: number
+  unit: string
+  status: "normal" | "warning" | "danger" | "healthy" | "unhealthy"
+  subtitle?: string
+  extra?: React.ReactNode
+}
+
+export function SystemHealthCard({
+  title,
+  icon,
+  value,
+  unit,
+  status,
+  subtitle,
+  extra,
+}: SystemHealthCardProps) {
+  const statusColors = {
+    normal: "text-green-600 bg-green-100",
+    healthy: "text-green-600 bg-green-100",
+    warning: "text-yellow-600 bg-yellow-100",
+    danger: "text-red-600 bg-red-100",
+    unhealthy: "text-red-600 bg-red-100",
+  }
+
+  const statusLabels = {
+    normal: "正常",
+    healthy: "正常",
+    warning: "警告",
+    danger: "危险",
+    unhealthy: "异常",
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <Badge variant="secondary" className={statusColors[status]}>
+          {statusLabels[status]}
+        </Badge>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center space-x-4">
+          <div className="p-2 bg-gray-100 rounded-lg">
+            {icon}
+          </div>
+          <div className="flex-1">
+            <div className="text-2xl font-bold">
+              {value}
+              <span className="text-sm font-normal text-gray-500 ml-1">
+                {unit}
+              </span>
+            </div>
+            {subtitle && (
+              <p className="text-xs text-gray-500">{subtitle}</p>
+            )}
+          </div>
+        </div>
+        {extra && <div className="mt-4">{extra}</div>}
+      </CardContent>
+    </Card>
+  )
+}
+
+// 使用示例
+export function CpuHealthCard({ cpu }: { cpu: CpuMetrics }) {
+  return (
+    <SystemHealthCard
+      title="CPU 使用率"
+      icon={<Cpu className="h-4 w-4" />}
+      value={cpu.usage_percent}
+      unit="%"
+      status={cpu.status}
+      subtitle={`${cpu.cores} 核心 • 平均 ${cpu.avg_1h}%`}
+      extra={
+        <Progress
+          value={cpu.usage_percent}
+          className="h-2"
+          indicatorClassName={
+            cpu.status === "danger"
+              ? "bg-red-500"
+              : cpu.status === "warning"
+              ? "bg-yellow-500"
+              : "bg-green-500"
+          }
+        />
+      }
+    />
+  )
+}
+```
+
+---
+
+**附录版本**: 1.0  
+**更新时间**: 2026-05-28  
+**说明**: 本附录提供了系统健康监控的详细实现代码，可直接用于后端服务开发。

--- a/docs/plan/observability/01-backend-implementation.md
+++ b/docs/plan/observability/01-backend-implementation.md
@@ -1,0 +1,844 @@
+# 后端实施详细指南
+
+## 目录
+1. [数据库查询实现](#数据库查询实现)
+2. [API 端点实现](#api-端点实现)
+3. [服务层实现](#服务层实现)
+4. [性能优化](#性能优化)
+
+---
+
+## 1. 数据库查询实现
+
+### 1.1 基础索引创建
+
+```sql
+-- 为 Message 表添加性能索引
+CREATE INDEX IF NOT EXISTS idx_message_created_at_agent 
+ON messages(created_at DESC, conversation_id) 
+WHERE is_active = true;
+
+CREATE INDEX IF NOT EXISTS idx_message_duration_status 
+ON messages(duration_ms, round_status, created_at DESC) 
+WHERE is_active = true AND is_round_canonical = true;
+
+-- 为 Conversation 表添加索引
+CREATE INDEX IF NOT EXISTS idx_conversation_agent_created 
+ON conversations(agent_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_created_at 
+ON conversations(created_at DESC);
+```
+
+### 1.2 核心聚合查询
+
+#### 1.2.1 概览指标查询
+
+```python
+# backend/app/services/observability/queries.py
+
+from datetime import datetime, timedelta
+from typing import Dict, Any
+from tortoise import Tortoise
+from tortoise.expressions import Q, F
+from tortoise.functions import Count, Avg
+from app.models.agent import Message, Conversation, MessageRoundStatus
+
+async def get_overview_metrics(
+    start_time: datetime,
+    end_time: datetime,
+    team_id: str | None = None
+) -> Dict[str, Any]:
+    """获取概览指标"""
+    
+    # 构建基础查询条件
+    base_filter = Q(
+        created_at__gte=start_time,
+        created_at__lte=end_time,
+        is_active=True,
+        is_round_canonical=True,
+        round_role="assistant_final"
+    )
+    
+    if team_id:
+        base_filter &= Q(conversation__agent__team_id=team_id)
+    
+    # 总请求数
+    total_requests = await Message.filter(base_filter).count()
+    
+    # 成功请求数
+    success_count = await Message.filter(
+        base_filter,
+        round_status=MessageRoundStatus.COMPLETED
+    ).count()
+    
+    # 超时请求数
+    timeout_count = await Message.filter(
+        base_filter,
+        round_status__in=[
+            MessageRoundStatus.ERROR,
+            MessageRoundStatus.MANUALLY_STOPPED
+        ]
+    ).count()
+    
+    # 计算环比（与前一周期对比）
+    period_duration = end_time - start_time
+    prev_start = start_time - period_duration
+    prev_end = start_time
+    
+    prev_filter = Q(
+        created_at__gte=prev_start,
+        created_at__lte=prev_end,
+        is_active=True,
+        is_round_canonical=True,
+        round_role="assistant_final"
+    )
+    if team_id:
+        prev_filter &= Q(conversation__agent__team_id=team_id)
+    
+    prev_total = await Message.filter(prev_filter).count()
+    
+    # 计算增长率
+    growth_rate = 0.0
+    if prev_total > 0:
+        growth_rate = ((total_requests - prev_total) / prev_total) * 100
+    
+    # 响应时间（需要原始数据计算分位数）
+    durations = await Message.filter(
+        base_filter,
+        duration_ms__isnull=False
+    ).values_list('duration_ms', flat=True)
+    
+    p50 = calculate_percentile(durations, 50) if durations else 0
+    
+    # 超时率
+    timeout_rate = (timeout_count / total_requests * 100) if total_requests > 0 else 0
+    
+    return {
+        "total_requests": total_requests,
+        "total_requests_growth": round(growth_rate, 2),
+        "success_count": success_count,
+        "timeout_count": timeout_count,
+        "timeout_rate": round(timeout_rate, 2),
+        "avg_response_time_p50": p50,
+    }
+
+
+def calculate_percentile(values: list[int], percentile: int) -> int:
+    """计算分位数"""
+    if not values:
+        return 0
+    sorted_values = sorted(values)
+    index = int(len(sorted_values) * percentile / 100)
+    return sorted_values[min(index, len(sorted_values) - 1)]
+```
+
+#### 1.2.2 Agent 性能查询
+
+```python
+async def get_agent_performance(
+    start_time: datetime,
+    end_time: datetime,
+    agent_ids: list[str] | None = None,
+    team_id: str | None = None,
+    sort_by: str = "request_count",
+    sort_order: str = "desc",
+    page: int = 1,
+    page_size: int = 20
+) -> Dict[str, Any]:
+    """获取 Agent 性能数据"""
+    
+    # 构建查询
+    base_filter = Q(
+        created_at__gte=start_time,
+        created_at__lte=end_time,
+        is_active=True,
+        is_round_canonical=True,
+        round_role="assistant_final"
+    )
+    
+    if team_id:
+        base_filter &= Q(conversation__agent__team_id=team_id)
+    
+    if agent_ids:
+        base_filter &= Q(conversation__agent_id__in=agent_ids)
+    
+    # 按 Agent 分组统计
+    messages = await Message.filter(base_filter).prefetch_related(
+        'conversation__agent',
+        'conversation__agent__team'
+    ).all()
+    
+    # 按 Agent 聚合
+    agent_stats = {}
+    for msg in messages:
+        agent_id = str(msg.conversation.agent.id)
+        if agent_id not in agent_stats:
+            agent_stats[agent_id] = {
+                "agent_id": agent_id,
+                "agent_name": msg.conversation.agent.name,
+                "team_name": msg.conversation.agent.team.name if msg.conversation.agent.team else "N/A",
+                "durations": [],
+                "request_count": 0,
+                "success_count": 0,
+                "timeout_count": 0,
+                "total_tokens": 0,
+            }
+        
+        stats = agent_stats[agent_id]
+        stats["request_count"] += 1
+        
+        if msg.round_status == MessageRoundStatus.COMPLETED:
+            stats["success_count"] += 1
+        elif msg.round_status in [MessageRoundStatus.ERROR, MessageRoundStatus.MANUALLY_STOPPED]:
+            stats["timeout_count"] += 1
+        
+        if msg.duration_ms:
+            stats["durations"].append(msg.duration_ms)
+        
+        if msg.token_usage:
+            stats["total_tokens"] += msg.token_usage.get("prompt", 0) + msg.token_usage.get("completion", 0)
+    
+    # 计算分位数和派生指标
+    result_data = []
+    for agent_id, stats in agent_stats.items():
+        durations = stats["durations"]
+        result_data.append({
+            "agent_id": stats["agent_id"],
+            "agent_name": stats["agent_name"],
+            "team_name": stats["team_name"],
+            "request_count": stats["request_count"],
+            "p50": calculate_percentile(durations, 50),
+            "p90": calculate_percentile(durations, 90),
+            "p95": calculate_percentile(durations, 95),
+            "p99": calculate_percentile(durations, 99),
+            "timeout_count": stats["timeout_count"],
+            "timeout_rate": round(stats["timeout_count"] / stats["request_count"] * 100, 2) if stats["request_count"] > 0 else 0,
+            "success_count": stats["success_count"],
+            "success_rate": round(stats["success_count"] / stats["request_count"] * 100, 2) if stats["request_count"] > 0 else 0,
+            "avg_tokens": round(stats["total_tokens"] / stats["request_count"], 0) if stats["request_count"] > 0 else 0,
+        })
+    
+    # 排序
+    sort_key_map = {
+        "request_count": "request_count",
+        "p50": "p50",
+        "p90": "p90",
+        "p95": "p95",
+        "timeout_rate": "timeout_rate",
+    }
+    sort_key = sort_key_map.get(sort_by, "request_count")
+    result_data.sort(key=lambda x: x[sort_key], reverse=(sort_order == "desc"))
+    
+    # 分页
+    total = len(result_data)
+    start_idx = (page - 1) * page_size
+    end_idx = start_idx + page_size
+    paginated_data = result_data[start_idx:end_idx]
+    
+    return {
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "data": paginated_data
+    }
+```
+
+#### 1.2.3 时间序列查询
+
+```python
+async def get_request_trend(
+    start_time: datetime,
+    end_time: datetime,
+    granularity: str = "hour",  # hour | day
+    team_id: str | None = None
+) -> Dict[str, Any]:
+    """获取请求量趋势"""
+    
+    # 根据粒度确定时间分组
+    if granularity == "hour":
+        time_format = "%Y-%m-%d %H:00:00"
+        delta = timedelta(hours=1)
+    else:  # day
+        time_format = "%Y-%m-%d 00:00:00"
+        delta = timedelta(days=1)
+    
+    base_filter = Q(
+        created_at__gte=start_time,
+        created_at__lte=end_time,
+        is_active=True,
+        is_round_canonical=True,
+        round_role="assistant_final"
+    )
+    
+    if team_id:
+        base_filter &= Q(conversation__agent__team_id=team_id)
+    
+    messages = await Message.filter(base_filter).values_list('created_at', flat=True)
+    
+    # 按时间分组
+    time_buckets = {}
+    current = start_time
+    while current <= end_time:
+        bucket_key = current.strftime(time_format)
+        time_buckets[bucket_key] = 0
+        current += delta
+    
+    for created_at in messages:
+        bucket_key = created_at.strftime(time_format)
+        if bucket_key in time_buckets:
+            time_buckets[bucket_key] += 1
+    
+    # 转换为列表
+    data = [
+        {"timestamp": key, "count": value}
+        for key, value in sorted(time_buckets.items())
+    ]
+    
+    return {"data": data}
+```
+
+#### 1.2.4 超时事件查询
+
+```python
+async def get_timeout_events(
+    start_time: datetime,
+    end_time: datetime,
+    timeout_type: str | None = None,  # idle | global
+    agent_ids: list[str] | None = None,
+    page: int = 1,
+    page_size: int = 20
+) -> Dict[str, Any]:
+    """获取超时事件列表
+    
+    注意：timeout_type 需要从日志系统获取，这里简化为从 round_status 推断
+    """
+    
+    base_filter = Q(
+        created_at__gte=start_time,
+        created_at__lte=end_time,
+        is_active=True,
+        is_round_canonical=True,
+        round_role="assistant_final",
+        round_status__in=[MessageRoundStatus.ERROR, MessageRoundStatus.MANUALLY_STOPPED]
+    )
+    
+    if agent_ids:
+        base_filter &= Q(conversation__agent_id__in=agent_ids)
+    
+    # 查询超时消息
+    total = await Message.filter(base_filter).count()
+    
+    messages = await Message.filter(base_filter).prefetch_related(
+        'conversation__agent',
+        'conversation__agent__model__model'
+    ).order_by('-created_at').offset((page - 1) * page_size).limit(page_size)
+    
+    data = []
+    for msg in messages:
+        agent = msg.conversation.agent
+        model_name = "N/A"
+        if agent.model and agent.model.model:
+            model_name = f"{agent.model.model.provider}/{agent.model.model.model_id}"
+        
+        # 简化：根据 duration 推断超时类型
+        # 实际应该从日志系统查询
+        timeout_type_inferred = "idle" if msg.duration_ms and msg.duration_ms < 3600000 else "global"
+        
+        data.append({
+            "timestamp": msg.created_at.isoformat(),
+            "agent_id": str(agent.id),
+            "agent_name": agent.name,
+            "timeout_type": timeout_type_inferred,
+            "timeout_threshold": 180 if timeout_type_inferred == "idle" else 3600,
+            "actual_duration": msg.duration_ms // 1000 if msg.duration_ms else 0,
+            "model_name": model_name,
+            "conversation_id": str(msg.conversation_id),
+        })
+    
+    return {
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "data": data
+    }
+```
+
+---
+
+## 2. API 端点实现
+
+### 2.1 路由结构
+
+```python
+# backend/app/api/v1/admin/endpoints/observability.py
+
+from fastapi import APIRouter, Depends, Query
+from datetime import datetime, timedelta
+from typing import Literal
+from uuid import UUID
+
+from app.api import deps
+from app.models.user import User
+from app.schemas.response import Response, success
+from app.services.observability import queries
+
+router = APIRouter()
+
+
+def parse_time_range(
+    time_range: Literal["today", "week", "month", "custom"],
+    start_time: datetime | None = None,
+    end_time: datetime | None = None
+) -> tuple[datetime, datetime]:
+    """解析时间范围"""
+    now = datetime.utcnow()
+    
+    if time_range == "today":
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        end = now
+    elif time_range == "week":
+        start = now - timedelta(days=7)
+        end = now
+    elif time_range == "month":
+        start = now - timedelta(days=30)
+        end = now
+    elif time_range == "custom":
+        if not start_time or not end_time:
+            raise ValueError("start_time and end_time required for custom range")
+        start = start_time
+        end = end_time
+    else:
+        raise ValueError(f"Invalid time_range: {time_range}")
+    
+    return start, end
+```
+
+### 2.2 概览端点
+
+```python
+@router.get("/overview")
+async def get_overview(
+    time_range: Literal["today", "week", "month", "custom"] = Query("today"),
+    start_time: datetime | None = Query(None),
+    end_time: datetime | None = Query(None),
+    current_user: User = Depends(deps.get_current_superuser),
+) -> Response:
+    """获取概览指标"""
+    
+    start, end = parse_time_range(time_range, start_time, end_time)
+    
+    metrics = await queries.get_overview_metrics(start, end)
+    
+    return success(data=metrics)
+```
+
+### 2.3 Agent 性能端点
+
+```python
+@router.get("/agents")
+async def get_agent_performance(
+    time_range: Literal["today", "week", "month", "custom"] = Query("today"),
+    start_time: datetime | None = Query(None),
+    end_time: datetime | None = Query(None),
+    agent_ids: str | None = Query(None, description="Comma-separated UUIDs"),
+    sort_by: Literal["request_count", "p50", "p90", "p95", "timeout_rate"] = Query("request_count"),
+    sort_order: Literal["asc", "desc"] = Query("desc"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    current_user: User = Depends(deps.get_current_superuser),
+) -> Response:
+    """获取 Agent 性能数据"""
+    
+    start, end = parse_time_range(time_range, start_time, end_time)
+    
+    agent_id_list = None
+    if agent_ids:
+        agent_id_list = [aid.strip() for aid in agent_ids.split(",")]
+    
+    result = await queries.get_agent_performance(
+        start, end,
+        agent_ids=agent_id_list,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        page=page,
+        page_size=page_size
+    )
+    
+    return success(data=result)
+```
+
+### 2.4 趋势端点
+
+```python
+@router.get("/request-trend")
+async def get_request_trend(
+    time_range: Literal["today", "week", "month", "custom"] = Query("today"),
+    start_time: datetime | None = Query(None),
+    end_time: datetime | None = Query(None),
+    granularity: Literal["hour", "day"] = Query("hour"),
+    current_user: User = Depends(deps.get_current_superuser),
+) -> Response:
+    """获取请求量趋势"""
+    
+    start, end = parse_time_range(time_range, start_time, end_time)
+    
+    result = await queries.get_request_trend(start, end, granularity)
+    
+    return success(data=result)
+
+
+@router.get("/response-time-trend")
+async def get_response_time_trend(
+    time_range: Literal["today", "week", "month", "custom"] = Query("today"),
+    start_time: datetime | None = Query(None),
+    end_time: datetime | None = Query(None),
+    granularity: Literal["hour", "day"] = Query("hour"),
+    current_user: User = Depends(deps.get_current_superuser),
+) -> Response:
+    """获取响应时间趋势"""
+    
+    start, end = parse_time_range(time_range, start_time, end_time)
+    
+    # 类似 request_trend，但返回分位数
+    result = await queries.get_response_time_trend(start, end, granularity)
+    
+    return success(data=result)
+```
+
+### 2.5 超时事件端点
+
+```python
+@router.get("/timeouts")
+async def get_timeout_events(
+    time_range: Literal["today", "week", "month", "custom"] = Query("today"),
+    start_time: datetime | None = Query(None),
+    end_time: datetime | None = Query(None),
+    timeout_type: Literal["idle", "global"] | None = Query(None),
+    agent_ids: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    current_user: User = Depends(deps.get_current_superuser),
+) -> Response:
+    """获取超时事件列表"""
+    
+    start, end = parse_time_range(time_range, start_time, end_time)
+    
+    agent_id_list = None
+    if agent_ids:
+        agent_id_list = [aid.strip() for aid in agent_ids.split(",")]
+    
+    result = await queries.get_timeout_events(
+        start, end,
+        timeout_type=timeout_type,
+        agent_ids=agent_id_list,
+        page=page,
+        page_size=page_size
+    )
+    
+    return success(data=result)
+```
+
+### 2.6 注册路由
+
+```python
+# backend/app/api/v1/admin/api.py
+
+from fastapi import APIRouter
+from app.api.v1.admin.endpoints import observability
+
+api_router = APIRouter()
+
+# ... 其他路由
+
+api_router.include_router(
+    observability.router,
+    prefix="/observability",
+    tags=["admin-observability"]
+)
+```
+
+---
+
+## 3. 服务层实现
+
+### 3.1 缓存策略
+
+```python
+# backend/app/services/observability/cache.py
+
+from functools import wraps
+from datetime import datetime, timedelta
+import hashlib
+import json
+from typing import Any, Callable
+from app.core.redis import redis_client
+
+def cache_observability_query(ttl_seconds: int = 300):
+    """缓存可观测性查询结果"""
+    
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        async def wrapper(*args, **kwargs) -> Any:
+            # 生成缓存键
+            cache_key_data = {
+                "func": func.__name__,
+                "args": str(args),
+                "kwargs": str(sorted(kwargs.items()))
+            }
+            cache_key_str = json.dumps(cache_key_data, sort_keys=True)
+            cache_key = f"obs:{hashlib.md5(cache_key_str.encode()).hexdigest()}"
+            
+            # 尝试从缓存获取
+            cached = await redis_client.get(cache_key)
+            if cached:
+                return json.loads(cached)
+            
+            # 执行查询
+            result = await func(*args, **kwargs)
+            
+            # 写入缓存
+            await redis_client.setex(
+                cache_key,
+                ttl_seconds,
+                json.dumps(result, default=str)
+            )
+            
+            return result
+        
+        return wrapper
+    return decorator
+```
+
+### 3.2 应用缓存
+
+```python
+# 在 queries.py 中应用缓存
+
+from app.services.observability.cache import cache_observability_query
+
+@cache_observability_query(ttl_seconds=300)  # 5 分钟缓存
+async def get_overview_metrics(
+    start_time: datetime,
+    end_time: datetime,
+    team_id: str | None = None
+) -> Dict[str, Any]:
+    # ... 原有实现
+    pass
+```
+
+---
+
+## 4. 性能优化
+
+### 4.1 数据库连接池配置
+
+```python
+# backend/app/core/config.py
+
+class Settings(BaseSettings):
+    # ... 其他配置
+    
+    # 数据库连接池（针对可观测性查询）
+    DB_POOL_MIN_SIZE: int = 5
+    DB_POOL_MAX_SIZE: int = 20
+    DB_POOL_MAX_QUERIES: int = 50000
+    DB_POOL_MAX_INACTIVE_CONNECTION_LIFETIME: float = 300.0
+```
+
+### 4.2 查询优化建议
+
+1. **使用物化视图**（PostgreSQL 9.3+）
+
+```sql
+-- 创建每小时聚合的物化视图
+CREATE MATERIALIZED VIEW observability_hourly_stats AS
+SELECT 
+    date_trunc('hour', m.created_at) as hour,
+    c.agent_id,
+    COUNT(*) as request_count,
+    COUNT(*) FILTER (WHERE m.round_status = 'completed') as success_count,
+    COUNT(*) FILTER (WHERE m.round_status IN ('error', 'manually_stopped')) as timeout_count,
+    percentile_cont(0.5) WITHIN GROUP (ORDER BY m.duration_ms) as p50,
+    percentile_cont(0.9) WITHIN GROUP (ORDER BY m.duration_ms) as p90,
+    percentile_cont(0.95) WITHIN GROUP (ORDER BY m.duration_ms) as p95,
+    percentile_cont(0.99) WITHIN GROUP (ORDER BY m.duration_ms) as p99
+FROM messages m
+JOIN conversations c ON m.conversation_id = c.id
+WHERE m.is_active = true 
+  AND m.is_round_canonical = true 
+  AND m.round_role = 'assistant_final'
+GROUP BY hour, c.agent_id;
+
+-- 创建索引
+CREATE INDEX idx_obs_hourly_hour_agent ON observability_hourly_stats(hour, agent_id);
+
+-- 定时刷新（通过 Celery 任务）
+REFRESH MATERIALIZED VIEW CONCURRENTLY observability_hourly_stats;
+```
+
+2. **Celery 定时任务**
+
+```python
+# backend/app/tasks/observability.py
+
+from celery import shared_task
+from app.core.db import get_db_connection
+
+@shared_task
+def refresh_observability_materialized_view():
+    """刷新可观测性物化视图"""
+    conn = get_db_connection()
+    conn.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY observability_hourly_stats")
+    conn.close()
+
+
+# backend/app/core/celery_app.py
+
+from celery.schedules import crontab
+
+app.conf.beat_schedule = {
+    # ... 其他任务
+    'refresh-observability-stats': {
+        'task': 'app.tasks.observability.refresh_observability_materialized_view',
+        'schedule': crontab(minute='*/15'),  # 每 15 分钟刷新
+    },
+}
+```
+
+### 4.3 分页优化
+
+```python
+# 使用游标分页代替 offset/limit（大数据量时更高效）
+
+async def get_agent_performance_cursor(
+    start_time: datetime,
+    end_time: datetime,
+    cursor: str | None = None,
+    page_size: int = 20
+) -> Dict[str, Any]:
+    """使用游标分页的 Agent 性能查询"""
+    
+    base_filter = Q(
+        created_at__gte=start_time,
+        created_at__lte=end_time,
+        is_active=True,
+        is_round_canonical=True,
+        round_role="assistant_final"
+    )
+    
+    if cursor:
+        # 解码游标（这里简化为 agent_id）
+        base_filter &= Q(conversation__agent_id__gt=cursor)
+    
+    # ... 查询逻辑
+    
+    # 返回下一个游标
+    next_cursor = result_data[-1]["agent_id"] if result_data else None
+    
+    return {
+        "data": result_data,
+        "next_cursor": next_cursor,
+        "has_more": len(result_data) == page_size
+    }
+```
+
+---
+
+## 5. 测试
+
+### 5.1 单元测试示例
+
+```python
+# backend/tests/services/test_observability_queries.py
+
+import pytest
+from datetime import datetime, timedelta
+from app.services.observability import queries
+from app.models.agent import Message, Conversation, Agent, MessageRoundStatus
+
+@pytest.mark.asyncio
+async def test_get_overview_metrics(db):
+    """测试概览指标查询"""
+    
+    # 准备测试数据
+    agent = await Agent.create(name="Test Agent", team_id=...)
+    conversation = await Conversation.create(agent=agent, user_id=...)
+    
+    # 创建成功消息
+    await Message.create(
+        conversation=conversation,
+        role="assistant",
+        content="test",
+        round_status=MessageRoundStatus.COMPLETED,
+        duration_ms=1000,
+        is_round_canonical=True,
+        round_role="assistant_final"
+    )
+    
+    # 创建超时消息
+    await Message.create(
+        conversation=conversation,
+        role="assistant",
+        content="test",
+        round_status=MessageRoundStatus.ERROR,
+        duration_ms=5000,
+        is_round_canonical=True,
+        round_role="assistant_final"
+    )
+    
+    # 执行查询
+    end_time = datetime.utcnow()
+    start_time = end_time - timedelta(hours=1)
+    
+    result = await queries.get_overview_metrics(start_time, end_time)
+    
+    # 断言
+    assert result["total_requests"] == 2
+    assert result["success_count"] == 1
+    assert result["timeout_count"] == 1
+    assert result["timeout_rate"] == 50.0
+```
+
+### 5.2 API 集成测试
+
+```python
+# backend/tests/api/test_observability_api.py
+
+import pytest
+from httpx import AsyncClient
+from app.main import app
+
+@pytest.mark.asyncio
+async def test_get_overview_endpoint(client: AsyncClient, superuser_token_headers):
+    """测试概览端点"""
+    
+    response = await client.get(
+        "/api/v1/admin/observability/overview?time_range=today",
+        headers=superuser_token_headers
+    )
+    
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert "total_requests" in data
+    assert "timeout_rate" in data
+    assert "avg_response_time_p50" in data
+```
+
+---
+
+## 6. 部署检查清单
+
+- [ ] 数据库索引已创建
+- [ ] 物化视图已创建（如果使用）
+- [ ] Celery 定时任务已配置
+- [ ] Redis 缓存已启用
+- [ ] API 权限检查已实施
+- [ ] 单元测试已通过
+- [ ] 集成测试已通过
+- [ ] 性能测试已完成（查询响应时间 < 2s）
+- [ ] 文档已更新
+
+---
+
+**下一步**: 查看 [02-frontend-implementation.md](./02-frontend-implementation.md) 了解前端实施细节。


### PR DESCRIPTION
## Summary

- **P0**: Replace single-value HTTP timeout with fine-grained `httpx.Timeout` (connect/read/write) across all 7 chat adapters; raise global timeout from 30min to 60min
- **P1**: Increase idle timeout from 90s to 180s; set HTTP read timeout to 200s so application-layer idle timeout triggers first with a controlled error instead of HTTP SDK aborting
- **P2**: Add dynamic timeout for reasoning models (300s read timeout via `model_uses_reasoning_timeout`) and tool-enabled agents (90min global timeout via `_has_tool_runtime`); add structured logging with `timeout_type`/`timeout_seconds`

## Files changed

**Backend code (11 files):**
- `backend/app/core/config.py` — new timeout settings
- `backend/app/llm/adapters/chat/base.py` — `http_timeout` property with `httpx.Timeout`, reasoning model detection
- `backend/app/llm/adapters/chat/openai_adapter.py` (and 5 other adapters) — `self.timeout` → `self.http_timeout`
- `backend/app/api/v1/endpoints/chat.py` — structured timeout logging
- `backend/app/api/v1/endpoints/chat_helpers/config.py` — dynamic timeout for tool-enabled agents

**Docs (3 files):**
- `docs/analysis/timeout-analysis.md` — comprehensive timeout strategy analysis
- `docs/plan/admin-observability-dashboard.md` — observability dashboard design
- `docs/plan/observability/01-backend-implementation.md` — implementation guide

## Test plan

- [ ] Normal streaming conversation completes without false timeout
- [ ] Reasoning model (o1/o3) gets 300s read timeout automatically
- [ ] Agent with tools/memory gets 90min global timeout automatically
- [ ] Explicit `timeout`/`read_timeout` model config still takes priority
- [ ] Idle timeout (180s) triggers before HTTP read timeout (200s) with friendly error message
- [ ] Heartbeat still correctly detects client disconnection
- [ ] `ruff check` and `ruff format --check` pass

Closes YUN-72