### PR TITLE
Fix chat thought-chain scroll state

### DIFF
--- a/frontend/components/chat/chat-container.tsx
+++ b/frontend/components/chat/chat-container.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, useCallback, useMemo, useRef, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ArrowDown } from 'lucide-react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { cn } from '@/lib/utils';
@@ -90,6 +90,29 @@ export function ChatContainer({
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const isAtBottomRef = useRef(true);
   const [showScrollButton, setShowScrollButton] = useState(false);
+  const [chainOfThoughtOpenByMessageId, setChainOfThoughtOpenByMessageId] = useState<Record<string, boolean>>({});
+
+  const setChainOfThoughtOpen = useCallback((messageId: string, open: boolean) => {
+    setChainOfThoughtOpenByMessageId((current) => ({
+      ...current,
+      [messageId]: open,
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (!isStreaming || messages.length === 0) {
+      return;
+    }
+
+    const message = messages[messages.length - 1];
+    if (message.role !== 'assistant') {
+      return;
+    }
+
+    setChainOfThoughtOpenByMessageId((current) => (
+      message.id in current ? current : { ...current, [message.id]: true }
+    ));
+  }, [isStreaming, messages]);
 
   // Last text content for "do not snap during open code fence" rule
   const lastMessageText = useMemo(() => {
@@ -143,6 +166,8 @@ export function ChatContainer({
               ? (versionIndex) => onSwitchVersion(message.id, versionIndex)
               : undefined
           }
+          chainOfThoughtOpen={chainOfThoughtOpenByMessageId[message.id]}
+          onChainOfThoughtOpenChange={(open) => setChainOfThoughtOpen(message.id, open)}
           onSelectOption={onSelectOption}
           onOpenCodePreview={onOpenCodePreview}
           hideToolCalls={hideToolCalls}
@@ -165,6 +190,8 @@ export function ChatContainer({
       onSelectOption,
       onOpenCodePreview,
       hideToolCalls,
+      chainOfThoughtOpenByMessageId,
+      setChainOfThoughtOpen,
     ],
   );
 

--- a/frontend/components/chat/chat-container.tsx
+++ b/frontend/components/chat/chat-container.tsx
@@ -99,20 +99,19 @@ export function ChatContainer({
     }));
   }, []);
 
-  useEffect(() => {
-    if (!isStreaming || messages.length === 0) {
-      return;
-    }
+  const lastMessage = messages[messages.length - 1];
+  const lastMessageId = lastMessage?.id;
+  const lastMessageRole = lastMessage?.role;
 
-    const message = messages[messages.length - 1];
-    if (message.role !== 'assistant') {
+  useEffect(() => {
+    if (!isStreaming || !lastMessageId || lastMessageRole !== 'assistant') {
       return;
     }
 
     setChainOfThoughtOpenByMessageId((current) => (
-      message.id in current ? current : { ...current, [message.id]: true }
+      lastMessageId in current ? current : { ...current, [lastMessageId]: true }
     ));
-  }, [isStreaming, messages]);
+  }, [isStreaming, lastMessageId, lastMessageRole]);
 
   // Last text content for "do not snap during open code fence" rule
   const lastMessageText = useMemo(() => {

--- a/frontend/components/chat/message.tsx
+++ b/frontend/components/chat/message.tsx
@@ -416,6 +416,10 @@ export interface MessageProps extends React.HTMLAttributes<HTMLDivElement> {
   onOpenCodePreview?: (payload: CodePreviewPayload) => void
   /** Hide tool call cards and tool execution details */
   hideToolCalls?: boolean
+  /** Controlled open state for chain of thought */
+  chainOfThoughtOpen?: boolean
+  /** Callback when chain of thought open state changes */
+  onChainOfThoughtOpenChange?: (open: boolean) => void
   /** Called when this message starts speaking so the parent can scroll it into view */
   onRequestScrollIntoView?: () => void
 }
@@ -434,6 +438,8 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
       onSelectOption,
       onOpenCodePreview,
       hideToolCalls = false,
+      chainOfThoughtOpen,
+      onChainOfThoughtOpenChange,
       onRequestScrollIntoView,
       className,
       ...props
@@ -1160,7 +1166,12 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
             <MessageContent>
               {/* Chain of Thought: shows RAG, reasoning, tool calls, and generating steps in order */}
               {isAssistant && hasChainOfThought && (
-                <ChainOfThought isStreaming={isChainOfThoughtStreaming}>
+                <ChainOfThought
+                  isStreaming={isChainOfThoughtStreaming}
+                  open={chainOfThoughtOpen}
+                  onOpenChange={onChainOfThoughtOpenChange}
+                  defaultOpen={false}
+                >
                   <ChainOfThoughtHeader title={tReasoning('thought')} />
                   <ChainOfThoughtContent>
                     {buildChainOfThoughtSteps()}


### PR DESCRIPTION
## Summary

* Keep chain-of-thought expansion state in the stable chat container keyed by message ID.
* Disable chat thought-chain auto-collapse so stream completion does not change virtualized row height and jump the scroll position.

## Test plan

- [X] `bun run lint`
- [X] `bun run build`
- [ ] Manual chat scroll verification after login

Closes clouisle/Clouisle#187<br>Linear: clouisle/Clouisle#187