### PR TITLE
Fix admin tool management copy

### DIFF
--- a/frontend/i18n/en/tools.json
+++ b/frontend/i18n/en/tools.json
@@ -3,8 +3,8 @@
     "common": {
       "openMenu": "Open menu"
     },
-    "title": "Capability Management",
-    "description": "Manage tools and Skills across teams",
+    "title": "Tool Management",
+    "description": "Manage tools across teams",
     "tabs": {
       "tools": "Tools",
       "skills": "Skills"

--- a/frontend/i18n/zh/tools.json
+++ b/frontend/i18n/zh/tools.json
@@ -3,8 +3,8 @@
     "common": {
       "openMenu": "打开菜单"
     },
-    "title": "能力管理",
-    "description": "管理跨团队的工具和 Skills",
+    "title": "工具管理",
+    "description": "管理跨团队的工具",
     "tabs": {
       "tools": "工具",
       "skills": "Skills"


### PR DESCRIPTION
## Summary
- Rename the admin tools page title from capability management to tool management in Chinese and English.
- Update the admin tools page description so it only refers to tools.

## Test plan
- [x] bun run --cwd frontend i18n:lint

Linear: YUN-86
Closes #200