### PR TITLE
Add embed API key shortcut (YUN-87)

### DIFF
--- a/frontend/app/(platform)/app/apps/[id]/_components/embed-config-dialog.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/_components/embed-config-dialog.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import * as React from 'react'
+import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { Copy, Check } from 'lucide-react'
 import { toast } from 'sonner'
@@ -12,7 +13,7 @@ import {
   normalizeValidationErrors,
 } from '@/lib/api'
 import { workflowsApi, type Workflow } from '@/lib/api/workflows'
-import { Button } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
@@ -365,7 +366,15 @@ export function EmbedConfigDialog({ open, onOpenChange, agent, workflow, onUpdat
 
                 {/* API Key input */}
                 <div className="space-y-2">
-                  <Label className="text-xs text-muted-foreground">{t('apiKey')}</Label>
+                  <div className="flex items-center justify-between gap-3">
+                    <Label className="text-xs text-muted-foreground">{t('apiKey')}</Label>
+                    <Link
+                      href="/app/api-keys"
+                      className={buttonVariants({ variant: 'outline', size: 'xs' })}
+                    >
+                      {t('manageApiKeys')}
+                    </Link>
+                  </div>
                   <Input
                     type="password"
                     value={apiKeyInput}

--- a/frontend/app/(platform)/app/apps/[id]/_components/embed-config-dialog.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/_components/embed-config-dialog.tsx
@@ -370,6 +370,8 @@ export function EmbedConfigDialog({ open, onOpenChange, agent, workflow, onUpdat
                     <Label className="text-xs text-muted-foreground">{t('apiKey')}</Label>
                     <Link
                       href="/app/api-keys"
+                      target="_blank"
+                      rel="noopener noreferrer"
                       className={buttonVariants({ variant: 'outline', size: 'xs' })}
                     >
                       {t('manageApiKeys')}

--- a/frontend/i18n/en/embed.json
+++ b/frontend/i18n/en/embed.json
@@ -28,6 +28,7 @@
       "bubbleGreetingPlaceholder": "Hi! How can I help you?",
       "apiKey": "API Key",
       "apiKeyDescription": "Paste your API key here. It will be included in the code snippet below.",
+      "manageApiKeys": "Manage API Keys",
       "codeSnippet": "Code Snippet",
       "codeSnippetDescription": "Copy and paste this code into your website",
       "copied": "Copied!",

--- a/frontend/i18n/types/embed.ts
+++ b/frontend/i18n/types/embed.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-29T17:26:33.338Z
+// GENERATED — 2026-05-29T19:06:47.779Z
 // Source: i18n/en/embed.json
 export type EmbedMessages = {
   embed: {
@@ -30,6 +30,7 @@ export type EmbedMessages = {
       bubbleGreetingPlaceholder: string
       apiKey: string
       apiKeyDescription: string
+      manageApiKeys: string
       codeSnippet: string
       codeSnippetDescription: string
       copied: string

--- a/frontend/i18n/zh/embed.json
+++ b/frontend/i18n/zh/embed.json
@@ -28,6 +28,7 @@
       "bubbleGreetingPlaceholder": "你好！有什么可以帮你的？",
       "apiKey": "API 密钥",
       "apiKeyDescription": "粘贴你的 API 密钥，它会自动填入下方代码片段中。",
+      "manageApiKeys": "管理 API 密钥",
       "codeSnippet": "代码片段",
       "codeSnippetDescription": "复制并粘贴此代码到你的网站",
       "copied": "已复制！",


### PR DESCRIPTION
## Summary
- Add a quick jump from Agent/workflow embed API Key configuration to platform API key management.
- Add matching English and Chinese i18n entries and regenerate the embed translation type.

## Test plan
- [x] node scripts/lint-translations.ts --strict
- [x] bun run lint
- [x] bun run build
- [ ] Browser click-through blocked locally by login requirement

Closes #201.