### PR TITLE
Address KB bulk action review comments

### DIFF
--- a/backend/app/api/v1/endpoints/knowledge_bases.py
+++ b/backend/app/api/v1/endpoints/knowledge_bases.py
@@ -1387,7 +1387,7 @@ async def retry_failed_chunk(
 
     doc.status = DocumentStatus.PROCESSING.value
     doc.error_message = None  # type: ignore[assignment]
-    await doc.save()
+    await doc.save(update_fields=["status", "error_message"])
 
     try:
         from app.tasks.knowledge_base import retry_failed_chunk_task
@@ -1399,7 +1399,7 @@ async def retry_failed_chunk(
         logger.warning("Celery task not dispatched - worker may not be running")
         doc.status = DocumentStatus.ERROR.value
         doc.error_message = "task_dispatch_failed"
-        await doc.save()
+        await doc.save(update_fields=["status", "error_message"])
 
     doc = await Document.get(id=doc_id).prefetch_related("uploaded_by")
     return success(

--- a/backend/app/tasks/knowledge_base.py
+++ b/backend/app/tasks/knowledge_base.py
@@ -1438,13 +1438,17 @@ def retry_failed_chunk_task(self, document_id: str, chunk_id: str) -> dict:
             _clear_task_metadata(document)
             await document.save()
 
-            stats = await Document.filter(
-                knowledge_base_id=kb.id,
-                status=DocumentStatus.COMPLETED.value,
-            ).annotate(
-                sum_chunks=Sum("chunk_count"),
-                sum_tokens=Sum("token_count"),
-            ).values("sum_chunks", "sum_tokens")
+            stats = (
+                await Document.filter(
+                    knowledge_base_id=kb.id,
+                    status=DocumentStatus.COMPLETED.value,
+                )
+                .annotate(
+                    sum_chunks=Sum("chunk_count"),
+                    sum_tokens=Sum("token_count"),
+                )
+                .values("sum_chunks", "sum_tokens")
+            )
             kb.total_chunks = stats[0].get("sum_chunks") or 0 if stats else 0
             kb.total_tokens = stats[0].get("sum_tokens") or 0 if stats else 0
             await kb.save(update_fields=["total_chunks", "total_tokens"])

--- a/backend/app/tasks/knowledge_base.py
+++ b/backend/app/tasks/knowledge_base.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from celery import shared_task
+from tortoise.functions import Sum
 
 from app.core.i18n import t, get_default_language
 from app.models.knowledge_base import (
@@ -1437,12 +1438,15 @@ def retry_failed_chunk_task(self, document_id: str, chunk_id: str) -> dict:
             _clear_task_metadata(document)
             await document.save()
 
-            docs = await Document.filter(
+            stats = await Document.filter(
                 knowledge_base_id=kb.id,
                 status=DocumentStatus.COMPLETED.value,
-            ).all()
-            kb.total_chunks = sum(doc.chunk_count for doc in docs)
-            kb.total_tokens = sum(doc.token_count for doc in docs)
+            ).annotate(
+                sum_chunks=Sum("chunk_count"),
+                sum_tokens=Sum("token_count"),
+            ).values("sum_chunks", "sum_tokens")
+            kb.total_chunks = stats[0].get("sum_chunks") or 0 if stats else 0
+            kb.total_tokens = stats[0].get("sum_tokens") or 0 if stats else 0
             await kb.save()
 
             await _send_doc_indexed_notification(

--- a/backend/app/tasks/knowledge_base.py
+++ b/backend/app/tasks/knowledge_base.py
@@ -1447,7 +1447,7 @@ def retry_failed_chunk_task(self, document_id: str, chunk_id: str) -> dict:
             ).values("sum_chunks", "sum_tokens")
             kb.total_chunks = stats[0].get("sum_chunks") or 0 if stats else 0
             kb.total_tokens = stats[0].get("sum_tokens") or 0 if stats else 0
-            await kb.save()
+            await kb.save(update_fields=["total_chunks", "total_tokens"])
 
             await _send_doc_indexed_notification(
                 document=document,

--- a/frontend/app/(dashboard)/knowledge-bases/[id]/_components/documents-table.tsx
+++ b/frontend/app/(dashboard)/knowledge-bases/[id]/_components/documents-table.tsx
@@ -99,7 +99,7 @@ const BULK_ACTION_CONCURRENCY = 3
 
 async function runBulkActions<T>(items: T[], action: (item: T) => Promise<unknown>) {
   for (let index = 0; index < items.length; index += BULK_ACTION_CONCURRENCY) {
-    await Promise.all(items.slice(index, index + BULK_ACTION_CONCURRENCY).map(action))
+    await Promise.allSettled(items.slice(index, index + BULK_ACTION_CONCURRENCY).map(action))
   }
 }
 

--- a/frontend/app/(dashboard)/knowledge-bases/[id]/_components/documents-table.tsx
+++ b/frontend/app/(dashboard)/knowledge-bases/[id]/_components/documents-table.tsx
@@ -95,6 +95,14 @@ const docTypeIcons: Record<string, React.ReactNode> = {
   url: <Link className="h-4 w-4 text-purple-500" />,
 }
 
+const BULK_ACTION_CONCURRENCY = 3
+
+async function runBulkActions<T>(items: T[], action: (item: T) => Promise<unknown>) {
+  for (let index = 0; index < items.length; index += BULK_ACTION_CONCURRENCY) {
+    await Promise.all(items.slice(index, index + BULK_ACTION_CONCURRENCY).map(action))
+  }
+}
+
 export function DocumentsTable({ knowledgeBaseId, refreshTrigger, onRefresh }: DocumentsTableProps) {
   const t = useTranslations('knowledgeBases')
   const commonT = useTranslations('common')
@@ -270,7 +278,7 @@ export function DocumentsTable({ knowledgeBaseId, refreshTrigger, onRefresh }: D
 
     setIsBulkActionLoading(true)
     try {
-      await Promise.all(pendingDocs.map(doc => adminKnowledgeBasesApi.processDocument(knowledgeBaseId, doc.id)))
+      await runBulkActions(pendingDocs, doc => adminKnowledgeBasesApi.processDocument(knowledgeBaseId, doc.id))
       toast.success(t('processStarted', { count: pendingDocs.length }))
       setSelectedDocs(new Set())
       await loadDocuments(false)
@@ -287,7 +295,7 @@ export function DocumentsTable({ knowledgeBaseId, refreshTrigger, onRefresh }: D
 
     setIsBulkActionLoading(true)
     try {
-      await Promise.all(failedDocs.map(doc => adminKnowledgeBasesApi.retryFailedChunks(knowledgeBaseId, doc.id)))
+      await runBulkActions(failedDocs, doc => adminKnowledgeBasesApi.retryFailedChunks(knowledgeBaseId, doc.id))
       toast.success(t('retryStarted'))
       setSelectedDocs(new Set())
       await loadDocuments(false)

--- a/frontend/app/(platform)/app/kb/[id]/_components/documents-table.tsx
+++ b/frontend/app/(platform)/app/kb/[id]/_components/documents-table.tsx
@@ -98,7 +98,7 @@ const BULK_ACTION_CONCURRENCY = 3
 
 async function runBulkActions<T>(items: T[], action: (item: T) => Promise<unknown>) {
   for (let index = 0; index < items.length; index += BULK_ACTION_CONCURRENCY) {
-    await Promise.all(items.slice(index, index + BULK_ACTION_CONCURRENCY).map(action))
+    await Promise.allSettled(items.slice(index, index + BULK_ACTION_CONCURRENCY).map(action))
   }
 }
 

--- a/frontend/app/(platform)/app/kb/[id]/_components/documents-table.tsx
+++ b/frontend/app/(platform)/app/kb/[id]/_components/documents-table.tsx
@@ -94,6 +94,14 @@ const docTypeIcons: Record<string, React.ReactNode> = {
   url: <Link className="h-4 w-4 text-purple-500" />,
 }
 
+const BULK_ACTION_CONCURRENCY = 3
+
+async function runBulkActions<T>(items: T[], action: (item: T) => Promise<unknown>) {
+  for (let index = 0; index < items.length; index += BULK_ACTION_CONCURRENCY) {
+    await Promise.all(items.slice(index, index + BULK_ACTION_CONCURRENCY).map(action))
+  }
+}
+
 export function DocumentsTable({ knowledgeBaseId, refreshTrigger, onRefresh }: DocumentsTableProps) {
   const t = useTranslations('knowledgeBases')
   const commonT = useTranslations('common')
@@ -269,7 +277,7 @@ export function DocumentsTable({ knowledgeBaseId, refreshTrigger, onRefresh }: D
 
     setIsBulkActionLoading(true)
     try {
-      await Promise.all(pendingDocs.map(doc => knowledgeBasesApi.processDocument(knowledgeBaseId, doc.id)))
+      await runBulkActions(pendingDocs, doc => knowledgeBasesApi.processDocument(knowledgeBaseId, doc.id))
       toast.success(t('processStarted', { count: pendingDocs.length }))
       setSelectedDocs(new Set())
       await loadDocuments(false)
@@ -286,7 +294,7 @@ export function DocumentsTable({ knowledgeBaseId, refreshTrigger, onRefresh }: D
 
     setIsBulkActionLoading(true)
     try {
-      await Promise.all(failedDocs.map(doc => knowledgeBasesApi.retryFailedChunks(knowledgeBaseId, doc.id)))
+      await runBulkActions(failedDocs, doc => knowledgeBasesApi.retryFailedChunks(knowledgeBaseId, doc.id))
       toast.success(t('retryStarted'))
       setSelectedDocs(new Set())
       await loadDocuments(false)


### PR DESCRIPTION
## Summary
- Use database aggregation when recomputing KB chunk/token totals after single-chunk retry.
- Limit document bulk action requests to batches of 3 concurrent requests.
- Save single-chunk retry status updates with targeted `update_fields`.

## Test plan
- `uv run ruff check app/tasks/knowledge_base.py`
- `uv run ruff check app/api/v1/endpoints/knowledge_bases.py`
- `bun run lint -- app/(dashboard)/knowledge-bases/[id]/_components/documents-table.tsx app/(platform)/app/kb/[id]/_components/documents-table.tsx`