### PR TITLE
Fix thought-chain scroll flicker

### DIFF
--- a/frontend/components/ai-elements/chain-of-thought.tsx
+++ b/frontend/components/ai-elements/chain-of-thought.tsx
@@ -10,7 +10,7 @@ import {
   Loader2Icon,
   type LucideIcon,
 } from "lucide-react";
-import type { ComponentProps, ReactNode } from "react";
+import type { ComponentProps, ReactNode, WheelEvent } from "react";
 import { createContext, memo, useCallback, useContext, useEffect, useId, useMemo, useState } from "react";
 import { Shimmer } from "./shimmer";
 
@@ -143,11 +143,28 @@ export const ChainOfThoughtHeader = memo(
 ChainOfThoughtHeader.displayName = "ChainOfThoughtHeader";
 
 // Content container
-export type ChainOfThoughtContentProps = ComponentProps<"div">;
+export type ChainOfThoughtContentProps = ComponentProps<"div"> & {
+  containScroll?: boolean;
+};
 
 export const ChainOfThoughtContent = memo(
-  ({ className, children, ...props }: ChainOfThoughtContentProps) => {
+  ({ className, children, containScroll = false, onWheel, ...props }: ChainOfThoughtContentProps) => {
     const { isOpen, contentId } = useChainOfThought();
+
+    const handleWheel = useCallback((event: WheelEvent<HTMLDivElement>) => {
+      onWheel?.(event);
+      if (!containScroll || event.isPropagationStopped()) {
+        return;
+      }
+
+      const target = event.currentTarget;
+      const canScrollUp = target.scrollTop > 0;
+      const canScrollDown = target.scrollTop + target.clientHeight < target.scrollHeight;
+
+      if ((event.deltaY < 0 && canScrollUp) || (event.deltaY > 0 && canScrollDown)) {
+        event.stopPropagation();
+      }
+    }, [containScroll, onWheel]);
 
     return (
       <div
@@ -159,6 +176,7 @@ export const ChainOfThoughtContent = memo(
           !isOpen && "hidden",
           className
         )}
+        onWheel={handleWheel}
         {...props}
       >
         {children}

--- a/frontend/components/ai-elements/chain-of-thought.tsx
+++ b/frontend/components/ai-elements/chain-of-thought.tsx
@@ -10,8 +10,8 @@ import {
   Loader2Icon,
   type LucideIcon,
 } from "lucide-react";
-import type { ComponentProps, ReactNode, WheelEvent } from "react";
-import { createContext, memo, useCallback, useContext, useEffect, useId, useMemo, useState } from "react";
+import type { ComponentProps, ReactNode } from "react";
+import { createContext, memo, useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from "react";
 import { Shimmer } from "./shimmer";
 
 // Chain of Thought Context
@@ -150,24 +150,32 @@ export type ChainOfThoughtContentProps = ComponentProps<"div"> & {
 export const ChainOfThoughtContent = memo(
   ({ className, children, containScroll = false, onWheel, ...props }: ChainOfThoughtContentProps) => {
     const { isOpen, contentId } = useChainOfThought();
+    const ref = useRef<HTMLDivElement>(null);
 
-    const handleWheel = useCallback((event: WheelEvent<HTMLDivElement>) => {
-      onWheel?.(event);
-      if (!containScroll || event.isPropagationStopped()) {
+    useEffect(() => {
+      const element = ref.current;
+      if (!element || !containScroll) {
         return;
       }
 
-      const target = event.currentTarget;
-      const canScrollUp = target.scrollTop > 0;
-      const canScrollDown = target.scrollTop + target.clientHeight < target.scrollHeight;
+      const handleNativeWheel = (event: WheelEvent) => {
+        const canScrollUp = element.scrollTop > 0.5;
+        const canScrollDown = element.scrollHeight - element.scrollTop - element.clientHeight > 1;
 
-      if ((event.deltaY < 0 && canScrollUp) || (event.deltaY > 0 && canScrollDown)) {
-        event.stopPropagation();
-      }
-    }, [containScroll, onWheel]);
+        if ((event.deltaY < 0 && canScrollUp) || (event.deltaY > 0 && canScrollDown)) {
+          event.stopPropagation();
+        }
+      };
+
+      element.addEventListener("wheel", handleNativeWheel, { passive: true });
+      return () => {
+        element.removeEventListener("wheel", handleNativeWheel);
+      };
+    }, [containScroll]);
 
     return (
       <div
+        ref={ref}
         id={contentId}
         data-state={isOpen ? "open" : "closed"}
         className={cn(
@@ -176,7 +184,7 @@ export const ChainOfThoughtContent = memo(
           !isOpen && "hidden",
           className
         )}
-        onWheel={handleWheel}
+        onWheel={onWheel}
         {...props}
       >
         {children}

--- a/frontend/components/chat/chat-container.tsx
+++ b/frontend/components/chat/chat-container.tsx
@@ -60,7 +60,7 @@ const VirtuosoScroller = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
         ref={ref}
         style={style}
         className={cn(
-          'overflow-y-scroll overflow-x-hidden [overflow-anchor:none] [scrollbar-gutter:stable]',
+          'overflow-y-auto overflow-x-hidden [overflow-anchor:none] [scrollbar-gutter:stable]',
           className,
         )}
         {...props}

--- a/frontend/components/chat/chat-container.tsx
+++ b/frontend/components/chat/chat-container.tsx
@@ -60,7 +60,7 @@ const VirtuosoScroller = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
         ref={ref}
         style={style}
         className={cn(
-          'overflow-y-auto overflow-x-hidden [overflow-anchor:none]',
+          'overflow-y-scroll overflow-x-hidden [overflow-anchor:none] [scrollbar-gutter:stable]',
           className,
         )}
         {...props}

--- a/frontend/components/chat/message.tsx
+++ b/frontend/components/chat/message.tsx
@@ -1170,9 +1170,10 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
                   isStreaming={isChainOfThoughtStreaming}
                   open={chainOfThoughtOpen ?? false}
                   onOpenChange={onChainOfThoughtOpenChange}
+                  defaultOpen={false}
                 >
                   <ChainOfThoughtHeader title={tReasoning('thought')} />
-                  <ChainOfThoughtContent>
+                  <ChainOfThoughtContent containScroll className="max-h-80 overflow-y-auto pr-2 [scrollbar-gutter:stable]">
                     {buildChainOfThoughtSteps()}
                   </ChainOfThoughtContent>
                 </ChainOfThought>


### PR DESCRIPTION
## Summary
- Keep the virtualized chat scroller scrollbar gutter stable to avoid layout shifts.
- Contain expanded thought-chain scrolling inside the panel so wheel events do not trigger virtual-list recalculation until the inner panel reaches an edge.
- Disable chat thought-chain auto-collapse so normal scrolling does not change row height unexpectedly.

## Test plan
- [x] `bun run --cwd frontend lint`
- [x] `bun run --cwd frontend build`
- [ ] Manual authenticated chat scroll verification

Fixes YUN-83.