### PR TITLE
Remove chat virtual scrolling

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -34,7 +34,6 @@
         "react": "19.2.6",
         "react-dom": "19.2.6",
         "react-resizable-panels": "^4.0.15",
-        "react-virtuoso": "^4.18.7",
         "reactflow": "^11.11.4",
         "recharts": "^3.6.0",
         "shadcn": "^4.7.0",
@@ -1762,8 +1761,6 @@
     "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
 
     "react-resizable-panels": ["react-resizable-panels@4.0.15", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-+ygM/EI2h4Qc/cl2fasQ2qwOgNfpQwXLNTU5PqhhPerliX+wnbf7ejcqran7lz3BqABzjddf0pJ3j3G/+A0v9Q=="],
-
-    "react-virtuoso": ["react-virtuoso@4.18.7", "", { "peerDependencies": { "react": ">=16 || >=17 || >= 18 || >= 19", "react-dom": ">=16 || >=17 || >= 18 || >=19" } }, "sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g=="],
 
     "reactflow": ["reactflow@11.11.4", "", { "dependencies": { "@reactflow/background": "11.3.14", "@reactflow/controls": "11.2.14", "@reactflow/core": "11.11.4", "@reactflow/minimap": "11.7.14", "@reactflow/node-resizer": "2.2.14", "@reactflow/node-toolbar": "1.3.14" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og=="],
 

--- a/frontend/components/chat/chat-container.tsx
+++ b/frontend/components/chat/chat-container.tsx
@@ -28,6 +28,8 @@ interface ChatContainerProps {
   hideToolCalls?: boolean;
 }
 
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
 function hasOpenCodeFence(content: string) {
   let openFence: '`' | '~' | null = null;
   let openFenceLength = 0;
@@ -70,6 +72,7 @@ export function ChatContainer({
   const messageRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const isAtBottomRef = useRef(true);
   const [showScrollButton, setShowScrollButton] = useState(false);
+  const showScrollButtonRef = useRef(false);
   const [chainOfThoughtOpenByMessageId, setChainOfThoughtOpenByMessageId] = useState<Record<string, boolean>>({});
 
   const setChainOfThoughtOpen = useCallback((messageId: string, open: boolean) => {
@@ -110,7 +113,12 @@ export function ChatContainer({
 
     const atBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight < atBottomThreshold;
     isAtBottomRef.current = atBottom;
-    setShowScrollButton(!atBottom && messages.length > 0);
+
+    const nextShowButton = !atBottom && messages.length > 0;
+    if (showScrollButtonRef.current !== nextShowButton) {
+      showScrollButtonRef.current = nextShowButton;
+      setShowScrollButton(nextShowButton);
+    }
   }, [messages.length]);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
@@ -120,7 +128,7 @@ export function ChatContainer({
     scroller.scrollTo({ top: scroller.scrollHeight, behavior });
   }, []);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!autoScroll || !isAtBottomRef.current) {
       updateAtBottomState();
       return;

--- a/frontend/components/chat/chat-container.tsx
+++ b/frontend/components/chat/chat-container.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { ArrowDown } from 'lucide-react';
-import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Message } from './message';
@@ -53,26 +52,6 @@ function hasOpenCodeFence(content: string) {
   return openFence !== null;
 }
 
-const VirtuosoScroller = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  function VirtuosoScroller({ className, style, ...props }, ref) {
-    return (
-      <div
-        ref={ref}
-        style={style}
-        className={cn(
-          'overflow-y-auto overflow-x-hidden [overflow-anchor:none] [scrollbar-gutter:stable]',
-          className,
-        )}
-        {...props}
-      />
-    );
-  },
-);
-
-function VirtuosoFooter() {
-  return <div className="h-4" />;
-}
-
 export function ChatContainer({
   messages,
   className,
@@ -87,7 +66,8 @@ export function ChatContainer({
   onOpenCodePreview,
   hideToolCalls = false,
 }: ChatContainerProps) {
-  const virtuosoRef = useRef<VirtuosoHandle>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const messageRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const isAtBottomRef = useRef(true);
   const [showScrollButton, setShowScrollButton] = useState(false);
   const [chainOfThoughtOpenByMessageId, setChainOfThoughtOpenByMessageId] = useState<Record<string, boolean>>({});
@@ -122,30 +102,37 @@ export function ChatContainer({
       .join('');
   }, [messages]);
 
-  const scrollToBottom = useCallback(() => {
-    virtuosoRef.current?.scrollToIndex({
-      index: 'LAST',
-      behavior: 'smooth',
-    });
+  const atBottomThreshold = 24;
+
+  const updateAtBottomState = useCallback(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+
+    const atBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight < atBottomThreshold;
+    isAtBottomRef.current = atBottom;
+    setShowScrollButton(!atBottom && messages.length > 0);
+  }, [messages.length]);
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+
+    scroller.scrollTo({ top: scroller.scrollHeight, behavior });
   }, []);
 
-  const handleAtBottomStateChange = useCallback(
-    (atBottom: boolean) => {
-      isAtBottomRef.current = atBottom;
-      setShowScrollButton(!atBottom && messages.length > 0);
-    },
-    [messages.length],
-  );
+  useLayoutEffect(() => {
+    if (!autoScroll || !isAtBottomRef.current) {
+      updateAtBottomState();
+      return;
+    }
 
-  const followOutput = useCallback(
-    (isAtBottom: boolean) => {
-      if (!autoScroll) return false as const;
-      if (!isAtBottom) return false as const;
-      if (isStreaming && hasOpenCodeFence(lastMessageText)) return false as const;
-      return 'auto' as const;
-    },
-    [autoScroll, isStreaming, lastMessageText],
-  );
+    if (isStreaming && hasOpenCodeFence(lastMessageText)) {
+      updateAtBottomState();
+      return;
+    }
+
+    scrollToBottom('auto');
+  }, [autoScroll, isStreaming, lastMessageText, messages, scrollToBottom, updateAtBottomState]);
 
   const itemContent = useCallback(
     (index: number, message: ChatMessage) => {
@@ -170,13 +157,13 @@ export function ChatContainer({
           onSelectOption={onSelectOption}
           onOpenCodePreview={onOpenCodePreview}
           hideToolCalls={hideToolCalls}
-          onRequestScrollIntoView={() =>
-            virtuosoRef.current?.scrollToIndex({
-              index,
-              align: 'start',
-              behavior: 'smooth',
-            })
-          }
+          onRequestScrollIntoView={() => {
+            const scroller = scrollerRef.current;
+            const target = messageRefs.current[message.id];
+            if (!scroller || !target) return;
+
+            scroller.scrollTo({ top: target.offsetTop, behavior: 'smooth' });
+          }}
         />
       );
     },
@@ -194,8 +181,6 @@ export function ChatContainer({
     ],
   );
 
-  const computeItemKey = useCallback((_: number, message: ChatMessage) => message.id, []);
-
   if (messages.length === 0 && emptyState) {
     return (
       <div className={cn('h-full flex items-center justify-center', className)}>{emptyState}</div>
@@ -204,25 +189,30 @@ export function ChatContainer({
 
   return (
     <div className={cn('relative h-full', className)}>
-      <Virtuoso
-        ref={virtuosoRef}
-        data={messages}
-        itemContent={itemContent}
-        computeItemKey={computeItemKey}
-        initialTopMostItemIndex={Math.max(messages.length - 1, 0)}
-        followOutput={followOutput}
-        atBottomStateChange={handleAtBottomStateChange}
-        increaseViewportBy={{ top: 400, bottom: 400 }}
-        components={{ Scroller: VirtuosoScroller, Footer: VirtuosoFooter }}
-        className="absolute inset-0"
-      />
+      <div
+        ref={scrollerRef}
+        className="absolute inset-0 overflow-y-auto overflow-x-hidden [overflow-anchor:none] [scrollbar-gutter:stable]"
+        onScroll={updateAtBottomState}
+      >
+        {messages.map((message, index) => (
+          <div
+            key={message.id}
+            ref={(element) => {
+              messageRefs.current[message.id] = element;
+            }}
+          >
+            {itemContent(index, message)}
+          </div>
+        ))}
+        <div className="h-4" />
+      </div>
 
       {showScrollToBottom && showScrollButton && (
         <Button
           variant="outline"
           size="icon"
           className="absolute bottom-4 left-1/2 -translate-x-1/2 h-8 w-8 rounded-full shadow-md bg-background/95 backdrop-blur-sm border-border/50 hover:bg-accent"
-          onClick={scrollToBottom}
+          onClick={() => scrollToBottom()}
         >
           <ArrowDown className="h-4 w-4" />
         </Button>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,6 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-resizable-panels": "^4.0.15",
-    "react-virtuoso": "^4.18.7",
     "reactflow": "^11.11.4",
     "recharts": "^3.6.0",
     "shadcn": "^4.7.0",


### PR DESCRIPTION
## Summary
- Replace the chat message virtual list with a normal scroll container to avoid scroll progress jumps from dynamic message heights.
- Preserve bottom-following, scroll-to-bottom, and speech scroll-into-view behavior with DOM scroll handling.
- Remove the unused `react-virtuoso` dependency from frontend package files.

## Test plan
- [x] `rg -n "react-virtuoso|Virtuoso" frontend`
- [x] `bun run --cwd frontend lint`
- [x] `bun run --cwd frontend build`
- [x] `git diff --check`
- [ ] Manual authenticated chat scroll verification

Follow-up for YUN-83.