### PR TITLE
Allow superadmins to transfer team ownership

### DIFF
--- a/backend/app/api/v1/endpoints/teams.py
+++ b/backend/app/api/v1/endpoints/teams.py
@@ -519,7 +519,11 @@ async def transfer_ownership(
     new_owner_id: UUID,
     current_user: User = Depends(deps.PermissionChecker("team:manage")),
 ) -> Any:
-    """Transfer team ownership to another member. Only current owner can do this."""
+    """
+    Transfer team ownership to another member.
+
+    Only current owner or superuser can do this.
+    """
     team = await Team.filter(id=team_id).first()
     if not team:
         raise BusinessError(
@@ -529,12 +533,20 @@ async def transfer_ownership(
         )
 
     current_membership = await TeamMember.filter(team=team, user=current_user).first()
-    if not current_membership or current_membership.role != TeamMemberRole.OWNER:
+    if not current_user.is_superuser and (
+        not current_membership or current_membership.role != TeamMemberRole.OWNER
+    ):
         raise BusinessError(
             code=ResponseCode.TEAM_OWNER_REQUIRED,
             msg_key="team_owner_required",
             status_code=403,
         )
+
+    previous_owner_membership = (
+        await TeamMember.filter(team=team, role=TeamMemberRole.OWNER)
+        .prefetch_related("user")
+        .first()
+    )
 
     new_owner = await User.filter(id=new_owner_id).first()
     new_owner_membership = (
@@ -549,8 +561,12 @@ async def transfer_ownership(
             status_code=404,
         )
 
-    current_membership.role = TeamMemberRole.ADMIN
-    await current_membership.save()
+    old_owner = (
+        previous_owner_membership.user if previous_owner_membership else current_user
+    )
+    if previous_owner_membership:
+        previous_owner_membership.role = TeamMemberRole.ADMIN
+        await previous_owner_membership.save()
 
     new_owner_membership.role = TeamMemberRole.OWNER
     await new_owner_membership.save()
@@ -569,23 +585,23 @@ async def transfer_ownership(
             "notify_team_ownership_received_content",
             lang=new_owner.locale,
             team_name=team.name,
-            old_owner=current_user.username,
+            old_owner=old_owner.username,
         ),
     )
 
     await AutoNotificationService.send_to_user(
         notification_type=AutoNotificationType.TEAM_OWNERSHIP_TRANSFERRED,
-        user_id=current_user.id,
-        title=t("notify_team_ownership_transferred_title", lang=current_user.locale),
+        user_id=old_owner.id,
+        title=t("notify_team_ownership_transferred_title", lang=old_owner.locale),
         content=t(
             "notify_team_ownership_transferred_content",
-            lang=current_user.locale,
+            lang=old_owner.locale,
             team_name=team.name,
             new_owner=new_owner.username,
         ),
     )
 
-    await sync_user_role_from_teams(current_user)
+    await sync_user_role_from_teams(old_owner)
     await sync_user_role_from_teams(new_owner)
 
     return success(data=team, msg_key="ownership_transferred")

--- a/backend/app/api/v1/endpoints/teams.py
+++ b/backend/app/api/v1/endpoints/teams.py
@@ -561,9 +561,14 @@ async def transfer_ownership(
             status_code=404,
         )
 
-    old_owner = (
-        previous_owner_membership.user if previous_owner_membership else current_user
-    )
+    old_owner = previous_owner_membership.user if previous_owner_membership else None
+    if old_owner and new_owner.id == old_owner.id:
+        raise BusinessError(
+            code=ResponseCode.CANNOT_PROMOTE_TO_OWNER,
+            msg_key="cannot_promote_to_owner",
+            status_code=400,
+        )
+
     if previous_owner_membership:
         previous_owner_membership.role = TeamMemberRole.ADMIN
         await previous_owner_membership.save()
@@ -585,23 +590,26 @@ async def transfer_ownership(
             "notify_team_ownership_received_content",
             lang=new_owner.locale,
             team_name=team.name,
-            old_owner=old_owner.username,
+            old_owner=(
+                old_owner.username if old_owner else t("unknown", lang=new_owner.locale)
+            ),
         ),
     )
 
-    await AutoNotificationService.send_to_user(
-        notification_type=AutoNotificationType.TEAM_OWNERSHIP_TRANSFERRED,
-        user_id=old_owner.id,
-        title=t("notify_team_ownership_transferred_title", lang=old_owner.locale),
-        content=t(
-            "notify_team_ownership_transferred_content",
-            lang=old_owner.locale,
-            team_name=team.name,
-            new_owner=new_owner.username,
-        ),
-    )
+    if old_owner:
+        await AutoNotificationService.send_to_user(
+            notification_type=AutoNotificationType.TEAM_OWNERSHIP_TRANSFERRED,
+            user_id=old_owner.id,
+            title=t("notify_team_ownership_transferred_title", lang=old_owner.locale),
+            content=t(
+                "notify_team_ownership_transferred_content",
+                lang=old_owner.locale,
+                team_name=team.name,
+                new_owner=new_owner.username,
+            ),
+        )
+        await sync_user_role_from_teams(old_owner)
 
-    await sync_user_role_from_teams(old_owner)
     await sync_user_role_from_teams(new_owner)
 
     return success(data=team, msg_key="ownership_transferred")

--- a/backend/tests/api/test_team_ownership_transfer.py
+++ b/backend/tests/api/test_team_ownership_transfer.py
@@ -1,0 +1,137 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.api.v1.endpoints import teams
+from app.schemas.team import TeamMemberRole
+
+
+class _TeamQuery:
+    def __init__(self, team):
+        self._team = team
+
+    def prefetch_related(self, *_args):
+        return self
+
+    async def first(self):
+        return self._team
+
+    def __await__(self):
+        async def resolve():
+            return self._team
+
+        return resolve().__await__()
+
+
+class _TeamFilter:
+    def __init__(self, team):
+        self._team = team
+
+    async def first(self):
+        return self._team
+
+
+class _MembershipQuery:
+    def __init__(self, membership):
+        self._membership = membership
+
+    def prefetch_related(self, *_args):
+        return self
+
+    async def first(self):
+        return self._membership
+
+
+class _UserQuery:
+    def __init__(self, user):
+        self._user = user
+
+    async def first(self):
+        return self._user
+
+
+class _TeamModel:
+    @staticmethod
+    def filter(**_kwargs):
+        return _TeamFilter(_TEAM)
+
+    @staticmethod
+    def get(**_kwargs):
+        return _TeamQuery(_TEAM)
+
+
+class _TeamMemberModel:
+    @staticmethod
+    def filter(**kwargs):
+        if kwargs.get("role") == TeamMemberRole.OWNER:
+            return _MembershipQuery(_OWNER_MEMBERSHIP)
+        user = kwargs["user"]
+        return _MembershipQuery(_MEMBERSHIPS.get(user.id))
+
+
+class _UserModel:
+    @staticmethod
+    def filter(**kwargs):
+        return _UserQuery(_USERS.get(kwargs["id"]))
+
+
+_USERS = {}
+_MEMBERSHIPS = {}
+_TEAM = None
+_OWNER_MEMBERSHIP = None
+
+
+@pytest.mark.anyio
+async def test_superuser_can_transfer_team_ownership():
+    global _USERS, _MEMBERSHIPS, _TEAM, _OWNER_MEMBERSHIP
+
+    superuser = SimpleNamespace(
+        id=uuid4(), username="super", locale="en", is_superuser=True
+    )
+    old_owner = SimpleNamespace(
+        id=uuid4(), username="old-owner", locale="en", is_superuser=False
+    )
+    new_owner = SimpleNamespace(
+        id=uuid4(), username="new-owner", locale="en", is_superuser=False
+    )
+    _TEAM = SimpleNamespace(id=uuid4(), name="Team", owner=old_owner, save=AsyncMock())
+    _OWNER_MEMBERSHIP = SimpleNamespace(
+        user=old_owner,
+        role=TeamMemberRole.OWNER,
+        save=AsyncMock(),
+    )
+    new_owner_membership = SimpleNamespace(
+        user=new_owner,
+        role=TeamMemberRole.ADMIN,
+        save=AsyncMock(),
+    )
+    _USERS = {new_owner.id: new_owner}
+    _MEMBERSHIPS = {old_owner.id: _OWNER_MEMBERSHIP, new_owner.id: new_owner_membership}
+
+    with (
+        patch("app.api.v1.endpoints.teams.Team", _TeamModel),
+        patch("app.api.v1.endpoints.teams.TeamMember", _TeamMemberModel),
+        patch("app.api.v1.endpoints.teams.User", _UserModel),
+        patch(
+            "app.api.v1.endpoints.teams.AutoNotificationService.send_to_user",
+            new=AsyncMock(),
+        ),
+        patch(
+            "app.api.v1.endpoints.teams.sync_user_role_from_teams",
+            new=AsyncMock(),
+        ) as sync_roles,
+    ):
+        response = await teams.transfer_ownership(
+            team_id=_TEAM.id,
+            new_owner_id=new_owner.id,
+            current_user=superuser,
+        )
+
+    assert response["code"] == 0
+    assert _OWNER_MEMBERSHIP.role == TeamMemberRole.ADMIN
+    assert new_owner_membership.role == TeamMemberRole.OWNER
+    assert _TEAM.owner is new_owner
+    sync_roles.assert_any_await(old_owner)
+    sync_roles.assert_any_await(new_owner)

--- a/backend/tests/api/test_team_ownership_transfer.py
+++ b/backend/tests/api/test_team_ownership_transfer.py
@@ -135,3 +135,84 @@ async def test_superuser_can_transfer_team_ownership():
     assert _TEAM.owner is new_owner
     sync_roles.assert_any_await(old_owner)
     sync_roles.assert_any_await(new_owner)
+
+
+@pytest.mark.anyio
+async def test_transfer_ownership_rejects_existing_owner():
+    global _USERS, _MEMBERSHIPS, _TEAM, _OWNER_MEMBERSHIP
+
+    superuser = SimpleNamespace(
+        id=uuid4(), username="super", locale="en", is_superuser=True
+    )
+    old_owner = SimpleNamespace(
+        id=uuid4(), username="old-owner", locale="en", is_superuser=False
+    )
+    _TEAM = SimpleNamespace(id=uuid4(), name="Team", owner=old_owner, save=AsyncMock())
+    _OWNER_MEMBERSHIP = SimpleNamespace(
+        user=old_owner,
+        role=TeamMemberRole.OWNER,
+        save=AsyncMock(),
+    )
+    _USERS = {old_owner.id: old_owner}
+    _MEMBERSHIPS = {old_owner.id: _OWNER_MEMBERSHIP}
+
+    with (
+        patch("app.api.v1.endpoints.teams.Team", _TeamModel),
+        patch("app.api.v1.endpoints.teams.TeamMember", _TeamMemberModel),
+        patch("app.api.v1.endpoints.teams.User", _UserModel),
+        pytest.raises(teams.BusinessError) as error,
+    ):
+        await teams.transfer_ownership(
+            team_id=_TEAM.id,
+            new_owner_id=old_owner.id,
+            current_user=superuser,
+        )
+
+    assert error.value.msg_key == "cannot_promote_to_owner"
+    _OWNER_MEMBERSHIP.save.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_superuser_transfer_handles_missing_previous_owner():
+    global _USERS, _MEMBERSHIPS, _TEAM, _OWNER_MEMBERSHIP
+
+    superuser = SimpleNamespace(
+        id=uuid4(), username="super", locale="en", is_superuser=True
+    )
+    new_owner = SimpleNamespace(
+        id=uuid4(), username="new-owner", locale="en", is_superuser=False
+    )
+    _TEAM = SimpleNamespace(id=uuid4(), name="Team", owner=None, save=AsyncMock())
+    _OWNER_MEMBERSHIP = None
+    new_owner_membership = SimpleNamespace(
+        user=new_owner,
+        role=TeamMemberRole.ADMIN,
+        save=AsyncMock(),
+    )
+    _USERS = {new_owner.id: new_owner}
+    _MEMBERSHIPS = {new_owner.id: new_owner_membership}
+
+    with (
+        patch("app.api.v1.endpoints.teams.Team", _TeamModel),
+        patch("app.api.v1.endpoints.teams.TeamMember", _TeamMemberModel),
+        patch("app.api.v1.endpoints.teams.User", _UserModel),
+        patch(
+            "app.api.v1.endpoints.teams.AutoNotificationService.send_to_user",
+            new=AsyncMock(),
+        ) as notify_user,
+        patch(
+            "app.api.v1.endpoints.teams.sync_user_role_from_teams",
+            new=AsyncMock(),
+        ) as sync_roles,
+    ):
+        response = await teams.transfer_ownership(
+            team_id=_TEAM.id,
+            new_owner_id=new_owner.id,
+            current_user=superuser,
+        )
+
+    assert response["code"] == 0
+    assert new_owner_membership.role == TeamMemberRole.OWNER
+    assert _TEAM.owner is new_owner
+    assert notify_user.await_count == 1
+    sync_roles.assert_awaited_once_with(new_owner)


### PR DESCRIPTION
## Summary
- allow superusers to use the team ownership transfer endpoint without being current team owner
- demote the actual previous owner and notify/sync roles for the previous and new owners
- add focused regression coverage for superuser ownership transfer

## Tests
- PYTHONPATH=. uv run pytest tests/api/test_team_ownership_transfer.py
- uv run ruff check app/api/v1/endpoints/teams.py tests/api/test_team_ownership_transfer.py
- uv run ruff format --check app/api/v1/endpoints/teams.py tests/api/test_team_ownership_transfer.py

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)