### PR TITLE
YUN-82: Fix Agent orchestration large-screen layout

### DIFF
--- a/frontend/app/(platform)/app/apps/[id]/_components/agent-preview-panel.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/_components/agent-preview-panel.tsx
@@ -289,9 +289,9 @@ export function AgentPreviewPanel({ agent }: AgentPreviewPanelProps) {
       <div className="relative pb-4 shrink-0">
         {/* Variable Panel - Collapsible above input */}
         {hasVisibleVariables && (
-          <div className="mx-auto max-w-3xl px-4">
+          <div className="px-4">
             <Collapsible open={variablesOpen} onOpenChange={setVariablesOpen}>
-              <div className="rounded-t-lg border border-b-0 bg-muted/30 overflow-hidden w-[70%] mx-auto">
+              <div className="rounded-t-lg border border-b-0 bg-muted/30 overflow-hidden w-full mx-auto">
                 <CollapsibleTrigger className="flex items-center justify-between w-full px-2.5 py-1.5 text-xs hover:bg-muted/50 transition-colors">
                   <span className="text-muted-foreground">
                     {tVars('title')}
@@ -341,6 +341,7 @@ export function AgentPreviewPanel({ agent }: AgentPreviewPanelProps) {
           files={files}
           onFilesChange={setFiles}
           isUploading={isUploading}
+          className="max-w-none"
         />
       </div>
     </div>

--- a/frontend/app/(platform)/app/apps/[id]/page.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/page.tsx
@@ -324,7 +324,7 @@ export function AgentEditor({
         <div className="flex-1 flex h-full overflow-hidden p-6 gap-6 min-h-0">
           {/* Orchestration Form */}
           <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-scrollbar]]:border-l-0">
-            <div className="w-full">
+            <div className="w-full max-w-6xl">
               <AgentOrchestrationForm
                 agent={agent}
                 onUpdate={handleOrchestrationUpdate}

--- a/frontend/app/(platform)/app/apps/[id]/page.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/page.tsx
@@ -324,7 +324,7 @@ export function AgentEditor({
         <div className="flex-1 flex h-full overflow-hidden p-6 gap-6 min-h-0">
           {/* Orchestration Form */}
           <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-scrollbar]]:border-l-0">
-            <div className="max-w-3xl">
+            <div className="w-full">
               <AgentOrchestrationForm
                 agent={agent}
                 onUpdate={handleOrchestrationUpdate}
@@ -333,7 +333,7 @@ export function AgentEditor({
           </ScrollArea>
 
           {/* Preview Panel */}
-          <div className="w-95 min-w-95 shrink-0 h-full min-h-0 overflow-hidden border rounded-lg">
+          <div className="w-95 min-w-95 2xl:w-[clamp(30rem,28vw,42rem)] 2xl:min-w-[30rem] shrink-0 h-full min-h-0 overflow-hidden border rounded-lg">
             <AgentPreviewPanel agent={{ ...agent, hide_tool_calls: hideToolCalls }} />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Remove the narrow max-width wrapper from the Agent orchestration form so the middle area can use wide-screen space.
- Expand the debug preview panel on 2xl screens with a bounded responsive width.
- Let the preview variable panel and chat input fill the wider preview panel.

## Linked issues
- Linear: YUN-82
- Closes #197

## Validation
- bun run --cwd frontend lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)