### PR TITLE
YUN-88: Support multimodal knowledge base assets

### DIFF
--- a/backend/app/api/v1/admin/endpoints/audit_logs.py
+++ b/backend/app/api/v1/admin/endpoints/audit_logs.py
@@ -636,7 +636,7 @@ async def trigger_manual_archive(
 
 @router.get("/export", response_model=None)
 async def export_audit_logs(
-    format: str = Query("csv", regex="^(csv|json)$"),
+    format: str = Query("csv", pattern="^(csv|json)$"),
     user_id: UUID | None = Query(None),
     team_id: UUID | None = Query(None),
     action: list[str] | None = Query(None),

--- a/backend/app/api/v1/admin/endpoints/users.py
+++ b/backend/app/api/v1/admin/endpoints/users.py
@@ -854,7 +854,7 @@ class ExpiringPasswordUser(BaseModel):
 async def get_expiring_passwords(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
-    filter: str = Query("all", regex="^(all|expired|expiring|force_change)$"),
+    filter: str = Query("all", pattern="^(all|expired|expiring|force_change)$"),
     current_user: User = Depends(deps.PermissionChecker("admin:user:read")),
 ) -> Any:
     """

--- a/backend/app/api/v1/endpoints/knowledge_bases.py
+++ b/backend/app/api/v1/endpoints/knowledge_bases.py
@@ -4,6 +4,8 @@ Provides CRUD operations for knowledge bases and documents.
 """
 
 import logging
+import mimetypes
+import os
 from contextvars import ContextVar
 from typing import Any, Optional
 from uuid import UUID, uuid4
@@ -862,6 +864,9 @@ async def delete_document(
     vector_store = VectorStore()
     await vector_store.delete_document_vectors(doc_id)
 
+    # Delete extracted media assets if exists
+    document_processor.delete_media_assets(kb.id, doc.id)
+
     # Delete file if exists
     if doc.file_path:
         document_processor.delete_file(doc.file_path)
@@ -904,8 +909,6 @@ async def download_document(
             status_code=404,
         )
 
-    import os
-
     if not os.path.exists(doc.file_path):
         raise BusinessError(
             code=ResponseCode.VALIDATION_ERROR,
@@ -933,6 +936,38 @@ async def download_document(
         filename=doc.name,
         media_type=media_type,
     )
+
+
+@router.get("/{kb_id}/documents/{doc_id}/media/{filename}")
+async def get_document_media(
+    kb_id: UUID,
+    doc_id: UUID,
+    filename: str,
+    current_user: User = Depends(require_kb_read),
+) -> FileResponse:
+    """
+    Get extracted media from a processed document.
+    """
+    await check_kb_access(kb_id, current_user, require_write=False)
+
+    doc = await Document.filter(id=doc_id, knowledge_base_id=kb_id).first()
+    if not doc:
+        raise BusinessError(
+            code=ResponseCode.DOCUMENT_NOT_FOUND,
+            msg_key="document_not_found",
+            status_code=404,
+        )
+
+    file_path = document_processor.get_media_asset_path(kb_id, doc_id, filename)
+    if not file_path.exists():
+        raise BusinessError(
+            code=ResponseCode.VALIDATION_ERROR,
+            msg_key="file_not_found",
+            status_code=404,
+        )
+
+    media_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    return FileResponse(path=file_path, media_type=media_type)
 
 
 @router.post(
@@ -1173,6 +1208,8 @@ async def preview_document_chunks(
                 doc.file_path,
                 doc.doc_type,
                 clean_text=preview_in.clean_text,
+                kb_id=kb_id,
+                document_id=doc_id,
             )
         else:
             text, _ = await document_processor.fetch_url_content(

--- a/backend/app/api/v1/endpoints/knowledge_bases.py
+++ b/backend/app/api/v1/endpoints/knowledge_bases.py
@@ -3,6 +3,7 @@ Knowledge Base API endpoints.
 Provides CRUD operations for knowledge bases and documents.
 """
 
+import asyncio
 import logging
 import mimetypes
 import os
@@ -865,7 +866,7 @@ async def delete_document(
     await vector_store.delete_document_vectors(doc_id)
 
     # Delete extracted media assets if exists
-    document_processor.delete_media_assets(kb.id, doc.id)
+    await asyncio.to_thread(document_processor.delete_media_assets, kb.id, doc.id)
 
     # Delete file if exists
     if doc.file_path:
@@ -958,7 +959,14 @@ async def get_document_media(
             status_code=404,
         )
 
-    file_path = document_processor.get_media_asset_path(kb_id, doc_id, filename)
+    try:
+        file_path = document_processor.get_media_asset_path(kb_id, doc_id, filename)
+    except ValueError:
+        raise BusinessError(
+            code=ResponseCode.VALIDATION_ERROR,
+            msg_key="file_not_found",
+            status_code=404,
+        ) from None
     if not file_path.exists():
         raise BusinessError(
             code=ResponseCode.VALIDATION_ERROR,

--- a/backend/app/core/init_data.py
+++ b/backend/app/core/init_data.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from tortoise import Tortoise
@@ -11,6 +12,18 @@ logger = logging.getLogger(__name__)
 
 # System role name constant
 SUPER_ADMIN_ROLE = "Super Admin"
+STARTUP_MIGRATION_LOCK_TIMEOUT = "2s"
+STARTUP_MIGRATION_QUERY_TIMEOUT_SECONDS = 3
+
+
+async def execute_startup_migration_query(conn, query: str):
+    await conn.execute_query(f"SET lock_timeout = '{STARTUP_MIGRATION_LOCK_TIMEOUT}'")
+    try:
+        return await asyncio.wait_for(
+            conn.execute_query(query), timeout=STARTUP_MIGRATION_QUERY_TIMEOUT_SECONDS
+        )
+    finally:
+        await conn.execute_query("RESET lock_timeout")
 
 
 async def sync_role_permissions(
@@ -236,10 +249,13 @@ async def init_agent_tools_credentials():
     if not rows:
         logger.info("Adding tools_credentials column to agents table...")
         try:
-            await conn.execute_query("""
+            await execute_startup_migration_query(
+                conn,
+                """
                 ALTER TABLE agents
                 ADD COLUMN tools_credentials JSONB NOT NULL DEFAULT '{}'::jsonb
-            """)
+                """,
+            )
             logger.info("Added tools_credentials column to agents table")
         except Exception as e:
             logger.error(f"Could not add tools_credentials column: {e}")
@@ -249,12 +265,27 @@ async def init_agent_tools_credentials():
 
     # Update existing agents with NULL tools_credentials (shouldn't happen with DEFAULT, but just in case)
     try:
-        await conn.execute_query("""
-            UPDATE agents
-            SET tools_credentials = '{}'::jsonb
+        _, rows = await execute_startup_migration_query(
+            conn,
+            """
+            SELECT COUNT(*) AS null_count
+            FROM agents
             WHERE tools_credentials IS NULL
-        """)
-        logger.info("Updated existing agents with default tools_credentials")
+            """,
+        )
+        null_count = rows[0]["null_count"] if rows else 0
+        if null_count:
+            await execute_startup_migration_query(
+                conn,
+                """
+                UPDATE agents
+                SET tools_credentials = '{}'::jsonb
+                WHERE tools_credentials IS NULL
+                """,
+            )
+            logger.info("Updated existing agents with default tools_credentials")
+        else:
+            logger.info("No agents require tools_credentials backfill")
     except Exception as e:
         logger.warning(f"Could not update existing agents: {e}")
 
@@ -282,12 +313,27 @@ async def init_agent_visibility_values():
         return
 
     try:
-        await conn.execute_query("""
-            UPDATE agents
-            SET visibility = 'team'
+        _, rows = await execute_startup_migration_query(
+            conn,
+            """
+            SELECT COUNT(*) AS public_count
+            FROM agents
             WHERE visibility = 'public'
-        """)
-        logger.info("Normalized legacy public agent visibility to team")
+            """,
+        )
+        public_count = rows[0]["public_count"] if rows else 0
+        if public_count:
+            await execute_startup_migration_query(
+                conn,
+                """
+                UPDATE agents
+                SET visibility = 'team'
+                WHERE visibility = 'public'
+                """,
+            )
+            logger.info("Normalized legacy public agent visibility to team")
+        else:
+            logger.info("No legacy public agent visibility values found")
     except Exception as e:
         logger.error(f"Could not normalize agent visibility values: {e}")
         raise
@@ -367,10 +413,13 @@ async def init_agent_streaming_config():
     if not rows:
         logger.info("Adding streaming_config column to agents table...")
         try:
-            await conn.execute_query("""
+            await execute_startup_migration_query(
+                conn,
+                """
                 ALTER TABLE agents
                 ADD COLUMN streaming_config JSONB NOT NULL DEFAULT '{}'::jsonb
-            """)
+                """,
+            )
             logger.info("Added streaming_config column to agents table")
         except Exception as e:
             logger.error(f"Could not add streaming_config column: {e}")
@@ -410,10 +459,13 @@ async def init_agent_context_compression_config():
     if not rows:
         logger.info("Adding context_compression_config column to agents table...")
         try:
-            await conn.execute_query("""
+            await execute_startup_migration_query(
+                conn,
+                """
                 ALTER TABLE agents
                 ADD COLUMN context_compression_config JSONB NOT NULL DEFAULT '{}'::jsonb
-            """)
+                """,
+            )
             logger.info("Added context_compression_config column to agents table")
         except Exception as e:
             logger.error(f"Could not add context_compression_config column: {e}")
@@ -733,10 +785,13 @@ async def init_agent_user_input_request():
     if not rows:
         logger.info("Adding enable_user_input_request column to agents table...")
         try:
-            await conn.execute_query("""
+            await execute_startup_migration_query(
+                conn,
+                """
                 ALTER TABLE agents
                 ADD COLUMN enable_user_input_request BOOLEAN NOT NULL DEFAULT FALSE
-            """)
+                """,
+            )
             logger.info("Added enable_user_input_request column to agents table")
         except Exception as e:
             logger.error(f"Could not add enable_user_input_request column: {e}")
@@ -1018,6 +1073,9 @@ async def fix_cascade_delete_policies():
     conn = Tortoise.get_connection("default")
 
     try:
+        await conn.execute_query(
+            f"SET lock_timeout = '{STARTUP_MIGRATION_LOCK_TIMEOUT}'"
+        )
         # 1. Fix Agent.created_by: CASCADE -> SET NULL
         logger.info("Fixing agents.created_by_id foreign key...")
         await conn.execute_query("""
@@ -1188,6 +1246,8 @@ async def fix_cascade_delete_policies():
         logger.error(f"Error fixing CASCADE delete policies: {e}")
         # Don't raise - allow app to continue even if migration fails
         logger.warning("Continuing despite migration errors...")
+    finally:
+        await conn.execute_query("RESET lock_timeout")
 
 
 async def init_sso_tables():
@@ -1479,10 +1539,13 @@ async def init_agent_hide_tool_calls_field():
         )
         return
 
-    await conn.execute_query("""
+    await execute_startup_migration_query(
+        conn,
+        """
         ALTER TABLE agents
         ADD COLUMN IF NOT EXISTS hide_tool_calls BOOLEAN NOT NULL DEFAULT FALSE
-    """)
+        """,
+    )
 
     logger.info("Agent hide_tool_calls field added successfully")
 
@@ -1508,16 +1571,22 @@ async def init_agent_memory_fields():
     logger.info("Adding enable_memory and memory_config fields to agents table...")
 
     # Add enable_memory field
-    await conn.execute_query("""
+    await execute_startup_migration_query(
+        conn,
+        """
         ALTER TABLE agents
         ADD COLUMN IF NOT EXISTS enable_memory BOOLEAN NOT NULL DEFAULT FALSE
-    """)
+        """,
+    )
 
     # Add memory_config field
-    await conn.execute_query("""
+    await execute_startup_migration_query(
+        conn,
+        """
         ALTER TABLE agents
         ADD COLUMN IF NOT EXISTS memory_config JSONB NOT NULL DEFAULT '{}'
-    """)
+        """,
+    )
 
     logger.info("Agent memory fields added successfully")
 
@@ -1541,22 +1610,34 @@ async def init_agent_media_generation_fields():
         )
         return
 
-    await conn.execute_query("""
+    await execute_startup_migration_query(
+        conn,
+        """
         ALTER TABLE agents
         ADD COLUMN IF NOT EXISTS enable_image_generation BOOLEAN NOT NULL DEFAULT FALSE
-    """)
-    await conn.execute_query("""
+        """,
+    )
+    await execute_startup_migration_query(
+        conn,
+        """
         ALTER TABLE agents
         ADD COLUMN IF NOT EXISTS image_generation_config JSONB NOT NULL DEFAULT '{}'::jsonb
-    """)
-    await conn.execute_query("""
+        """,
+    )
+    await execute_startup_migration_query(
+        conn,
+        """
         ALTER TABLE agents
         ADD COLUMN IF NOT EXISTS enable_video_generation BOOLEAN NOT NULL DEFAULT FALSE
-    """)
-    await conn.execute_query("""
+        """,
+    )
+    await execute_startup_migration_query(
+        conn,
+        """
         ALTER TABLE agents
         ADD COLUMN IF NOT EXISTS video_generation_config JSONB NOT NULL DEFAULT '{}'::jsonb
-    """)
+        """,
+    )
 
     logger.info("Agent media generation fields added successfully")
 

--- a/backend/app/services/chat_context.py
+++ b/backend/app/services/chat_context.py
@@ -67,6 +67,9 @@ AGGRESSIVE_BLOCK_SUMMARY_CHARS = 220
 DEFAULT_FILE_CONTENT_HEAD_CHARS = 12000
 DEFAULT_FILE_CONTENT_TAIL_CHARS = 4000
 FILE_CONTENT_PLACEHOLDER = "{{fileContent}}"
+MARKDOWN_IMAGE_DISPLAY_INSTRUCTION = """## Markdown Output
+
+When the user asks you to show or display an image, output the image using normal Markdown image syntax, for example `![alt text](image-url)`. Do not wrap the Markdown image in a code block unless the user explicitly asks for the literal Markdown source."""
 DEFAULT_CONTEXT_COMPRESSION_CONFIG = {
     "enabled": True,
     "micro_compaction_enabled": True,
@@ -594,6 +597,10 @@ def _build_system_prompt(
             system_prompt = system_prompt.replace(f"{{{{{key}}}}}", str(value))
         system_prompt = system_prompt.replace("{{query}}", user_message)
         system_prompt = system_prompt.replace(FILE_CONTENT_PLACEHOLDER, "")
+
+    system_prompt = _append_prompt_section(
+        system_prompt, MARKDOWN_IMAGE_DISPLAY_INSTRUCTION
+    )
 
     if agent.enable_memory:
         system_prompt = _append_prompt_section(system_prompt, MEMORY_SYSTEM_INSTRUCTION)

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -3,6 +3,7 @@ Document processing service for knowledge base.
 Handles document parsing, text extraction, and chunking.
 """
 
+import asyncio
 import base64
 import binascii
 import hashlib
@@ -252,7 +253,13 @@ class DocumentProcessor:
         file_path = self.get_media_asset_path(kb_id, document_id, filename)
         os.makedirs(file_path.parent, exist_ok=True)
         if not file_path.exists():
-            file_path.write_bytes(content)
+            temp_file_path = file_path.with_name(f".tmp_{file_path.name}")
+            try:
+                temp_file_path.write_bytes(content)
+                temp_file_path.replace(file_path)
+            except Exception:
+                temp_file_path.unlink(missing_ok=True)
+                raise
         url = (
             f"/api/v1/knowledge-bases/{kb_id}/documents/{document_id}/media/{filename}"
         )
@@ -350,7 +357,8 @@ class DocumentProcessor:
 
         # Clean up text
         if kb_id is not None and document_id is not None:
-            text, media_assets = self.replace_embedded_media_data_uris(
+            text, media_assets = await asyncio.to_thread(
+                self.replace_embedded_media_data_uris,
                 text,
                 kb_id=kb_id,
                 document_id=document_id,

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -3,10 +3,14 @@ Document processing service for knowledge base.
 Handles document parsing, text extraction, and chunking.
 """
 
+import base64
+import binascii
 import hashlib
 import logging
+import mimetypes
 import os
 import re
+import shutil
 from pathlib import Path
 from datetime import datetime
 from typing import Any
@@ -21,7 +25,6 @@ from app.models.knowledge_base import (
 logger = logging.getLogger(__name__)
 
 
-# Supported MIME types mapping
 MIME_TYPE_MAP: dict[str, str] = {
     "application/pdf": DocumentType.PDF.value,
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": DocumentType.DOCX.value,
@@ -51,6 +54,23 @@ EXT_TYPE_MAP: dict[str, str] = {
     ".xlsx": DocumentType.XLSX.value,
     ".xls": DocumentType.XLS.value,
     ".json": DocumentType.JSON.value,
+}
+
+MEDIA_ASSETS_METADATA_KEY = "media_assets"
+DATA_URI_IMAGE_RE = re.compile(r"data:(image/[a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=]+)")
+ALLOWED_MEDIA_MIME_TYPES = {
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/svg+xml",
+    "image/webp",
+}
+MEDIA_MIME_EXTENSIONS = {
+    "image/gif": ".gif",
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/svg+xml": ".svg",
+    "image/webp": ".webp",
 }
 
 
@@ -200,8 +220,85 @@ class DocumentProcessor:
             return True
         return False
 
+    def delete_media_assets(self, kb_id: UUID, document_id: UUID) -> None:
+        asset_dir = self._resolve_storage_path(str(kb_id), "media", str(document_id))
+        if asset_dir.exists():
+            shutil.rmtree(asset_dir, ignore_errors=True)
+
+    def _get_media_asset_extension(self, content_type: str) -> str:
+        return MEDIA_MIME_EXTENSIONS.get(
+            content_type,
+            mimetypes.guess_extension(content_type, strict=False) or ".bin",
+        )
+
+    def get_media_asset_path(
+        self, kb_id: UUID, document_id: UUID, filename: str
+    ) -> Path:
+        return self._resolve_storage_path(
+            str(kb_id), "media", str(document_id), self._sanitize_filename(filename)
+        )
+
+    def _save_media_asset(
+        self,
+        *,
+        kb_id: UUID,
+        document_id: UUID,
+        content_type: str,
+        content: bytes,
+    ) -> dict[str, Any]:
+        digest = hashlib.sha256(content).hexdigest()[:16]
+        extension = self._get_media_asset_extension(content_type)
+        filename = self._sanitize_filename(f"{digest}{extension}")
+        file_path = self.get_media_asset_path(kb_id, document_id, filename)
+        os.makedirs(file_path.parent, exist_ok=True)
+        if not file_path.exists():
+            file_path.write_bytes(content)
+        url = (
+            f"/api/v1/knowledge-bases/{kb_id}/documents/{document_id}/media/{filename}"
+        )
+        return {
+            "path": str(file_path),
+            "url": url,
+            "filename": filename,
+            "content_type": content_type,
+            "size": len(content),
+        }
+
+    def replace_embedded_media_data_uris(
+        self,
+        text: str,
+        *,
+        kb_id: UUID,
+        document_id: UUID,
+    ) -> tuple[str, list[dict[str, Any]]]:
+        assets: list[dict[str, Any]] = []
+
+        def replace(match: re.Match[str]) -> str:
+            content_type = match.group(1).lower()
+            if content_type not in ALLOWED_MEDIA_MIME_TYPES:
+                return match.group(0)
+            try:
+                content = base64.b64decode(match.group(2), validate=True)
+            except binascii.Error:
+                return match.group(0)
+            asset = self._save_media_asset(
+                kb_id=kb_id,
+                document_id=document_id,
+                content_type=content_type,
+                content=content,
+            )
+            assets.append(asset)
+            return asset["url"]
+
+        return DATA_URI_IMAGE_RE.sub(replace, text), assets
+
     async def extract_text(
-        self, path: str, doc_type: str, clean_text: bool = True
+        self,
+        path: str,
+        doc_type: str,
+        clean_text: bool = True,
+        kb_id: UUID | None = None,
+        document_id: UUID | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """
         Extract text content from a document.
@@ -252,6 +349,14 @@ class DocumentProcessor:
             raise ValueError("document_processing_failed_generic")
 
         # Clean up text
+        if kb_id is not None and document_id is not None:
+            text, media_assets = self.replace_embedded_media_data_uris(
+                text,
+                kb_id=kb_id,
+                document_id=document_id,
+            )
+            if media_assets:
+                metadata[MEDIA_ASSETS_METADATA_KEY] = media_assets
         text = self._clean_text(text, clean=clean_text)
         metadata["char_count"] = len(text)
 
@@ -299,7 +404,7 @@ class DocumentProcessor:
             from markitdown import MarkItDown
 
             md = MarkItDown()
-            result = md.convert(path)
+            result = md.convert(path, keep_data_uris=True)
 
             text = result.text_content
 

--- a/backend/app/services/notification.py
+++ b/backend/app/services/notification.py
@@ -30,6 +30,7 @@ async def create_notification(
     actor: Optional[User] = None,
     meta: Optional[dict] = None,
 ) -> Notification:
+    await notification.save()
     await create_notification_audit(
         notification_id=notification.id,
         action=NotificationAuditAction.CREATE,

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -39,6 +39,11 @@ logger = logging.getLogger(__name__)
 
 EMBEDDING_REQUEST_TIMEOUT_SECONDS = 120.0
 
+
+class EmbeddingRequestTimeoutError(Exception):
+    pass
+
+
 # Initialize jieba (disable verbose output)
 jieba.setLogLevel(logging.WARNING)
 
@@ -578,8 +583,14 @@ class VectorStore:
         except QuotaExceededError:
             logger.error(f"Team {self.team_id} quota exceeded for embedding")
             raise
-        except Exception as e:
-            logger.error(f"Error generating embeddings: {e}")
+        except asyncio.TimeoutError as e:
+            logger.exception(
+                "Embedding request timed out after %s seconds",
+                EMBEDDING_REQUEST_TIMEOUT_SECONDS,
+            )
+            raise EmbeddingRequestTimeoutError("embedding_request_timeout") from e
+        except Exception:
+            logger.exception("Error generating embeddings")
             raise
 
     async def embed_query(self, query: str) -> list[float]:
@@ -615,8 +626,14 @@ class VectorStore:
         except QuotaExceededError:
             logger.error(f"Team {self.team_id} quota exceeded for query embedding")
             raise
-        except Exception as e:
-            logger.error(f"Error generating query embedding: {e}")
+        except asyncio.TimeoutError as e:
+            logger.exception(
+                "Query embedding request timed out after %s seconds",
+                EMBEDDING_REQUEST_TIMEOUT_SECONDS,
+            )
+            raise EmbeddingRequestTimeoutError("embedding_request_timeout") from e
+        except Exception:
+            logger.exception("Error generating query embedding")
             raise
 
     async def store_chunks(
@@ -1404,7 +1421,8 @@ class VectorStore:
             Exception: If embedding generation or storage fails
         """
         # Generate embedding
-        embedding = await self.embed_query(chunk.content)
+        embeddings = await self.embed_texts([chunk.content])
+        embedding = embeddings[0]
         await _ensure_kb_dimension(kb_id, len(embedding))
 
         # Store embedding reference

--- a/backend/app/sso/providers/oidc.py
+++ b/backend/app/sso/providers/oidc.py
@@ -4,7 +4,7 @@ import secrets
 from typing import Any, Dict, Tuple
 
 import httpx
-from authlib.jose import jwt
+from joserfc import jwt
 
 from app.core.i18n import t
 from app.sso.providers.base import BaseSSOProvider
@@ -146,5 +146,5 @@ class OIDCProvider(BaseSSOProvider):
         Note: For production, should fetch JWKS from provider and validate signature
         """
         # For now, decode without verification (should be improved)
-        claims = jwt.decode(id_token, self.config.get("client_secret", ""))
-        return claims
+        token = jwt.decode(id_token, self.config.get("client_secret", ""))
+        return token.claims

--- a/backend/app/tasks/knowledge_base.py
+++ b/backend/app/tasks/knowledge_base.py
@@ -4,6 +4,7 @@ Celery tasks for knowledge base document processing.
 
 import logging
 from datetime import datetime, timezone
+from typing import Any, cast
 from uuid import UUID
 
 from celery import shared_task
@@ -18,7 +19,11 @@ from app.models.knowledge_base import (
 from app.models.notification import AutoNotificationType
 from app.services.auto_notification import AutoNotificationService
 from app.services.document_processor import document_processor
-from app.services.vector_store import VectorStore, DimensionMismatchError
+from app.services.vector_store import (
+    VectorStore,
+    DimensionMismatchError,
+    EmbeddingRequestTimeoutError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +44,19 @@ def _get_dimension_mismatch_error(document: Document, user_locale: str = "en") -
 def _get_generic_processing_error(document: Document, user_locale: str = "en") -> str:
     return t(
         "document_processing_failed_generic",
+        lang=_get_document_error_lang(document, user_locale),
+    )
+
+
+def _get_embedding_error(
+    document: Document, error: Exception, user_locale: str = "en"
+) -> str:
+    if isinstance(error, EmbeddingRequestTimeoutError):
+        return t(
+            "request_timeout", lang=_get_document_error_lang(document, user_locale)
+        )
+    return str(error) or t(
+        "unknown_error_generic",
         lang=_get_document_error_lang(document, user_locale),
     )
 
@@ -252,7 +270,7 @@ def process_document_task(self, document_id: str) -> dict:
 
         existing_chunks = await DocumentChunk.filter(document_id=doc_uuid).count()
         if existing_chunks > 0:
-            return embed_document_chunks_task(document_id)
+            return await _embed_existing_document_chunks(document_id, task_id)
 
         try:
             # Update status to processing
@@ -838,6 +856,242 @@ def rechunk_document_task(self, document_id: str) -> dict:
     return loop.run_until_complete(_rechunk())
 
 
+async def _embed_existing_document_chunks(
+    document_id: str, task_id: str | None
+) -> dict:
+    doc_uuid = UUID(document_id)
+
+    document = (
+        await Document.filter(id=doc_uuid)
+        .prefetch_related("knowledge_base", "uploaded_by")
+        .first()
+    )
+
+    if not document:
+        logger.error(f"Document {document_id} not found")
+        default_lang = await get_default_language()
+        return {
+            "status": "error",
+            "message": t("document_not_found", lang=default_lang),
+        }
+
+    if _is_stale_task(document, task_id):
+        return await _finish_stale_task(document, task_id)
+    if _is_finished_task(document, task_id):
+        return await _finish_already_finished_task(document, task_id)
+
+    kb = document.knowledge_base
+    kb_id = cast(UUID, kb.id)
+    kb_team_id = cast(UUID, kb.team_id)
+    user_locale = (
+        getattr(document.uploaded_by, "locale", "en") if document.uploaded_by else "en"
+    )
+
+    async def _refresh_kb_stats() -> None:
+        docs = await Document.filter(
+            knowledge_base_id=kb_id,
+            status=DocumentStatus.COMPLETED.value,
+        ).all()
+        kb.total_chunks = sum(doc.chunk_count for doc in docs)
+        kb.total_tokens = sum(doc.token_count for doc in docs)
+        await kb.save()
+        logger.info(
+            f"KB {kb_id} stats refreshed: chunks={kb.total_chunks}, tokens={kb.total_tokens}"
+        )
+
+    try:
+        chunks = await DocumentChunk.filter(document_id=doc_uuid).order_by(
+            "chunk_index"
+        )
+
+        if not chunks:
+            logger.warning(f"No chunks found for document {document_id}")
+            default_lang = await get_default_language()
+            document.status = DocumentStatus.ERROR.value
+            document.error_message = t("no_chunks_to_embed", lang=default_lang)
+            await document.save()
+            return {
+                "status": "success",
+                "message": t("no_chunks_to_embed", lang=default_lang),
+                "embedded_count": 0,
+            }
+
+        embedding_model_id = (
+            str(kb.embedding_model_id) if kb.embedding_model_id else None
+        )
+        team_id = str(kb.team_id) if kb.team_id else None
+        vector_store = VectorStore(
+            embedding_model_id=embedding_model_id,
+            team_id=team_id,
+        )
+
+        embedded_count = await DocumentChunk.filter(
+            document_id=doc_uuid, status="embedded"
+        ).count()
+        failed_count = 0
+        last_error: str | None = None
+        total_chunks = len(chunks)
+        total_tokens = sum(chunk.token_count for chunk in chunks)
+        for chunk in chunks:
+            if chunk.status == "embedded":
+                continue
+            try:
+                await vector_store.add_chunk_vector(kb_id, chunk)
+                chunk.status = "embedded"
+                chunk.error_message = cast(Any, None)
+                await chunk.save(update_fields=["status", "error_message"])
+                embedded_count += 1
+            except Exception as e:
+                failed_count += 1
+                last_error = _get_embedding_error(document, e, user_locale)
+                chunk.status = "failed"
+                chunk.error_message = last_error[:500]
+                await chunk.save(update_fields=["status", "error_message"])
+                logger.exception("Failed to embed chunk %s", chunk.id)
+
+            document.metadata = document.metadata or {}
+            document.metadata["embed_progress"] = {
+                "embedded": embedded_count,
+                "failed": failed_count,
+                "total": total_chunks,
+            }
+            await document.save(update_fields=["metadata"])
+
+        document.metadata = document.metadata or {}
+        _clear_task_metadata(document)
+
+        if embedded_count == 0 and len(chunks) > 0:
+            document.status = DocumentStatus.ERROR.value
+            document.chunk_count = total_chunks
+            document.token_count = total_tokens
+            document.error_message = t(
+                "all_chunks_failed_to_embed",
+                lang=user_locale,
+                error=last_error or t("unknown_error_generic", lang=user_locale),
+            )[:500]
+            await document.save()
+
+            logger.error(
+                f"Document {document_id} embedding failed: "
+                f"0/{len(chunks)} chunks embedded"
+            )
+
+            localized_error = t(
+                "all_chunks_failed_to_embed",
+                lang=user_locale,
+                error=last_error or t("unknown_error_generic", lang=user_locale),
+            )
+            await _send_doc_failed_notification(
+                document=document,
+                kb_name=kb.name,
+                team_id=kb_team_id,
+                error=localized_error,
+                user_locale=user_locale,
+            )
+
+            return {
+                "status": "error",
+                "document_id": document_id,
+                "message": localized_error,
+                "embedded_count": 0,
+                "total_chunks": len(chunks),
+            }
+
+        if failed_count > 0:
+            document.status = DocumentStatus.ERROR.value
+            document.chunk_count = total_chunks
+            document.token_count = total_tokens
+            document.error_message = t(
+                "chunks_failed_to_embed",
+                lang=user_locale,
+                failed_count=failed_count,
+                total_chunks=len(chunks),
+                error=last_error,
+            )[:500]
+            await document.save()
+
+            await _refresh_kb_stats()
+
+            logger.error(
+                f"Document {document_id} embedding partially failed: "
+                f"{embedded_count}/{len(chunks)} chunks embedded, {failed_count} failed"
+            )
+
+            await _send_doc_failed_notification(
+                document=document,
+                kb_name=kb.name,
+                team_id=kb_team_id,
+                error=document.error_message,
+                user_locale=user_locale,
+            )
+
+            return {
+                "status": "error",
+                "document_id": document_id,
+                "message": document.error_message,
+                "embedded_count": embedded_count,
+                "failed_count": failed_count,
+                "total_chunks": len(chunks),
+            }
+
+        document.status = DocumentStatus.COMPLETED.value
+        document.chunk_count = total_chunks
+        document.token_count = total_tokens
+        document.processed_at = datetime.now(timezone.utc)
+        document.error_message = None
+        await document.save()
+        logger.info(
+            f"Document {document_id} status updated: {document.status}, chunks={document.chunk_count}, tokens={document.token_count}"
+        )
+
+        await _refresh_kb_stats()
+
+        logger.info(
+            f"Document {document_id} embedding completed: "
+            f"{embedded_count}/{len(chunks)} chunks embedded"
+        )
+
+        await _send_doc_indexed_notification(
+            document=document,
+            kb_name=kb.name,
+            team_id=kb_team_id,
+            chunk_count=document.chunk_count,
+            token_count=document.token_count,
+            user_locale=user_locale,
+        )
+
+        return {
+            "status": "success",
+            "document_id": document_id,
+            "embedded_count": embedded_count,
+            "total_chunks": len(chunks),
+        }
+
+    except Exception as e:
+        logger.exception(f"Error embedding document {document_id}: {e}")
+
+        document.status = DocumentStatus.ERROR.value
+        _clear_task_metadata(document)
+        document.error_message = _get_generic_processing_error(document, user_locale)[
+            :500
+        ]
+        await document.save()
+
+        await _send_doc_failed_notification(
+            document=document,
+            kb_name=kb.name,
+            team_id=kb_team_id,
+            error=document.error_message,
+            user_locale=user_locale,
+        )
+
+        return {
+            "status": "error",
+            "document_id": document_id,
+            "message": document.error_message,
+        }
+
+
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
 def embed_document_chunks_task(self, document_id: str) -> dict:
     """
@@ -854,268 +1108,16 @@ def embed_document_chunks_task(self, document_id: str) -> dict:
     """
     import asyncio
 
-    async def _embed():
-        doc_uuid = UUID(document_id)
-
-        # Get document with KB and uploader for locale
-        document = (
-            await Document.filter(id=doc_uuid)
-            .prefetch_related("knowledge_base", "uploaded_by")
-            .first()
-        )
-
-        if not document:
-            logger.error(f"Document {document_id} not found")
-            default_lang = await get_default_language()
-            return {
-                "status": "error",
-                "message": t("document_not_found", lang=default_lang),
-            }
-
-        task_id = getattr(self.request, "id", None)
-        if _is_stale_task(document, task_id):
-            return await _finish_stale_task(document, task_id)
-        if _is_finished_task(document, task_id):
-            return await _finish_already_finished_task(document, task_id)
-
-        kb = document.knowledge_base
-        # Get uploader's locale for notifications
-        user_locale = (
-            getattr(document.uploaded_by, "locale", "en")
-            if document.uploaded_by
-            else "en"
-        )
-
-        async def _refresh_kb_stats() -> None:
-            docs = await Document.filter(
-                knowledge_base_id=kb.id,
-                status=DocumentStatus.COMPLETED.value,
-            ).all()
-            kb.total_chunks = sum(doc.chunk_count for doc in docs)
-            kb.total_tokens = sum(doc.token_count for doc in docs)
-            await kb.save()
-            logger.info(
-                f"KB {kb.id} stats refreshed: chunks={kb.total_chunks}, tokens={kb.total_tokens}"
-            )
-
-        try:
-            # Get all chunks for this document
-            chunks = await DocumentChunk.filter(document_id=doc_uuid).order_by(
-                "chunk_index"
-            )
-
-            if not chunks:
-                logger.warning(f"No chunks found for document {document_id}")
-                default_lang = await get_default_language()
-                document.status = DocumentStatus.ERROR.value
-                document.error_message = t("no_chunks_to_embed", lang=default_lang)
-                await document.save()
-                return {
-                    "status": "success",
-                    "message": t("no_chunks_to_embed", lang=default_lang),
-                    "embedded_count": 0,
-                }
-
-            # Initialize vector store with KB's embedding model and team ID for usage tracking
-            embedding_model_id = (
-                str(kb.embedding_model_id) if kb.embedding_model_id else None
-            )
-            team_id = str(kb.team_id) if kb.team_id else None
-            vector_store = VectorStore(
-                embedding_model_id=embedding_model_id,
-                team_id=team_id,
-            )
-
-            # Generate embeddings and store vectors for each chunk with progress
-            embedded_count = await DocumentChunk.filter(
-                document_id=doc_uuid, status="embedded"
-            ).count()
-            failed_count = 0
-            last_error = None
-            total_chunks = len(chunks)
-            total_tokens = sum(chunk.token_count for chunk in chunks)
-            for chunk in chunks:
-                if chunk.status == "embedded":
-                    continue
-                try:
-                    await vector_store.add_chunk_vector(kb.id, chunk)
-                    chunk.status = "embedded"
-                    chunk.error_message = None
-                    await chunk.save(update_fields=["status", "error_message"])
-                    embedded_count += 1
-                except Exception as e:
-                    failed_count += 1
-                    last_error = str(e)
-                    chunk.status = "failed"
-                    chunk.error_message = _get_generic_processing_error(
-                        document, user_locale
-                    )[:500]
-                    await chunk.save(update_fields=["status", "error_message"])
-                    logger.error(f"Failed to embed chunk {chunk.id}: {e}")
-
-                # Update progress in document metadata
-                document.metadata = document.metadata or {}
-                document.metadata["embed_progress"] = {
-                    "embedded": embedded_count,
-                    "failed": failed_count,
-                    "total": total_chunks,
-                }
-                await document.save(update_fields=["metadata"])
-
-            # Clear progress from metadata
-            document.metadata = document.metadata or {}
-            _clear_task_metadata(document)
-
-            # Check if embedding was successful
-            if embedded_count == 0 and len(chunks) > 0:
-                # All chunks failed - mark as error
-                document.status = DocumentStatus.ERROR.value
-                document.chunk_count = total_chunks
-                document.token_count = total_tokens
-                document.error_message = t(
-                    "all_chunks_failed_to_embed",
-                    lang=user_locale,
-                    error=last_error or t("unknown_error_generic", lang=user_locale),
-                )[:500]
-                await document.save()
-
-                logger.error(
-                    f"Document {document_id} embedding failed: "
-                    f"0/{len(chunks)} chunks embedded"
-                )
-
-                # Send failure notification
-                localized_error = t(
-                    "all_chunks_failed_to_embed",
-                    lang=user_locale,
-                    error=last_error or t("unknown_error_generic", lang=user_locale),
-                )
-                await _send_doc_failed_notification(
-                    document=document,
-                    kb_name=kb.name,
-                    team_id=kb.team_id,
-                    error=localized_error,
-                    user_locale=user_locale,
-                )
-
-                return {
-                    "status": "error",
-                    "document_id": document_id,
-                    "message": localized_error,
-                    "embedded_count": 0,
-                    "total_chunks": len(chunks),
-                }
-
-            # Check if there were any failures
-            if failed_count > 0:
-                # Partial failure - mark as error with details
-                document.status = DocumentStatus.ERROR.value
-                document.chunk_count = total_chunks
-                document.token_count = total_tokens
-                document.error_message = t(
-                    "chunks_failed_to_embed",
-                    lang=user_locale,
-                    failed_count=failed_count,
-                    total_chunks=len(chunks),
-                    error=last_error,
-                )[:500]
-                await document.save()
-
-                await _refresh_kb_stats()
-
-                logger.error(
-                    f"Document {document_id} embedding partially failed: "
-                    f"{embedded_count}/{len(chunks)} chunks embedded, {failed_count} failed"
-                )
-
-                # Send failure notification
-                await _send_doc_failed_notification(
-                    document=document,
-                    kb_name=kb.name,
-                    team_id=kb.team_id,
-                    error=document.error_message,
-                    user_locale=user_locale,
-                )
-
-                return {
-                    "status": "error",
-                    "document_id": document_id,
-                    "message": document.error_message,
-                    "embedded_count": embedded_count,
-                    "failed_count": failed_count,
-                    "total_chunks": len(chunks),
-                }
-
-            # All chunks embedded successfully
-            document.status = DocumentStatus.COMPLETED.value
-            document.chunk_count = total_chunks
-            document.token_count = total_tokens
-            document.processed_at = datetime.now(timezone.utc)
-            document.error_message = None
-            await document.save()
-            logger.info(
-                f"Document {document_id} status updated: {document.status}, chunks={document.chunk_count}, tokens={document.token_count}"
-            )
-
-            # Update KB statistics
-            await _refresh_kb_stats()
-
-            logger.info(
-                f"Document {document_id} embedding completed: "
-                f"{embedded_count}/{len(chunks)} chunks embedded"
-            )
-
-            # Send success notification
-            await _send_doc_indexed_notification(
-                document=document,
-                kb_name=kb.name,
-                team_id=kb.team_id,
-                chunk_count=document.chunk_count,
-                token_count=document.token_count,
-                user_locale=user_locale,
-            )
-
-            return {
-                "status": "success",
-                "document_id": document_id,
-                "embedded_count": embedded_count,
-                "total_chunks": len(chunks),
-            }
-
-        except Exception as e:
-            logger.exception(f"Error embedding document {document_id}: {e}")
-
-            # Update document status to ERROR
-            document.status = DocumentStatus.ERROR.value
-            _clear_task_metadata(document)
-            document.error_message = _get_generic_processing_error(
-                document, user_locale
-            )[:500]
-            await document.save()
-
-            # Send failure notification
-            await _send_doc_failed_notification(
-                document=document,
-                kb_name=kb.name,
-                team_id=kb.team_id,
-                error=document.error_message,
-                user_locale=user_locale,
-            )
-
-            return {
-                "status": "error",
-                "document_id": document_id,
-                "message": document.error_message,
-            }
-
-    # Run async function
+    task_id = getattr(self.request, "id", None)
     try:
         loop = asyncio.get_event_loop()
     except RuntimeError:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
-    return loop.run_until_complete(_embed())
+    return loop.run_until_complete(
+        _embed_existing_document_chunks(document_id, task_id)
+    )
 
 
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
@@ -1214,12 +1216,10 @@ def retry_failed_chunks_task(self, document_id: str) -> dict:
                     embedded_count += 1
                 except Exception as e:
                     still_failed += 1
-                    last_error = str(e)
-                    chunk.error_message = _get_generic_processing_error(
-                        document, user_locale
-                    )[:500]
+                    last_error = _get_embedding_error(document, e, user_locale)
+                    chunk.error_message = last_error[:500]
                     await chunk.save(update_fields=["error_message"])
-                    logger.error(f"Retry failed for chunk {chunk.id}: {e}")
+                    logger.exception("Retry failed for chunk %s", chunk.id)
 
                 # Update progress
                 document.metadata = document.metadata or {}
@@ -1477,10 +1477,9 @@ def retry_failed_chunk_task(self, document_id: str, chunk_id: str) -> dict:
 
         except Exception as e:
             logger.exception(f"Error retrying failed chunk {chunk_id}: {e}")
+            embedding_error = _get_embedding_error(document, e, user_locale)
             chunk.status = "failed"
-            chunk.error_message = _get_generic_processing_error(document, user_locale)[
-                :500
-            ]
+            chunk.error_message = embedding_error[:500]
             await chunk.save(update_fields=["status", "error_message"])
 
             total_chunks = await DocumentChunk.filter(document_id=doc_uuid).count()
@@ -1495,7 +1494,7 @@ def retry_failed_chunk_task(self, document_id: str, chunk_id: str) -> dict:
                 lang=user_locale,
                 failed_count=remaining_failed,
                 total_chunks=total_chunks,
-                error=str(e) or t("unknown_error_generic", lang=user_locale),
+                error=embedding_error,
             )[:500]
             await document.save()
 

--- a/backend/app/tasks/knowledge_base.py
+++ b/backend/app/tasks/knowledge_base.py
@@ -265,10 +265,13 @@ def process_document_task(self, document_id: str) -> dict:
             clean_text_setting = doc_meta.get("clean_text", True)
 
             if document.file_path:
+                document_processor.delete_media_assets(kb.id, document.id)
                 text, metadata = await document_processor.extract_text(
                     document.file_path,
                     document.doc_type,
                     clean_text=clean_text_setting,
+                    kb_id=kb.id,
+                    document_id=document.id,
                 )
             elif document.source_url:
                 text, metadata = await document_processor.fetch_url_content(
@@ -663,10 +666,13 @@ def rechunk_document_task(self, document_id: str) -> dict:
 
             # Extract text
             if document.file_path:
+                document_processor.delete_media_assets(kb.id, document.id)
                 text, _ = await document_processor.extract_text(
                     document.file_path,
                     document.doc_type,
                     clean_text=clean_text_setting,
+                    kb_id=kb.id,
+                    document_id=document.id,
                 )
             elif document.source_url:
                 text, _ = await document_processor.fetch_url_content(

--- a/backend/tests/services/test_chat_context_sandbox_prompt.py
+++ b/backend/tests/services/test_chat_context_sandbox_prompt.py
@@ -3,10 +3,10 @@ from types import SimpleNamespace
 from app.services.chat_context import _build_system_prompt
 
 
-def _agent(*, tools_config=None):
+def _agent(*, tools_config=None, system_prompt="Base prompt"):
     return SimpleNamespace(
         id="agent-1",
-        system_prompt="Base prompt",
+        system_prompt=system_prompt,
         enable_memory=False,
         enable_user_input_request=False,
         tools_config=tools_config or [],
@@ -71,5 +71,20 @@ def test_build_system_prompt_formats_sections_with_clear_spacing():
         user_locale="en",
     )
 
-    assert "Base prompt\n\n## Sandbox Environment Guidance" in prompt
+    assert "Base prompt\n\n## Markdown Output" in prompt
+    assert "## Markdown Output" in prompt
+    assert "## Sandbox Environment Guidance" in prompt
     assert "## Response Language\nYou MUST respond in English only." in prompt
+
+
+def test_build_system_prompt_injects_markdown_image_display_guidance_without_base_prompt():
+    prompt = _build_system_prompt(
+        agent=_agent(system_prompt=""),
+        conversation=_conversation(),
+        user_message="show the generated image",
+        user_locale="en",
+    )
+
+    assert "## Markdown Output" in prompt
+    assert "normal Markdown image syntax" in prompt
+    assert "Do not wrap the Markdown image in a code block" in prompt

--- a/backend/tests/services/test_document_processor_media_assets.py
+++ b/backend/tests/services/test_document_processor_media_assets.py
@@ -1,0 +1,117 @@
+import base64
+import zipfile
+from uuid import uuid4
+
+import pytest
+
+from app.services.document_processor import DocumentProcessor
+from app.models.knowledge_base import DocumentType
+
+
+def test_replace_embedded_media_data_uris_saves_assets(tmp_path):
+    processor = DocumentProcessor(upload_dir=str(tmp_path / "documents"))
+    kb_id = uuid4()
+    document_id = uuid4()
+    image_content = b"image-bytes"
+    data_uri = "data:image/png;base64," + base64.b64encode(image_content).decode(
+        "ascii"
+    )
+
+    text, assets = processor.replace_embedded_media_data_uris(
+        f"before ![sample]({data_uri}) after",
+        kb_id=kb_id,
+        document_id=document_id,
+    )
+
+    assert data_uri not in text
+    assert f"/api/v1/knowledge-bases/{kb_id}/documents/{document_id}/media/" in text
+    assert len(assets) == 1
+    assert assets[0]["content_type"] == "image/png"
+    assert assets[0]["size"] == len(image_content)
+    assert (
+        processor.get_media_asset_path(
+            kb_id, document_id, assets[0]["filename"]
+        ).read_bytes()
+        == image_content
+    )
+
+
+@pytest.mark.asyncio
+async def test_extract_text_resourceizes_markdown_data_uri_when_context_is_provided(
+    tmp_path,
+):
+    processor = DocumentProcessor(upload_dir=str(tmp_path / "documents"))
+    kb_id = uuid4()
+    document_id = uuid4()
+    image_content = b"image-bytes"
+    data_uri = "data:image/png;base64," + base64.b64encode(image_content).decode(
+        "ascii"
+    )
+    markdown_path = processor.get_storage_path(kb_id, "sample.md")
+
+    with open(markdown_path, "w", encoding="utf-8") as file:
+        file.write(f"# Title\n\n![sample]({data_uri})")
+
+    text, metadata = await processor.extract_text(
+        markdown_path,
+        DocumentType.MD.value,
+        kb_id=kb_id,
+        document_id=document_id,
+    )
+
+    assert data_uri not in text
+    assert metadata["media_assets"][0]["content_type"] == "image/png"
+    assert metadata["media_assets"][0]["size"] == len(image_content)
+
+
+@pytest.mark.asyncio
+async def test_extract_text_resourceizes_docx_embedded_image(tmp_path):
+    processor = DocumentProcessor(upload_dir=str(tmp_path / "documents"))
+    kb_id = uuid4()
+    document_id = uuid4()
+    image_content = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1Pe"
+        "AAAADUlEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+    )
+    docx_path = processor.get_storage_path(kb_id, "sample.docx")
+    content_types = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"""
+    root_rels = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"""
+    document_rels = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+</Relationships>"""
+    document_xml = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+  <w:body>
+    <w:p><w:r><w:t>Before image</w:t></w:r></w:p>
+    <w:p><w:r><w:drawing><wp:inline><wp:docPr id="1" name="Picture 1" descr="red pixel"/><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:pic><pic:nvPicPr><pic:cNvPr id="0" name="sample.png" descr="red pixel"/></pic:nvPicPr><pic:blipFill><a:blip r:embed="rId1"/></pic:blipFill><pic:spPr/></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>
+    <w:p><w:r><w:t>After image</w:t></w:r></w:p>
+  </w:body>
+</w:document>"""
+
+    with zipfile.ZipFile(docx_path, "w") as archive:
+        archive.writestr("[Content_Types].xml", content_types)
+        archive.writestr("_rels/.rels", root_rels)
+        archive.writestr("word/document.xml", document_xml)
+        archive.writestr("word/_rels/document.xml.rels", document_rels)
+        archive.writestr("word/media/image1.png", image_content)
+
+    text, metadata = await processor.extract_text(
+        docx_path,
+        DocumentType.DOCX.value,
+        kb_id=kb_id,
+        document_id=document_id,
+    )
+
+    assert "data:image/png;base64" not in text
+    assert f"/api/v1/knowledge-bases/{kb_id}/documents/{document_id}/media/" in text
+    assert metadata["media_assets"][0]["content_type"] == "image/png"

--- a/backend/tests/services/test_notification_service.py
+++ b/backend/tests/services/test_notification_service.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.notification import NotificationAuditAction
+from app.services.notification import create_notification
+
+
+@pytest.mark.asyncio
+async def test_create_notification_saves_notification_before_audit():
+    notification = SimpleNamespace(id="notification-id", save=AsyncMock())
+
+    with patch(
+        "app.services.notification.create_notification_audit",
+        new=AsyncMock(),
+    ) as create_audit:
+        result = await create_notification(notification)  # type: ignore[arg-type]
+
+    notification.save.assert_awaited_once()
+    create_audit.assert_awaited_once_with(
+        notification_id="notification-id",
+        action=NotificationAuditAction.CREATE,
+        user=None,
+        meta=None,
+    )
+    assert result is notification

--- a/backend/tests/services/test_vector_store.py
+++ b/backend/tests/services/test_vector_store.py
@@ -1,0 +1,94 @@
+import asyncio
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+from app.services.vector_store import EmbeddingRequestTimeoutError, VectorStore
+
+vector_store_module = importlib.import_module("app.services.vector_store")
+
+
+class HangingModelManager:
+    async def embed(self, texts, model_id=None):
+        await asyncio.sleep(1)
+        return []
+
+    async def embed_query(self, text, model_id=None):
+        await asyncio.sleep(1)
+        return []
+
+
+@pytest.mark.asyncio
+async def test_embed_texts_converts_timeout(monkeypatch):
+    monkeypatch.setattr(vector_store_module, "EMBEDDING_REQUEST_TIMEOUT_SECONDS", 0.001)
+    monkeypatch.setattr(vector_store_module, "_get_model_manager", HangingModelManager)
+
+    store = VectorStore()
+
+    with pytest.raises(EmbeddingRequestTimeoutError):
+        await store.embed_texts(["slow"])
+
+
+@pytest.mark.asyncio
+async def test_embed_query_converts_timeout(monkeypatch):
+    monkeypatch.setattr(vector_store_module, "EMBEDDING_REQUEST_TIMEOUT_SECONDS", 0.001)
+    monkeypatch.setattr(vector_store_module, "_get_model_manager", HangingModelManager)
+
+    store = VectorStore()
+
+    with pytest.raises(EmbeddingRequestTimeoutError):
+        await store.embed_query("slow")
+
+
+@pytest.mark.asyncio
+async def test_add_chunk_vector_uses_timed_embed_texts(monkeypatch):
+    calls = []
+    chunk = SimpleNamespace(
+        id="chunk-id",
+        document_id="document-id",
+        content="content",
+        embedding_id=None,
+    )
+    chunk.save = AsyncMock()
+
+    async def fake_embed_texts(self, texts):
+        calls.append(texts)
+        return [[0.1, 0.2, 0.3]]
+
+    async def fake_ensure_kb_dimension(kb_id, dimension):
+        assert str(kb_id) == "00000000-0000-0000-0000-000000000001"
+        assert dimension == 3
+
+    async def fake_store_embedding(
+        self, chunk_id, embedding, dimension=None, payload=None
+    ):
+        assert chunk_id == "chunk-id"
+        assert embedding == [0.1, 0.2, 0.3]
+        assert dimension == 3
+        assert payload == {
+            "kb_id": "00000000-0000-0000-0000-000000000001",
+            "document_id": "document-id",
+        }
+
+    monkeypatch.setattr(VectorStore, "embed_texts", fake_embed_texts)
+    monkeypatch.setattr(
+        vector_store_module, "_ensure_kb_dimension", fake_ensure_kb_dimension
+    )
+    monkeypatch.setattr(VectorStore, "_store_embedding", fake_store_embedding)
+
+    store = VectorStore()
+
+    result = await store.add_chunk_vector(
+        UUID("00000000-0000-0000-0000-000000000001"),
+        chunk,
+    )
+
+    assert result is True
+    assert calls == [["content"]]
+    assert (
+        chunk.embedding_id == "kb_00000000-0000-0000-0000-000000000001_chunk_chunk-id"
+    )
+    chunk.save.assert_awaited_once()

--- a/frontend/app/(platform)/app/kb/[id]/documents/[docId]/_components/document-detail-client.tsx
+++ b/frontend/app/(platform)/app/kb/[id]/documents/[docId]/_components/document-detail-client.tsx
@@ -551,6 +551,17 @@ export function DocumentDetailClient({ knowledgeBaseId, documentId }: DocumentDe
             <div className="flex flex-col items-center justify-center h-full text-center p-8">
               <Loader2 className="h-12 w-12 text-blue-500 animate-spin mb-4" />
               <h3 className="text-lg font-medium mb-2">{t('documentProcessingTitle')}</h3>
+              {(() => {
+                const progress = document.metadata?.embed_progress as { embedded?: number; failed?: number; total?: number } | undefined
+                if (progress?.total) {
+                  return (
+                    <p className="text-sm text-blue-500 font-medium mb-2">
+                      {t('embeddingProgress', { embedded: progress.embedded ?? 0, total: progress.total })}
+                    </p>
+                  )
+                }
+                return null
+              })()}
               <p className="text-muted-foreground max-w-md">
                 {t('documentProcessingDescription')}
               </p>

--- a/frontend/app/(platform)/app/kb/[id]/search/_components/search-test-client.tsx
+++ b/frontend/app/(platform)/app/kb/[id]/search/_components/search-test-client.tsx
@@ -47,6 +47,7 @@ function AuthenticatedMarkdownImage({ src = '', alt = '' }: { src?: string, alt?
   const [failed, setFailed] = React.useState(false)
 
   React.useEffect(() => {
+    let cancelled = false
     setFailed(false)
     if (!src) {
       setObjectUrl(null)
@@ -74,14 +75,17 @@ function AuthenticatedMarkdownImage({ src = '', alt = '' }: { src?: string, alt?
         return response.blob()
       })
       .then(blob => {
+        if (cancelled) return
         currentObjectUrl = URL.createObjectURL(blob)
         setObjectUrl(currentObjectUrl)
       })
       .catch(error => {
+        if (cancelled) return
         if ((error as Error).name !== 'AbortError') setFailed(true)
       })
 
     return () => {
+      cancelled = true
       controller.abort()
       if (currentObjectUrl) URL.revokeObjectURL(currentObjectUrl)
     }

--- a/frontend/app/(platform)/app/kb/[id]/search/_components/search-test-client.tsx
+++ b/frontend/app/(platform)/app/kb/[id]/search/_components/search-test-client.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import * as React from 'react'
+import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
+import { useTheme } from 'next-themes'
 import {
   ArrowLeft,
   Search,
@@ -33,18 +35,82 @@ import {
   ToggleGroupItem,
 } from '@/components/ui/toggle-group'
 import { cn } from '@/lib/utils'
+import { API_BASE_URL } from '@/lib/constants'
 
 interface SearchTestClientProps {
   knowledgeBaseId: string
 }
 
+const MDPreview = dynamic(() => import('@uiw/react-md-editor').then(mod => mod.default.Markdown), { ssr: false })
+
+function resolveMediaUrl(src: string): string {
+  if (src.startsWith('/api/v1/')) {
+    return `${API_BASE_URL.replace(/\/api\/v1\/?$/, '')}${src}`
+  }
+  return src
+}
+
+function AuthenticatedMarkdownImage({ src = '', alt = '' }: { src?: string, alt?: string }) {
+  const [objectUrl, setObjectUrl] = React.useState<string | null>(null)
+  const [failed, setFailed] = React.useState(false)
+
+  React.useEffect(() => {
+    setFailed(false)
+    if (!src) {
+      setObjectUrl(null)
+      return
+    }
+    if (src.startsWith('data:') || src.startsWith('javascript:')) {
+      setObjectUrl(null)
+      setFailed(true)
+      return
+    }
+    if (!src.startsWith('/api/v1/knowledge-bases/')) {
+      setObjectUrl(src)
+      return
+    }
+
+    setObjectUrl(null)
+    const controller = new AbortController()
+    const token = localStorage.getItem('access_token')
+    const headers = token ? { Authorization: `Bearer ${token}` } : undefined
+    let currentObjectUrl: string | null = null
+
+    fetch(resolveMediaUrl(src), { headers, signal: controller.signal })
+      .then(response => {
+        if (!response.ok) throw new Error('image_load_failed')
+        return response.blob()
+      })
+      .then(blob => {
+        currentObjectUrl = URL.createObjectURL(blob)
+        setObjectUrl(currentObjectUrl)
+      })
+      .catch(error => {
+        if ((error as Error).name !== 'AbortError') setFailed(true)
+      })
+
+    return () => {
+      controller.abort()
+      if (currentObjectUrl) URL.revokeObjectURL(currentObjectUrl)
+    }
+  }, [src])
+
+  if (failed || !objectUrl) {
+    return <span className="text-muted-foreground">{alt || src}</span>
+  }
+
+  return <img src={objectUrl} alt={alt} loading="lazy" />
+}
+
 export function SearchTestClient({ knowledgeBaseId }: SearchTestClientProps) {
   const t = useTranslations('knowledgeBases')
   const router = useRouter()
+  const { resolvedTheme } = useTheme()
   
   // 知识库信息
   const [knowledgeBase, setKnowledgeBase] = React.useState<KnowledgeBase | null>(null)
   const [isLoadingKb, setIsLoadingKb] = React.useState(true)
+  const [mounted, setMounted] = React.useState(false)
   
   // 搜索状态
   const [query, setQuery] = React.useState('')
@@ -64,7 +130,13 @@ export function SearchTestClient({ knowledgeBaseId }: SearchTestClientProps) {
   
   // 展开的结果
   const [expandedResults, setExpandedResults] = React.useState<Set<string>>(new Set())
-  
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const colorMode = mounted ? (resolvedTheme === 'dark' ? 'dark' : 'light') : 'light'
+
   // 加载知识库信息
   React.useEffect(() => {
     const loadKnowledgeBase = async () => {
@@ -285,10 +357,20 @@ export function SearchTestClient({ knowledgeBaseId }: SearchTestClientProps) {
                           )}
                         </div>
                       )}
-                      <div className="rounded bg-muted/50 p-3">
-                        <p className="text-xs whitespace-pre-wrap leading-relaxed">
-                          {result.content}
-                        </p>
+                      <div className="rounded bg-muted/50 p-3" data-color-mode={colorMode}>
+                        <div className="wmde-markdown text-xs leading-relaxed [&_img]:max-h-80 [&_img]:rounded-md [&_img]:border [&_img]:object-contain">
+                          <MDPreview
+                            source={result.content}
+                            components={{
+                              img: ({ src, alt }) => (
+                                <AuthenticatedMarkdownImage
+                                  src={typeof src === 'string' ? src : undefined}
+                                  alt={alt}
+                                />
+                              ),
+                            }}
+                          />
+                        </div>
                       </div>
                       {result.rerank_reason && (
                         <p className="mt-2 text-[11px] text-muted-foreground">

--- a/frontend/app/(platform)/app/kb/[id]/search/_components/search-test-client.tsx
+++ b/frontend/app/(platform)/app/kb/[id]/search/_components/search-test-client.tsx
@@ -35,20 +35,12 @@ import {
   ToggleGroupItem,
 } from '@/components/ui/toggle-group'
 import { cn } from '@/lib/utils'
-import { API_BASE_URL } from '@/lib/constants'
 
 interface SearchTestClientProps {
   knowledgeBaseId: string
 }
 
 const MDPreview = dynamic(() => import('@uiw/react-md-editor').then(mod => mod.default.Markdown), { ssr: false })
-
-function resolveMediaUrl(src: string): string {
-  if (src.startsWith('/api/v1/')) {
-    return `${API_BASE_URL.replace(/\/api\/v1\/?$/, '')}${src}`
-  }
-  return src
-}
 
 function AuthenticatedMarkdownImage({ src = '', alt = '' }: { src?: string, alt?: string }) {
   const [objectUrl, setObjectUrl] = React.useState<string | null>(null)
@@ -76,7 +68,7 @@ function AuthenticatedMarkdownImage({ src = '', alt = '' }: { src?: string, alt?
     const headers = token ? { Authorization: `Bearer ${token}` } : undefined
     let currentObjectUrl: string | null = null
 
-    fetch(resolveMediaUrl(src), { headers, signal: controller.signal })
+    fetch(src, { headers, signal: controller.signal })
       .then(response => {
         if (!response.ok) throw new Error('image_load_failed')
         return response.blob()

--- a/frontend/components/chat/message.tsx
+++ b/frontend/components/chat/message.tsx
@@ -1443,6 +1443,73 @@ function PreviewableMarkdownBlock({
   )
 }
 
+function getAuthenticatedApiAssetUrl(src: string): string | null {
+  return src.startsWith('/api/v1/') ? src : null
+}
+
+function isBlockedImageSrc(src: string): boolean {
+  const normalized = src.trim().toLowerCase()
+  return normalized.startsWith('javascript:') || normalized.startsWith('data:')
+}
+
+type AuthenticatedMarkdownImageProps = Omit<React.ComponentProps<'img'>, 'src' | 'alt'> & {
+  src?: string
+  alt?: string
+}
+
+function AuthenticatedMarkdownImage({ src = '', alt = '', ...props }: AuthenticatedMarkdownImageProps) {
+  const [objectUrl, setObjectUrl] = React.useState<string | null>(null)
+  const [failed, setFailed] = React.useState(false)
+
+  React.useEffect(() => {
+    setFailed(false)
+    if (!src) {
+      setObjectUrl(null)
+      return
+    }
+    if (isBlockedImageSrc(src)) {
+      setObjectUrl(null)
+      setFailed(true)
+      return
+    }
+    const authenticatedUrl = getAuthenticatedApiAssetUrl(src)
+    if (!authenticatedUrl) {
+      setObjectUrl(src)
+      return
+    }
+
+    setObjectUrl(null)
+    const controller = new AbortController()
+    const token = localStorage.getItem('access_token')
+    const headers = token ? { Authorization: `Bearer ${token}` } : undefined
+    let currentObjectUrl: string | null = null
+
+    fetch(authenticatedUrl, { headers, signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) throw new Error('image_load_failed')
+        return response.blob()
+      })
+      .then((blob) => {
+        currentObjectUrl = URL.createObjectURL(blob)
+        setObjectUrl(currentObjectUrl)
+      })
+      .catch((error) => {
+        if ((error as Error).name !== 'AbortError') setFailed(true)
+      })
+
+    return () => {
+      controller.abort()
+      if (currentObjectUrl) URL.revokeObjectURL(currentObjectUrl)
+    }
+  }, [src])
+
+  if (failed || !objectUrl) {
+    return <span className="text-muted-foreground">{alt || src}</span>
+  }
+
+  return <img {...props} src={objectUrl} alt={alt} loading="lazy" />
+}
+
 function isSameOriginChatLink(url: string) {
   if (typeof window === 'undefined') {
     return false
@@ -1706,6 +1773,9 @@ function TextWithCitations({
   const rehypePlugins = isStreaming ? STREAMING_REHYPE_PLUGINS : undefined
 
   const components = React.useMemo(() => ({
+    img: ({ src, alt, ...props }: React.ComponentProps<'img'>) => (
+      <AuthenticatedMarkdownImage src={typeof src === 'string' ? src : undefined} alt={alt || ''} {...props} />
+    ),
     p: ({ children, node, ...props }: React.ComponentProps<'p'> & {
       node?: {
         children?: Array<{ tagName?: string; type?: string }>


### PR DESCRIPTION
## Summary
- Preserve embedded document images during MarkItDown conversion by saving data URI media as private knowledge base assets.
- Serve extracted media through authenticated knowledge base document routes and clean assets on delete/reprocess.
- Render Markdown search results with authenticated image loading so matched chunks can show referenced images.

## Test plan
- [x] `PYTHONPATH=backend uv run --project backend pytest backend/tests/services/test_document_processor_media_assets.py`
- [x] `uv run --project backend ruff check backend/app/services/document_processor.py backend/app/api/v1/endpoints/knowledge_bases.py backend/app/tasks/knowledge_base.py backend/tests/services/test_document_processor_media_assets.py`
- [x] `uv run --project backend ruff format --check backend/app/services/document_processor.py backend/app/api/v1/endpoints/knowledge_bases.py backend/app/tasks/knowledge_base.py backend/tests/services/test_document_processor_media_assets.py`
- [x] `bun run --cwd frontend lint -- "app/(platform)/app/kb/[id]/search/_components/search-test-client.tsx"`
- [x] `bun run --cwd frontend build`

Refs YUN-88.