### PR TITLE
YUN-75: Admin observability dashboard

### DIFF
--- a/backend/app/api/v1/admin/api.py
+++ b/backend/app/api/v1/admin/api.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.api.v1.admin.endpoints import (
     dashboard,
+    observability,
     audit_logs,
     conversations,
     users,
@@ -27,6 +28,9 @@ admin_router = APIRouter()
 
 admin_router.include_router(
     dashboard.router, prefix="/dashboard", tags=["admin-dashboard"]
+)
+admin_router.include_router(
+    observability.router, prefix="/observability", tags=["admin-observability"]
 )
 admin_router.include_router(
     audit_logs.router, prefix="/audit-logs", tags=["admin-audit-logs"]

--- a/backend/app/api/v1/admin/endpoints/observability.py
+++ b/backend/app/api/v1/admin/endpoints/observability.py
@@ -1,0 +1,208 @@
+"""
+Admin observability endpoints.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+
+from app.api.deps import PermissionChecker
+from app.models.user import User
+from app.schemas.response import Response, success
+from app.services import admin_observability
+
+router = APIRouter()
+
+
+def _cache_params(**params: Any) -> dict[str, Any]:
+    return {key: value for key, value in params.items() if value is not None}
+
+
+@router.get("/overview", response_model=Response[dict])
+async def get_observability_overview(
+    time_range: str = Query("30d", description="Time range: 7d, 30d, 90d, all"),
+    current_user: User = Depends(PermissionChecker("admin:dashboard:access")),
+) -> Any:
+    data = await admin_observability.cached_payload(
+        "overview",
+        _cache_params(time_range=time_range),
+        lambda: admin_observability.get_overview(time_range),
+    )
+    return success(data=data)
+
+
+@router.get("/agents", response_model=Response[dict])
+async def get_observability_agents(
+    time_range: str = Query("30d", description="Time range: 7d, 30d, 90d, all"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    sort_by: str = Query("requests"),
+    sort_order: str = Query("desc", pattern="^(asc|desc)$"),
+    current_user: User = Depends(PermissionChecker("admin:dashboard:access")),
+) -> Any:
+    data = await admin_observability.cached_payload(
+        "agents",
+        _cache_params(
+            time_range=time_range,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        ),
+        lambda: admin_observability.get_agents(
+            time_range, page, page_size, sort_by, sort_order
+        ),
+    )
+    return success(data=data)
+
+
+@router.get("/agent/{agent_id}", response_model=Response[dict])
+async def get_observability_agent_detail(
+    agent_id: UUID,
+    time_range: str = Query("30d", description="Time range: 7d, 30d, 90d, all"),
+    current_user: User = Depends(PermissionChecker("admin:dashboard:access")),
+) -> Any:
+    data = await admin_observability.cached_payload(
+        "agent-detail",
+        _cache_params(agent_id=str(agent_id), time_range=time_range),
+        lambda: admin_observability.get_agent_detail(agent_id, time_range),
+    )
+    return success(data=data)
+
+
+@router.get("/workflows", response_model=Response[dict])
+async def get_observability_workflows(
+    time_range: str = Query("30d", description="Time range: 7d, 30d, 90d, all"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    sort_by: str = Query("runs"),
+    sort_order: str = Query("desc", pattern="^(asc|desc)$"),
+    current_user: User = Depends(PermissionChecker("admin:dashboard:access")),
+) -> Any:
+    data = await admin_observability.cached_payload(
+        "workflows",
+        _cache_params(
+            time_range=time_range,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        ),
+        lambda: admin_observability.get_workflows(
+            time_range, page, page_size, sort_by, sort_order
+        ),
+    )
+    return success(data=data)
+
+
+@router.get("/workflow/{workflow_id}", response_model=Response[dict])
+async def get_observability_workflow_detail(
+    workflow_id: UUID,
+    time_range: str = Query("30d", description="Time range: 7d, 30d, 90d, all"),
+    current_user: User = Depends(PermissionChecker("admin:dashboard:access")),
+) -> Any:
+    data = await admin_observability.cached_payload(
+        "workflow-detail",
+        _cache_params(workflow_id=str(workflow_id), time_range=time_range),
+        lambda: admin_observability.get_workflow_detail(workflow_id, time_range),
+    )
+    return success(data=data)
+
+
+@router.get("/timeouts", response_model=Response[dict])
+async def get_observability_timeouts(
+    time_range: str = Query("30d", description="Time range: 7d, 30d, 90d, all"),
+    source: str = Query("all", pattern="^(all|agent|workflow)$"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    current_user: User = Depends(PermissionChecker("admin:dashboard:access")),
+) -> Any:
+    data = await admin_observability.cached_payload(
+        "timeouts",
+        _cache_params(
+            time_range=time_range, source=source, page=page, page_size=page_size
+        ),
+        lambda: admin_observability.get_timeouts(time_range, source, page, page_size),
+    )
+    return success(data=data)
+
+
+@router.get("/throughput", response_model=Response[dict])
+async def get_observability_throughput(
+    time_range: str = Query("30d", description="Time range: 7d, 30d, 90d, all"),
+    granularity: str | None = Query(None, description="Granularity: hour, day"),
+    current_user: User = Depends(PermissionChecker("admin:dashboard:access")),
+) -> Any:
+    data = await admin_observability.cached_payload(
+        "throughput",
+        _cache_params(time_range=time_range, granularity=granularity),
+        lambda: admin_observability.get_throughput(time_range, granularity),
+    )
+    return success(data=data)
+
+
+@router.get("/tokens", response_model=Response[dict])
+async def get_observability_tokens(
+    time_range: str = Query("30d", description="Time range: 7d, 30d, 90d, all"),
+    current_user: User = Depends(PermissionChecker("admin:dashboard:access")),
+) -> Any:
+    data = await admin_observability.cached_payload(
+        "tokens",
+        _cache_params(time_range=time_range),
+        lambda: admin_observability.get_tokens(time_range),
+    )
+    return success(data=data)
+
+
+@router.get("/system/health", response_model=Response[dict])
+async def get_observability_system_health(
+    current_user: User = Depends(PermissionChecker("admin:dashboard:access")),
+) -> Any:
+    data = await admin_observability.cached_payload(
+        "system-health",
+        {},
+        admin_observability.get_system_health,
+    )
+    return success(data=data)
+
+
+@router.get("/system/trend", response_model=Response[dict])
+async def get_observability_system_trend(
+    current_user: User = Depends(PermissionChecker("admin:dashboard:access")),
+) -> Any:
+    data = await admin_observability.cached_payload(
+        "system-trend",
+        {},
+        admin_observability.get_system_trend,
+    )
+    return success(data=data)
+
+
+@router.get("/system/slow-queries", response_model=Response[dict])
+async def get_observability_slow_queries(
+    threshold_ms: int = Query(1000, ge=1),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    current_user: User = Depends(PermissionChecker("admin:dashboard:access")),
+) -> Any:
+    data = await admin_observability.cached_payload(
+        "system-slow-queries",
+        _cache_params(threshold_ms=threshold_ms, page=page, page_size=page_size),
+        lambda: admin_observability.get_slow_queries(threshold_ms, page, page_size),
+    )
+    return success(data=data)
+
+
+@router.get("/system/workers", response_model=Response[dict])
+async def get_observability_workers(
+    current_user: User = Depends(PermissionChecker("admin:dashboard:access")),
+) -> Any:
+    data = await admin_observability.cached_payload(
+        "system-workers",
+        {},
+        admin_observability.get_workers,
+    )
+    return success(data=data)

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -532,6 +532,12 @@ async def round_has_persisted_trace(message: Message | None) -> bool:
     ).exists()
 
 
+def _first_token_ms(start_time: float, first_token_time: float | None) -> int | None:
+    if first_token_time is None:
+        return None
+    return int((first_token_time - start_time) * 1000)
+
+
 async def persist_partial_round_error(
     message: Message | None,
     *,
@@ -539,6 +545,7 @@ async def persist_partial_round_error(
     reasoning: str,
     model_id: str | None,
     start_time: float,
+    first_token_time: float | None = None,
     fallback_content: str | None = None,
 ) -> bool:
     if message is None:
@@ -562,6 +569,7 @@ async def persist_partial_round_error(
     message.model_used = model_id  # type: ignore[assignment]
     message.model_used = model_id
     message.duration_ms = int((time.time() - start_time) * 1000)
+    message.first_token_ms = _first_token_ms(start_time, first_token_time)
     message.is_manually_stopped = False
     message.round_status = MessageRoundStatus.ERROR
     message.created_at = now_utc()
@@ -1714,6 +1722,9 @@ async def chat_stream(
                             assistant_msg.duration_ms = int(
                                 (time.time() - start_time) * 1000
                             )
+                            assistant_msg.first_token_ms = _first_token_ms(
+                                start_time, first_token_time
+                            )
                             assistant_msg.is_manually_stopped = True
                             assistant_msg.round_status = (
                                 MessageRoundStatus.MANUALLY_STOPPED
@@ -2057,6 +2068,9 @@ async def chat_stream(
                             assistant_msg.duration_ms = int(
                                 (time.time() - start_time) * 1000
                             )
+                            assistant_msg.first_token_ms = _first_token_ms(
+                                start_time, first_token_time
+                            )
                             assistant_msg.is_manually_stopped = True
                             assistant_msg.round_status = (
                                 MessageRoundStatus.MANUALLY_STOPPED
@@ -2093,6 +2107,9 @@ async def chat_stream(
                                     assistant_msg.model_used = model_id
                                     assistant_msg.duration_ms = int(
                                         (time.time() - start_time) * 1000
+                                    )
+                                    assistant_msg.first_token_ms = _first_token_ms(
+                                        start_time, first_token_time
                                     )
                                     assistant_msg.is_manually_stopped = True
                                     assistant_msg.round_status = (
@@ -2154,6 +2171,9 @@ async def chat_stream(
                                     assistant_msg.model_used = model_id
                                     assistant_msg.duration_ms = int(
                                         (time.time() - start_time) * 1000
+                                    )
+                                    assistant_msg.first_token_ms = _first_token_ms(
+                                        start_time, first_token_time
                                     )
                                     assistant_msg.is_manually_stopped = True
                                     assistant_msg.round_status = (
@@ -2294,6 +2314,9 @@ async def chat_stream(
                     )
                     assistant_msg.model_used = model_id
                     assistant_msg.duration_ms = duration_ms
+                    assistant_msg.first_token_ms = _first_token_ms(
+                        start_time, first_token_time
+                    )
                     assistant_msg.is_manually_stopped = False
                     assistant_msg.round_status = terminal_round_status
                     # Ensure assistant message appears after tool calls/results in history
@@ -2377,11 +2400,7 @@ async def chat_stream(
                     )
 
                     # Send message_end event with version info and timing
-                    first_token_ms = (
-                        int((first_token_time - start_time) * 1000)
-                        if first_token_time
-                        else None
-                    )
+                    first_token_ms = assistant_msg.first_token_ms
                     tokens_per_second = (
                         round(output_tokens / (duration_ms / 1000), 1)
                         if duration_ms > 0 and output_tokens > 0
@@ -2396,6 +2415,7 @@ async def chat_stream(
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
+                        first_token_time=first_token_time,
                         fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                     )
                     logger.warning("Quota exceeded during stream: %s", e)
@@ -2407,6 +2427,7 @@ async def chat_stream(
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
+                        first_token_time=first_token_time,
                         fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                     )
                     logger.error("Model not found error during stream: %s", e)
@@ -2418,6 +2439,7 @@ async def chat_stream(
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
+                        first_token_time=first_token_time,
                         fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                     )
                     logger.error("Authentication error during stream: %s", e)
@@ -2429,6 +2451,7 @@ async def chat_stream(
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
+                        first_token_time=first_token_time,
                         fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                     )
                     logger.warning("Rate limit error during stream: %s", e)
@@ -2442,6 +2465,7 @@ async def chat_stream(
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
+                        first_token_time=first_token_time,
                         fallback_content=error_message,
                     )
                     yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': error_message})}\n\n"
@@ -2458,6 +2482,7 @@ async def chat_stream(
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
+                        first_token_time=first_token_time,
                         fallback_content=t("stream_timeout_exceeded"),
                     )
                     yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t('stream_timeout_exceeded'), 'timeout': idle_timeout})}\n\n"
@@ -2469,6 +2494,7 @@ async def chat_stream(
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
+                        first_token_time=first_token_time,
                         fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                     )
                     yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t(GENERIC_STREAM_ERROR_KEY)})}\n\n"
@@ -2487,6 +2513,7 @@ async def chat_stream(
                 reasoning=full_reasoning,
                 model_id=model_id,
                 start_time=start_time,
+                first_token_time=first_token_time,
                 fallback_content=t("stream_timeout_exceeded"),
             )
             # Send timeout error event
@@ -2501,6 +2528,9 @@ async def chat_stream(
                 assistant_msg.reasoning_content = full_reasoning or None
                 assistant_msg.model_used = model_id
                 assistant_msg.duration_ms = int((time.time() - start_time) * 1000)
+                assistant_msg.first_token_ms = _first_token_ms(
+                    start_time, first_token_time
+                )
                 assistant_msg.is_manually_stopped = True
                 assistant_msg.round_status = MessageRoundStatus.MANUALLY_STOPPED
                 assistant_msg.created_at = now_utc()
@@ -2522,6 +2552,7 @@ async def chat_stream(
                     reasoning=full_reasoning,
                     model_id=model_id,
                     start_time=start_time,
+                    first_token_time=first_token_time,
                     fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                 )
             yield f"event: {SSEEventType.ERROR}\ndata: {json.dumps({'code': ResponseCode.UNKNOWN_ERROR, 'msg': t(GENERIC_STREAM_ERROR_KEY)})}\n\n"
@@ -2603,6 +2634,7 @@ async def build_message_out_with_versions(
         model_used=message.model_used,
         token_usage=message.token_usage,
         duration_ms=message.duration_ms,
+        first_token_ms=message.first_token_ms,
         is_manually_stopped=message.is_manually_stopped,
         rag_context=message.rag_context,
         created_at=message.created_at,
@@ -2973,6 +3005,9 @@ async def regenerate_message(
                             new_message.duration_ms = int(
                                 (time.time() - start_time) * 1000
                             )
+                            new_message.first_token_ms = _first_token_ms(
+                                start_time, first_token_time
+                            )
                             new_message.is_manually_stopped = True
                             new_message.round_status = (
                                 MessageRoundStatus.MANUALLY_STOPPED
@@ -3235,6 +3270,9 @@ async def regenerate_message(
                             new_message.duration_ms = int(
                                 (time.time() - start_time) * 1000
                             )
+                            new_message.first_token_ms = _first_token_ms(
+                                start_time, first_token_time
+                            )
                             new_message.is_manually_stopped = True
                             new_message.round_status = (
                                 MessageRoundStatus.MANUALLY_STOPPED
@@ -3258,6 +3296,9 @@ async def regenerate_message(
                                     new_message.model_used = model_id
                                     new_message.duration_ms = int(
                                         (time.time() - start_time) * 1000
+                                    )
+                                    new_message.first_token_ms = _first_token_ms(
+                                        start_time, first_token_time
                                     )
                                     new_message.is_manually_stopped = True
                                     new_message.round_status = (
@@ -3314,6 +3355,9 @@ async def regenerate_message(
                                     new_message.model_used = model_id
                                     new_message.duration_ms = int(
                                         (time.time() - start_time) * 1000
+                                    )
+                                    new_message.first_token_ms = _first_token_ms(
+                                        start_time, first_token_time
                                     )
                                     new_message.is_manually_stopped = True
                                     new_message.round_status = (
@@ -3445,6 +3489,9 @@ async def regenerate_message(
                     )
                     new_message.model_used = model_id
                     new_message.duration_ms = duration_ms
+                    new_message.first_token_ms = _first_token_ms(
+                        start_time, first_token_time
+                    )
                     new_message.is_manually_stopped = False
                     new_message.round_status = terminal_round_status
                     # Ensure regenerated message appears after tool calls/results in history
@@ -3510,11 +3557,7 @@ async def regenerate_message(
                         total_tokens=F("total_tokens") + total_tokens,
                     )
 
-                    first_token_ms = (
-                        int((first_token_time - start_time) * 1000)
-                        if first_token_time
-                        else None
-                    )
+                    first_token_ms = new_message.first_token_ms
                     tokens_per_second = (
                         round(output_tokens / (duration_ms / 1000), 1)
                         if duration_ms > 0 and output_tokens > 0
@@ -3529,6 +3572,7 @@ async def regenerate_message(
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
+                        first_token_time=first_token_time,
                         fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                     )
                     if preserved_partial:
@@ -3547,6 +3591,7 @@ async def regenerate_message(
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
+                        first_token_time=first_token_time,
                         fallback_content=error_message,
                     )
                     if preserved_partial:
@@ -3564,6 +3609,7 @@ async def regenerate_message(
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
+                        first_token_time=first_token_time,
                         fallback_content=t("stream_timeout_exceeded"),
                     )
                     if preserved_partial:
@@ -3586,6 +3632,7 @@ async def regenerate_message(
                         reasoning=full_reasoning,
                         model_id=model_id,
                         start_time=start_time,
+                        first_token_time=first_token_time,
                         fallback_content=t(GENERIC_STREAM_ERROR_KEY),
                     )
                     if preserved_partial:
@@ -3611,6 +3658,7 @@ async def regenerate_message(
                 reasoning=full_reasoning,
                 model_id=model_id,
                 start_time=start_time,
+                first_token_time=first_token_time,
                 fallback_content=t("stream_timeout_exceeded"),
             )
             if preserved_partial:
@@ -3630,6 +3678,9 @@ async def regenerate_message(
                 new_message.reasoning_content = full_reasoning or None
                 new_message.model_used = model_id
                 new_message.duration_ms = int((time.time() - start_time) * 1000)
+                new_message.first_token_ms = _first_token_ms(
+                    start_time, first_token_time
+                )
                 new_message.is_manually_stopped = True
                 new_message.round_status = MessageRoundStatus.MANUALLY_STOPPED
                 new_message.created_at = now_utc()
@@ -3653,6 +3704,7 @@ async def regenerate_message(
                 reasoning=full_reasoning,
                 model_id=model_id,
                 start_time=start_time,
+                first_token_time=first_token_time,
                 fallback_content=t(GENERIC_STREAM_ERROR_KEY),
             )
             if preserved_partial:

--- a/backend/app/core/init_data.py
+++ b/backend/app/core/init_data.py
@@ -524,6 +524,10 @@ async def init_message_first_token_field():
     logger.info("Checking message first_token_ms field...")
 
     conn = Tortoise.get_connection("default")
+    dialect = getattr(getattr(conn, "capabilities", None), "dialect", "")
+    if dialect != "postgres":
+        logger.info("Skipping first_token_ms migration for non-PostgreSQL database")
+        return
 
     _, tables = await conn.execute_query("""
         SELECT table_name FROM information_schema.tables

--- a/backend/app/core/init_data.py
+++ b/backend/app/core/init_data.py
@@ -519,6 +519,43 @@ async def init_message_manual_stop_field():
     logger.info("Message manual stop migration complete")
 
 
+async def init_message_first_token_field():
+    """Add first_token_ms field to messages table if it does not exist."""
+    logger.info("Checking message first_token_ms field...")
+
+    conn = Tortoise.get_connection("default")
+
+    _, tables = await conn.execute_query("""
+        SELECT table_name FROM information_schema.tables
+        WHERE table_name = 'messages' AND table_schema = 'public'
+    """)
+
+    if not tables:
+        logger.info(
+            "Messages table does not exist yet, skipping first_token_ms migration"
+        )
+        return
+
+    _, rows = await conn.execute_query("""
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'messages' AND column_name = 'first_token_ms'
+    """)
+
+    if rows:
+        logger.info("first_token_ms column already exists")
+        return
+
+    logger.info("Adding first_token_ms column to messages table...")
+    await execute_startup_migration_query(
+        conn,
+        """
+        ALTER TABLE messages
+        ADD COLUMN first_token_ms INT NULL
+        """,
+    )
+    logger.info("Message first_token_ms migration complete")
+
+
 async def init_message_round_fields():
     """
     Add round-aware metadata fields to messages table.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -82,6 +82,7 @@ async def lifespan(app: FastAPI):
         init_agent_streaming_config,
         init_agent_context_compression_config,
         init_message_manual_stop_field,
+        init_message_first_token_field,
         init_message_round_fields,
         init_message_branch_parent_field,
         init_conversation_session_memory_table,
@@ -141,6 +142,11 @@ async def lifespan(app: FastAPI):
         await init_message_manual_stop_field()
     except Exception as e:
         logger.warning(f"Message manual stop migration failed: {e}")
+
+    try:
+        await init_message_first_token_field()
+    except Exception as e:
+        logger.warning(f"Message first token migration failed: {e}")
 
     try:
         await init_message_round_fields()

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -452,6 +452,9 @@ class Message(models.Model):
         null=True, description='Token usage {"prompt": 100, "completion": 50}'
     )
     duration_ms = fields.IntField(null=True, description="Response duration in ms")
+    first_token_ms = fields.IntField(
+        null=True, description="Time to first streamed token in ms"
+    )
     is_manually_stopped = fields.BooleanField(
         default=False, description="Whether generation was manually stopped"
     )

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -786,6 +786,7 @@ class MessageRoundStep(BaseModel):
     model_used: str | None = None
     token_usage: dict[str, int] | None = None
     duration_ms: int | None = None
+    first_token_ms: int | None = None
     is_manually_stopped: bool = False
     rag_context: list[dict[str, Any]] | None = None
     created_at: datetime
@@ -820,6 +821,7 @@ class MessageOut(BaseModel):
     model_used: str | None = None
     token_usage: dict[str, int] | None = None
     duration_ms: int | None = None
+    first_token_ms: int | None = None
     is_manually_stopped: bool = False
     rag_context: list[dict[str, Any]] | None = None
     created_at: datetime

--- a/backend/app/services/admin_observability.py
+++ b/backend/app/services/admin_observability.py
@@ -1,0 +1,1078 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import platform
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from tortoise import Tortoise
+
+from app.core.celery import celery_app
+from app.core.redis import get_redis
+from app.core.timezone import now, to_utc
+from app.models.agent import MessageRoundStatus
+from app.models.workflow import RunStatus
+
+try:  # pragma: no cover - exercised when dependency is installed
+    import psutil
+except ImportError:  # pragma: no cover - graceful runtime degradation
+    psutil = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+CACHE_TTL_SECONDS = 30
+CACHE_PREFIX = "admin:observability:v1"
+HEALTH_SNAPSHOT_KEY = f"{CACHE_PREFIX}:system:health:snapshots"
+VALID_TIME_RANGES = {"7d", "30d", "90d", "all"}
+VALID_GRANULARITIES = {"hour", "day"}
+WORKER_QUEUES = ("default", "workflow", "sandbox")
+
+
+def normalize_time_range(time_range: str) -> tuple[datetime | None, datetime]:
+    end_time = to_utc(now())
+    if time_range not in VALID_TIME_RANGES:
+        time_range = "30d"
+    if time_range == "all":
+        return None, end_time
+    days = int(time_range.removesuffix("d"))
+    return end_time - timedelta(days=days), end_time
+
+
+def normalize_granularity(time_range: str, granularity: str | None = None) -> str:
+    if granularity in VALID_GRANULARITIES:
+        return granularity
+    return "hour" if time_range == "7d" else "day"
+
+
+def continuous_percentile(
+    values: Sequence[float | int], percentile: float
+) -> float | None:
+    if not values:
+        return None
+    sorted_values = sorted(float(value) for value in values)
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (len(sorted_values) - 1) * percentile
+    lower = int(rank)
+    upper = min(lower + 1, len(sorted_values) - 1)
+    weight = rank - lower
+    return sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight
+
+
+def percentile_payload(values: Sequence[float | int]) -> dict[str, int | None]:
+    return {
+        "p50_ms": _round_nullable(continuous_percentile(values, 0.50)),
+        "p90_ms": _round_nullable(continuous_percentile(values, 0.90)),
+        "p95_ms": _round_nullable(continuous_percentile(values, 0.95)),
+        "p99_ms": _round_nullable(continuous_percentile(values, 0.99)),
+    }
+
+
+def extract_token_total(token_usage: Any) -> int:
+    if not isinstance(token_usage, dict):
+        return 0
+    for key in ("total", "total_tokens"):
+        value = token_usage.get(key)
+        if isinstance(value, int | float):
+            return int(value)
+    total = 0
+    for key in ("prompt", "completion", "prompt_tokens", "completion_tokens"):
+        value = token_usage.get(key)
+        if isinstance(value, int | float):
+            total += int(value)
+    return total
+
+
+def safe_rate(numerator: int | float, denominator: int | float) -> float:
+    if not denominator:
+        return 0.0
+    return round(float(numerator) / float(denominator) * 100, 2)
+
+
+async def cached_payload(
+    endpoint: str,
+    params: dict[str, Any],
+    producer: Callable[[], Awaitable[dict[str, Any]]],
+) -> dict[str, Any]:
+    cache_key = _cache_key(endpoint, params)
+    try:
+        redis = await get_redis()
+        cached = await redis.get(cache_key)
+        if cached:
+            return json.loads(cached)
+    except Exception as exc:
+        logger.warning("Observability cache read failed: %s", exc)
+
+    data = await producer()
+
+    try:
+        redis = await get_redis()
+        await redis.setex(cache_key, CACHE_TTL_SECONDS, json.dumps(data, default=str))
+    except Exception as exc:
+        logger.warning("Observability cache write failed: %s", exc)
+
+    return data
+
+
+async def get_overview(time_range: str) -> dict[str, Any]:
+    start_time, end_time = normalize_time_range(time_range)
+    agent_rows = await _agent_message_rows(start_time, end_time)
+    workflow_rows = await _workflow_run_rows(start_time, end_time)
+
+    agent_count = len(agent_rows)
+    workflow_count = len(workflow_rows)
+    total_requests = agent_count + workflow_count
+    agent_success = sum(
+        1
+        for row in agent_rows
+        if row.get("round_status") == MessageRoundStatus.COMPLETED.value
+    )
+    workflow_success = sum(
+        1 for row in workflow_rows if row.get("status") == RunStatus.SUCCESS.value
+    )
+    workflow_timeout = sum(
+        1 for row in workflow_rows if row.get("status") == RunStatus.TIMEOUT.value
+    )
+    agent_errors = sum(
+        1
+        for row in agent_rows
+        if row.get("round_status") == MessageRoundStatus.ERROR.value
+    )
+    durations = [
+        int(row["duration_ms"])
+        for row in [*agent_rows, *workflow_rows]
+        if row.get("duration_ms") is not None
+    ]
+    first_token_durations = [
+        int(row["first_token_ms"])
+        for row in agent_rows
+        if row.get("first_token_ms") is not None
+    ]
+    total_tokens = sum(
+        int(row.get("tokens") or 0) for row in [*agent_rows, *workflow_rows]
+    )
+
+    recent_start = end_time - timedelta(seconds=60)
+    recent_count = sum(
+        1
+        for row in [*agent_rows, *workflow_rows]
+        if _coerce_datetime(row.get("created_at")) >= recent_start
+    )
+    bucket_counts: dict[str, int] = {}
+    for row in [*agent_rows, *workflow_rows]:
+        created_at = _coerce_datetime(row.get("created_at"))
+        bucket = created_at.replace(minute=0, second=0, microsecond=0).isoformat()
+        bucket_counts[bucket] = bucket_counts.get(bucket, 0) + 1
+
+    return {
+        "time_range": time_range,
+        "generated_at": end_time.isoformat(),
+        "cache_ttl_seconds": CACHE_TTL_SECONDS,
+        "totals": {
+            "agent_requests": agent_count,
+            "workflow_runs": workflow_count,
+            "total_requests": total_requests,
+            "total_tokens": total_tokens,
+        },
+        "rates": {
+            "agent_success_rate": safe_rate(agent_success, agent_count),
+            "workflow_success_rate": safe_rate(workflow_success, workflow_count),
+            "overall_success_rate": safe_rate(
+                agent_success + workflow_success, total_requests
+            ),
+            "timeout_rate": safe_rate(workflow_timeout + agent_errors, total_requests),
+        },
+        "latency": percentile_payload(durations),
+        "ttft": percentile_payload(first_token_durations),
+        "throughput": {
+            "current_qps": round(recent_count / 60, 3),
+            "peak_hourly_requests": max(bucket_counts.values()) if bucket_counts else 0,
+        },
+    }
+
+
+async def get_agents(
+    time_range: str,
+    page: int,
+    page_size: int,
+    sort_by: str,
+    sort_order: str,
+) -> dict[str, Any]:
+    start_time, end_time = normalize_time_range(time_range)
+    rows = await _agent_performance_rows(start_time, end_time)
+    rows = sorted(
+        rows,
+        key=lambda row: row.get(_agent_sort_key(sort_by)) or 0,
+        reverse=sort_order != "asc",
+    )
+    return _paginate(rows, page, page_size, {"time_range": time_range})
+
+
+async def get_agent_detail(agent_id: UUID, time_range: str) -> dict[str, Any]:
+    start_time, end_time = normalize_time_range(time_range)
+    rows = [
+        row
+        for row in await _agent_performance_rows(start_time, end_time)
+        if str(row.get("agent_id")) == str(agent_id)
+    ]
+    trend = await _agent_trend_rows(
+        agent_id, start_time, end_time, normalize_granularity(time_range)
+    )
+    return {
+        "time_range": time_range,
+        "agent": rows[0] if rows else None,
+        "trend": trend,
+    }
+
+
+async def get_workflows(
+    time_range: str,
+    page: int,
+    page_size: int,
+    sort_by: str,
+    sort_order: str,
+) -> dict[str, Any]:
+    start_time, end_time = normalize_time_range(time_range)
+    rows = await _workflow_performance_rows(start_time, end_time)
+    rows = sorted(
+        rows,
+        key=lambda row: row.get(_workflow_sort_key(sort_by)) or 0,
+        reverse=sort_order != "asc",
+    )
+    return _paginate(rows, page, page_size, {"time_range": time_range})
+
+
+async def get_workflow_detail(workflow_id: UUID, time_range: str) -> dict[str, Any]:
+    start_time, end_time = normalize_time_range(time_range)
+    rows = [
+        row
+        for row in await _workflow_performance_rows(start_time, end_time)
+        if str(row.get("workflow_id")) == str(workflow_id)
+    ]
+    trend = await _workflow_trend_rows(
+        workflow_id, start_time, end_time, normalize_granularity(time_range)
+    )
+    nodes = await _workflow_node_rows(workflow_id, start_time, end_time)
+    return {
+        "time_range": time_range,
+        "workflow": rows[0] if rows else None,
+        "trend": trend,
+        "nodes": nodes,
+    }
+
+
+async def get_timeouts(
+    time_range: str, source: str, page: int, page_size: int
+) -> dict[str, Any]:
+    start_time, end_time = normalize_time_range(time_range)
+    events: list[dict[str, Any]] = []
+    if source in {"all", "workflow"}:
+        for row in await _workflow_timeout_rows(start_time, end_time):
+            events.append(
+                {
+                    "source": "workflow",
+                    "entity_id": row.get("workflow_id"),
+                    "entity_name": row.get("workflow_name") or "Unknown",
+                    "model": None,
+                    "timeout_type": "workflow",
+                    "created_at": _serialize_datetime(row.get("created_at")),
+                    "duration_ms": row.get("duration_ms"),
+                    "status": row.get("status"),
+                }
+            )
+    if source in {"all", "agent"}:
+        for row in await _agent_timeout_like_rows(start_time, end_time):
+            events.append(
+                {
+                    "source": "agent",
+                    "entity_id": row.get("agent_id"),
+                    "entity_name": row.get("agent_name") or "Unknown",
+                    "model": row.get("model_used"),
+                    "timeout_type": "unknown",
+                    "created_at": _serialize_datetime(row.get("created_at")),
+                    "duration_ms": row.get("duration_ms"),
+                    "status": row.get("round_status"),
+                }
+            )
+    events.sort(key=lambda row: str(row.get("created_at") or ""), reverse=True)
+    distribution: dict[str, int] = {}
+    for event in events:
+        key = str(event["source"])
+        distribution[key] = distribution.get(key, 0) + 1
+    payload = _paginate(events, page, page_size, {"time_range": time_range})
+    payload.update(
+        {
+            "distribution": distribution,
+            "agent_timeout_type_available": False,
+            "note": "Agent timeout subtype is unavailable for historical messages.",
+        }
+    )
+    return payload
+
+
+async def get_throughput(time_range: str, granularity: str | None) -> dict[str, Any]:
+    start_time, end_time = normalize_time_range(time_range)
+    bucket = normalize_granularity(time_range, granularity)
+    agent_rows = await _bucket_count_rows(
+        "messages",
+        "created_at",
+        start_time,
+        end_time,
+        bucket,
+        "round_role = 'assistant_final' AND is_round_canonical = true",
+    )
+    workflow_rows = await _bucket_count_rows(
+        "workflow_runs", "created_at", start_time, end_time, bucket
+    )
+    buckets = _merge_count_buckets(agent_rows, workflow_rows)
+    running_workflows = await _scalar_count(
+        "workflow_runs", "status = $1", [RunStatus.RUNNING.value]
+    )
+    current_qps = await _current_qps(end_time)
+    return {
+        "time_range": time_range,
+        "granularity": bucket,
+        "current": {
+            "qps": current_qps,
+            "tps": current_qps,
+            "running_workflows": running_workflows,
+        },
+        "buckets": buckets,
+    }
+
+
+async def get_tokens(time_range: str) -> dict[str, Any]:
+    start_time, end_time = normalize_time_range(time_range)
+    agent_rows = await _agent_message_rows(start_time, end_time)
+    workflow_rows = await _workflow_run_rows(start_time, end_time)
+    by_model: dict[str, int] = {}
+    for row in agent_rows:
+        model = str(row.get("model_used") or "unknown")
+        by_model[model] = by_model.get(model, 0) + int(row.get("tokens") or 0)
+    agent_tokens = sum(int(row.get("tokens") or 0) for row in agent_rows)
+    workflow_tokens = sum(int(row.get("tokens") or 0) for row in workflow_rows)
+    return {
+        "time_range": time_range,
+        "total_tokens": agent_tokens + workflow_tokens,
+        "by_source": [
+            {"source": "agent", "tokens": agent_tokens},
+            {"source": "workflow", "tokens": workflow_tokens},
+        ],
+        "by_model": [
+            {"model": model, "tokens": tokens}
+            for model, tokens in sorted(
+                by_model.items(), key=lambda item: item[1], reverse=True
+            )
+        ],
+    }
+
+
+async def get_system_health() -> dict[str, Any]:
+    generated_at = to_utc(now())
+    health = {
+        "generated_at": generated_at.isoformat(),
+        "cache_ttl_seconds": CACHE_TTL_SECONDS,
+        "cpu": _cpu_health(),
+        "memory": _memory_health(),
+        "disk": _disk_health(),
+        "database": await _database_health(),
+        "redis": await _redis_health(),
+        "workers": await get_workers(),
+    }
+    await _store_health_snapshot(health)
+    return health
+
+
+async def get_system_trend() -> dict[str, Any]:
+    try:
+        redis: Any = await get_redis()
+        raw_items = await redis.lrange(HEALTH_SNAPSHOT_KEY, 0, 120)
+    except Exception as exc:
+        logger.warning("System health trend unavailable: %s", exc)
+        raw_items = []
+    items = []
+    for raw in raw_items:
+        try:
+            items.append(json.loads(raw))
+        except (TypeError, json.JSONDecodeError):
+            continue
+    items.reverse()
+    return {"items": items}
+
+
+async def get_slow_queries(
+    threshold_ms: int, page: int, page_size: int
+) -> dict[str, Any]:
+    conn = Tortoise.get_connection("default")
+    try:
+        _, extension_rows = await conn.execute_query(
+            "SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements'"
+        )
+        if not extension_rows:
+            await conn.execute_query(
+                "CREATE EXTENSION IF NOT EXISTS pg_stat_statements"
+            )
+
+        _, rows = await conn.execute_query(
+            """
+            SELECT
+                query,
+                mean_exec_time AS avg_ms,
+                max_exec_time AS max_ms,
+                calls,
+                rows,
+                total_exec_time AS total_ms
+            FROM pg_stat_statements
+            WHERE mean_exec_time >= $1
+            ORDER BY mean_exec_time DESC
+            LIMIT $2 OFFSET $3
+            """,
+            [threshold_ms, min(page_size, 100), max(page - 1, 0) * page_size],
+        )
+    except Exception as exc:
+        logger.info("pg_stat_statements unavailable: %s", exc)
+        reason = str(exc)
+        if "must be loaded via shared_preload_libraries" in reason:
+            reason = "pg_stat_statements must be added to shared_preload_libraries and PostgreSQL must be restarted"
+        elif "permission denied" in reason.lower():
+            reason = "database user cannot create or read pg_stat_statements"
+        else:
+            reason = "pg_stat_statements is not available"
+        return {
+            "available": False,
+            "reason": reason,
+            "items": [],
+            "total": 0,
+            "page": page,
+            "page_size": page_size,
+        }
+    return {
+        "available": True,
+        "reason": None,
+        "items": [_normalize_row(row) for row in rows],
+        "total": len(rows),
+        "page": page,
+        "page_size": page_size,
+    }
+
+
+async def get_workers() -> dict[str, Any]:
+    try:
+        inspect = celery_app.control.inspect(timeout=1.0)
+        active, reserved, scheduled, stats = await asyncio.to_thread(
+            lambda: (
+                inspect.active() or {},
+                inspect.reserved() or {},
+                inspect.scheduled() or {},
+                inspect.stats() or {},
+            )
+        )
+        active_count = sum(len(tasks) for tasks in active.values())
+        reserved_count = sum(len(tasks) for tasks in reserved.values())
+        scheduled_count = sum(len(tasks) for tasks in scheduled.values())
+        queue_lengths = await _queue_lengths()
+        return {
+            "status": "healthy" if stats else "unknown",
+            "worker_count": len(stats),
+            "active_tasks": active_count,
+            "reserved_tasks": reserved_count,
+            "scheduled_tasks": scheduled_count,
+            "queues": queue_lengths,
+        }
+    except Exception as exc:
+        logger.warning("Celery worker inspection failed: %s", exc)
+        return {
+            "status": "unknown",
+            "worker_count": 0,
+            "active_tasks": 0,
+            "reserved_tasks": 0,
+            "scheduled_tasks": 0,
+            "queues": [],
+            "error": str(exc),
+        }
+
+
+async def _agent_message_rows(
+    start_time: datetime | None, end_time: datetime
+) -> list[dict[str, Any]]:
+    where, params = _time_where("m.created_at", start_time, end_time)
+    _, rows = await _execute(
+        f"""
+        SELECT
+            m.created_at,
+            m.duration_ms,
+            m.first_token_ms,
+            m.round_status,
+            m.model_used,
+            COALESCE(
+                (m.token_usage->>'total')::bigint,
+                (m.token_usage->>'total_tokens')::bigint,
+                COALESCE((m.token_usage->>'prompt')::bigint, (m.token_usage->>'prompt_tokens')::bigint, 0)
+                  + COALESCE((m.token_usage->>'completion')::bigint, (m.token_usage->>'completion_tokens')::bigint, 0),
+                0
+            ) AS tokens
+        FROM messages m
+        WHERE {where}
+          AND m.round_role = 'assistant_final'
+          AND m.is_round_canonical = true
+        """,
+        params,
+    )
+    return [_normalize_row(row) for row in rows]
+
+
+async def _workflow_run_rows(
+    start_time: datetime | None, end_time: datetime
+) -> list[dict[str, Any]]:
+    where, params = _time_where("wr.created_at", start_time, end_time)
+    _, rows = await _execute(
+        f"""
+        SELECT
+            wr.created_at,
+            wr.total_duration_ms AS duration_ms,
+            wr.status,
+            COALESCE(
+                (wr.total_token_usage->>'total')::bigint,
+                (wr.total_token_usage->>'total_tokens')::bigint,
+                COALESCE((wr.total_token_usage->>'prompt')::bigint, (wr.total_token_usage->>'prompt_tokens')::bigint, 0)
+                  + COALESCE((wr.total_token_usage->>'completion')::bigint, (wr.total_token_usage->>'completion_tokens')::bigint, 0),
+                0
+            ) AS tokens
+        FROM workflow_runs wr
+        WHERE {where}
+        """,
+        params,
+    )
+    return [_normalize_row(row) for row in rows]
+
+
+async def _agent_performance_rows(
+    start_time: datetime | None, end_time: datetime
+) -> list[dict[str, Any]]:
+    where, params = _time_where("m.created_at", start_time, end_time)
+    _, rows = await _execute(
+        f"""
+        SELECT
+            a.id AS agent_id,
+            a.name AS agent_name,
+            t.name AS team_name,
+            COUNT(m.id)::int AS request_count,
+            percentile_cont(0.50) WITHIN GROUP (ORDER BY m.duration_ms) FILTER (WHERE m.duration_ms IS NOT NULL) AS p50_ms,
+            percentile_cont(0.90) WITHIN GROUP (ORDER BY m.duration_ms) FILTER (WHERE m.duration_ms IS NOT NULL) AS p90_ms,
+            percentile_cont(0.95) WITHIN GROUP (ORDER BY m.duration_ms) FILTER (WHERE m.duration_ms IS NOT NULL) AS p95_ms,
+            percentile_cont(0.99) WITHIN GROUP (ORDER BY m.duration_ms) FILTER (WHERE m.duration_ms IS NOT NULL) AS p99_ms,
+            percentile_cont(0.50) WITHIN GROUP (ORDER BY m.first_token_ms) FILTER (WHERE m.first_token_ms IS NOT NULL) AS ttft_p50_ms,
+            percentile_cont(0.90) WITHIN GROUP (ORDER BY m.first_token_ms) FILTER (WHERE m.first_token_ms IS NOT NULL) AS ttft_p90_ms,
+            percentile_cont(0.95) WITHIN GROUP (ORDER BY m.first_token_ms) FILTER (WHERE m.first_token_ms IS NOT NULL) AS ttft_p95_ms,
+            percentile_cont(0.99) WITHIN GROUP (ORDER BY m.first_token_ms) FILTER (WHERE m.first_token_ms IS NOT NULL) AS ttft_p99_ms,
+            SUM(CASE WHEN m.round_status = 'completed' THEN 1 ELSE 0 END)::int AS success_count,
+            SUM(CASE WHEN m.round_status = 'error' THEN 1 ELSE 0 END)::int AS error_count,
+            0::int AS timeout_count,
+            SUM(
+                COALESCE(
+                    (m.token_usage->>'total')::bigint,
+                    (m.token_usage->>'total_tokens')::bigint,
+                    COALESCE((m.token_usage->>'prompt')::bigint, (m.token_usage->>'prompt_tokens')::bigint, 0)
+                    + COALESCE((m.token_usage->>'completion')::bigint, (m.token_usage->>'completion_tokens')::bigint, 0),
+                    0
+                )
+            )::bigint AS total_tokens
+        FROM messages m
+        JOIN conversations c ON c.id = m.conversation_id
+        LEFT JOIN agents a ON a.id = c.agent_id
+        LEFT JOIN teams t ON t.id = a.team_id
+        WHERE {where}
+          AND m.round_role = 'assistant_final'
+          AND m.is_round_canonical = true
+          AND c.agent_id IS NOT NULL
+        GROUP BY a.id, a.name, t.name
+        """,
+        params,
+    )
+    return [_decorate_performance_row(row, "request_count") for row in rows]
+
+
+async def _workflow_performance_rows(
+    start_time: datetime | None, end_time: datetime
+) -> list[dict[str, Any]]:
+    where, params = _time_where("wr.created_at", start_time, end_time)
+    _, rows = await _execute(
+        f"""
+        SELECT
+            w.id AS workflow_id,
+            w.name AS workflow_name,
+            t.name AS team_name,
+            COUNT(wr.id)::int AS run_count,
+            percentile_cont(0.50) WITHIN GROUP (ORDER BY wr.total_duration_ms) FILTER (WHERE wr.total_duration_ms IS NOT NULL) AS p50_ms,
+            percentile_cont(0.90) WITHIN GROUP (ORDER BY wr.total_duration_ms) FILTER (WHERE wr.total_duration_ms IS NOT NULL) AS p90_ms,
+            percentile_cont(0.95) WITHIN GROUP (ORDER BY wr.total_duration_ms) FILTER (WHERE wr.total_duration_ms IS NOT NULL) AS p95_ms,
+            percentile_cont(0.99) WITHIN GROUP (ORDER BY wr.total_duration_ms) FILTER (WHERE wr.total_duration_ms IS NOT NULL) AS p99_ms,
+            SUM(CASE WHEN wr.status = 'success' THEN 1 ELSE 0 END)::int AS success_count,
+            SUM(CASE WHEN wr.status = 'failed' THEN 1 ELSE 0 END)::int AS error_count,
+            SUM(CASE WHEN wr.status = 'timeout' THEN 1 ELSE 0 END)::int AS timeout_count,
+            SUM(wr.failed_nodes)::int AS failed_nodes,
+            AVG(wr.total_nodes) AS avg_nodes,
+            SUM(
+                COALESCE(
+                    (wr.total_token_usage->>'total')::bigint,
+                    (wr.total_token_usage->>'total_tokens')::bigint,
+                    COALESCE((wr.total_token_usage->>'prompt')::bigint, (wr.total_token_usage->>'prompt_tokens')::bigint, 0)
+                    + COALESCE((wr.total_token_usage->>'completion')::bigint, (wr.total_token_usage->>'completion_tokens')::bigint, 0),
+                    0
+                )
+            )::bigint AS total_tokens
+        FROM workflow_runs wr
+        LEFT JOIN workflows w ON w.id = wr.workflow_id
+        LEFT JOIN teams t ON t.id = w.team_id
+        WHERE {where}
+        GROUP BY w.id, w.name, t.name
+        """,
+        params,
+    )
+    return [_decorate_performance_row(row, "run_count") for row in rows]
+
+
+async def _agent_trend_rows(
+    agent_id: UUID, start_time: datetime | None, end_time: datetime, granularity: str
+) -> list[dict[str, Any]]:
+    where, params = _time_where("m.created_at", start_time, end_time, start_index=3)
+    _, rows = await _execute(
+        f"""
+        SELECT
+            date_trunc($1, m.created_at) AS bucket,
+            COUNT(m.id)::int AS request_count,
+            percentile_cont(0.50) WITHIN GROUP (ORDER BY m.duration_ms) FILTER (WHERE m.duration_ms IS NOT NULL) AS p50_ms,
+            percentile_cont(0.90) WITHIN GROUP (ORDER BY m.duration_ms) FILTER (WHERE m.duration_ms IS NOT NULL) AS p90_ms,
+            percentile_cont(0.95) WITHIN GROUP (ORDER BY m.duration_ms) FILTER (WHERE m.duration_ms IS NOT NULL) AS p95_ms,
+            percentile_cont(0.95) WITHIN GROUP (ORDER BY m.first_token_ms) FILTER (WHERE m.first_token_ms IS NOT NULL) AS ttft_p95_ms,
+            SUM(CASE WHEN m.round_status = 'completed' THEN 1 ELSE 0 END)::int AS success_count,
+            SUM(CASE WHEN m.round_status = 'error' THEN 1 ELSE 0 END)::int AS error_count
+        FROM messages m
+        JOIN conversations c ON c.id = m.conversation_id
+        WHERE c.agent_id = $2
+          AND {where}
+          AND m.round_role = 'assistant_final'
+          AND m.is_round_canonical = true
+        GROUP BY bucket
+        ORDER BY bucket
+        """,
+        [granularity, str(agent_id), *params],
+    )
+    return [_decorate_bucket_row(row, "request_count") for row in rows]
+
+
+async def _workflow_trend_rows(
+    workflow_id: UUID, start_time: datetime | None, end_time: datetime, granularity: str
+) -> list[dict[str, Any]]:
+    where, params = _time_where("wr.created_at", start_time, end_time, start_index=3)
+    _, rows = await _execute(
+        f"""
+        SELECT
+            date_trunc($1, wr.created_at) AS bucket,
+            COUNT(wr.id)::int AS run_count,
+            percentile_cont(0.50) WITHIN GROUP (ORDER BY wr.total_duration_ms) FILTER (WHERE wr.total_duration_ms IS NOT NULL) AS p50_ms,
+            percentile_cont(0.90) WITHIN GROUP (ORDER BY wr.total_duration_ms) FILTER (WHERE wr.total_duration_ms IS NOT NULL) AS p90_ms,
+            percentile_cont(0.95) WITHIN GROUP (ORDER BY wr.total_duration_ms) FILTER (WHERE wr.total_duration_ms IS NOT NULL) AS p95_ms,
+            SUM(CASE WHEN wr.status = 'success' THEN 1 ELSE 0 END)::int AS success_count,
+            SUM(CASE WHEN wr.status = 'timeout' THEN 1 ELSE 0 END)::int AS timeout_count,
+            SUM(wr.failed_nodes)::int AS failed_nodes
+        FROM workflow_runs wr
+        WHERE wr.workflow_id = $2
+          AND {where}
+        GROUP BY bucket
+        ORDER BY bucket
+        """,
+        [granularity, str(workflow_id), *params],
+    )
+    return [_decorate_bucket_row(row, "run_count") for row in rows]
+
+
+async def _workflow_node_rows(
+    workflow_id: UUID, start_time: datetime | None, end_time: datetime
+) -> list[dict[str, Any]]:
+    where, params = _time_where("wr.created_at", start_time, end_time, start_index=2)
+    _, rows = await _execute(
+        f"""
+        SELECT
+            ne.node_type,
+            COUNT(ne.id)::int AS execution_count,
+            SUM(CASE WHEN ne.status = 'failed' THEN 1 ELSE 0 END)::int AS failed_count,
+            AVG(ne.execution_duration_ms) AS avg_duration_ms
+        FROM workflow_node_executions ne
+        JOIN workflow_runs wr ON wr.id = ne.run_id
+        WHERE wr.workflow_id = $1
+          AND {where}
+        GROUP BY ne.node_type
+        ORDER BY execution_count DESC
+        LIMIT 20
+        """,
+        [str(workflow_id), *params],
+    )
+    return [_normalize_row(row) for row in rows]
+
+
+async def _workflow_timeout_rows(
+    start_time: datetime | None, end_time: datetime
+) -> list[dict[str, Any]]:
+    where, params = _time_where("wr.created_at", start_time, end_time)
+    _, rows = await _execute(
+        f"""
+        SELECT wr.created_at, wr.status, wr.total_duration_ms AS duration_ms, w.id AS workflow_id, w.name AS workflow_name
+        FROM workflow_runs wr
+        LEFT JOIN workflows w ON w.id = wr.workflow_id
+        WHERE {where} AND wr.status = 'timeout'
+        ORDER BY wr.created_at DESC
+        LIMIT 1000
+        """,
+        params,
+    )
+    return [_normalize_row(row) for row in rows]
+
+
+async def _agent_timeout_like_rows(
+    start_time: datetime | None, end_time: datetime
+) -> list[dict[str, Any]]:
+    where, params = _time_where("m.created_at", start_time, end_time)
+    _, rows = await _execute(
+        f"""
+        SELECT m.created_at, m.duration_ms, m.round_status, m.model_used, a.id AS agent_id, a.name AS agent_name
+        FROM messages m
+        JOIN conversations c ON c.id = m.conversation_id
+        LEFT JOIN agents a ON a.id = c.agent_id
+        WHERE {where}
+          AND m.round_role = 'assistant_final'
+          AND m.is_round_canonical = true
+          AND m.round_status = 'error'
+        ORDER BY m.created_at DESC
+        LIMIT 1000
+        """,
+        params,
+    )
+    return [_normalize_row(row) for row in rows]
+
+
+async def _bucket_count_rows(
+    table: str,
+    created_column: str,
+    start_time: datetime | None,
+    end_time: datetime,
+    granularity: str,
+    extra_where: str | None = None,
+) -> list[dict[str, Any]]:
+    where, params = _time_where(created_column, start_time, end_time, start_index=2)
+    if extra_where:
+        where = f"{where} AND {extra_where}"
+    _, rows = await _execute(
+        f"""
+        SELECT date_trunc($1, {created_column}) AS bucket, COUNT(*)::int AS count
+        FROM {table}
+        WHERE {where}
+        GROUP BY bucket
+        ORDER BY bucket
+        """,
+        [granularity, *params],
+    )
+    return [_normalize_row(row) for row in rows]
+
+
+async def _current_qps(end_time: datetime) -> float:
+    start_time = end_time - timedelta(seconds=60)
+    agent_count = await _scalar_count(
+        "messages",
+        "created_at >= $1 AND created_at < $2 AND round_role = 'assistant_final' AND is_round_canonical = true",
+        [start_time, end_time],
+    )
+    workflow_count = await _scalar_count(
+        "workflow_runs", "created_at >= $1 AND created_at < $2", [start_time, end_time]
+    )
+    return round((agent_count + workflow_count) / 60, 3)
+
+
+async def _scalar_count(table: str, where: str, params: list[Any]) -> int:
+    _, rows = await _execute(
+        f"SELECT COUNT(*)::int AS count FROM {table} WHERE {where}", params
+    )
+    return int(rows[0].get("count") or 0) if rows else 0
+
+
+async def _execute(query: str, params: list[Any]) -> tuple[int, list[dict[str, Any]]]:
+    conn = Tortoise.get_connection("default")
+    row_count, rows = await conn.execute_query(query, params)
+    return row_count, list(rows)
+
+
+def _time_where(
+    column: str,
+    start_time: datetime | None,
+    end_time: datetime,
+    start_index: int = 1,
+) -> tuple[str, list[Any]]:
+    if start_time is None:
+        return f"{column} < ${start_index}", [end_time]
+    return f"{column} >= ${start_index} AND {column} < ${start_index + 1}", [
+        start_time,
+        end_time,
+    ]
+
+
+def _decorate_performance_row(row: dict[str, Any], count_key: str) -> dict[str, Any]:
+    normalized = _normalize_row(row)
+    count = int(normalized.get(count_key) or 0)
+    success_count = int(normalized.get("success_count") or 0)
+    timeout_count = int(normalized.get("timeout_count") or 0)
+    total_tokens = int(normalized.get("total_tokens") or 0)
+    for key in (
+        "p50_ms",
+        "p90_ms",
+        "p95_ms",
+        "p99_ms",
+        "ttft_p50_ms",
+        "ttft_p90_ms",
+        "ttft_p95_ms",
+        "ttft_p99_ms",
+    ):
+        if key in normalized:
+            normalized[key] = _round_nullable(normalized.get(key))
+    normalized["success_rate"] = safe_rate(success_count, count)
+    normalized["timeout_rate"] = safe_rate(timeout_count, count)
+    normalized["avg_tokens"] = round(total_tokens / count, 2) if count else 0
+    return normalized
+
+
+def _decorate_bucket_row(row: dict[str, Any], count_key: str) -> dict[str, Any]:
+    normalized = _normalize_row(row)
+    count = int(normalized.get(count_key) or 0)
+    success_count = int(normalized.get("success_count") or 0)
+    for key in ("p50_ms", "p90_ms", "p95_ms", "ttft_p95_ms"):
+        normalized[key] = _round_nullable(normalized.get(key))
+    normalized["success_rate"] = safe_rate(success_count, count)
+    normalized["bucket"] = _serialize_datetime(normalized.get("bucket"))
+    return normalized
+
+
+def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {key: _serialize_value(value) for key, value in row.items()}
+
+
+def _serialize_value(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, float):
+        return round(value, 2)
+    return value
+
+
+def _serialize_datetime(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _coerce_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value)
+    return to_utc(now())
+
+
+def _round_nullable(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(round(float(value)))
+
+
+def _paginate(
+    rows: list[dict[str, Any]],
+    page: int,
+    page_size: int,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    page = max(page, 1)
+    page_size = min(max(page_size, 1), 100)
+    start = (page - 1) * page_size
+    payload = {
+        "items": rows[start : start + page_size],
+        "total": len(rows),
+        "page": page,
+        "page_size": page_size,
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def _cache_key(endpoint: str, params: dict[str, Any]) -> str:
+    encoded = json.dumps(params, sort_keys=True, default=str)
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    return f"{CACHE_PREFIX}:{endpoint}:{digest}"
+
+
+def _agent_sort_key(sort_by: str) -> str:
+    return {
+        "requests": "request_count",
+        "p50": "p50_ms",
+        "p90": "p90_ms",
+        "p95": "p95_ms",
+        "p99": "p99_ms",
+        "timeout_rate": "timeout_rate",
+        "success_rate": "success_rate",
+        "tokens": "total_tokens",
+    }.get(sort_by, "request_count")
+
+
+def _workflow_sort_key(sort_by: str) -> str:
+    return {
+        "runs": "run_count",
+        "p50": "p50_ms",
+        "p90": "p90_ms",
+        "p95": "p95_ms",
+        "p99": "p99_ms",
+        "timeout_rate": "timeout_rate",
+        "success_rate": "success_rate",
+        "tokens": "total_tokens",
+        "failed_nodes": "failed_nodes",
+    }.get(sort_by, "run_count")
+
+
+def _merge_count_buckets(
+    agent_rows: list[dict[str, Any]], workflow_rows: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    for row in agent_rows:
+        bucket = _serialize_datetime(row.get("bucket")) or ""
+        merged.setdefault(
+            bucket, {"bucket": bucket, "agent_requests": 0, "workflow_runs": 0}
+        )["agent_requests"] = int(row.get("count") or 0)
+    for row in workflow_rows:
+        bucket = _serialize_datetime(row.get("bucket")) or ""
+        merged.setdefault(
+            bucket, {"bucket": bucket, "agent_requests": 0, "workflow_runs": 0}
+        )["workflow_runs"] = int(row.get("count") or 0)
+    for item in merged.values():
+        item["total_requests"] = item["agent_requests"] + item["workflow_runs"]
+    return [merged[key] for key in sorted(merged)]
+
+
+def _cpu_health() -> dict[str, Any]:
+    if psutil is None:
+        return {"status": "unknown", "error": "psutil is not installed"}
+    percent = psutil.cpu_percent(interval=None)
+    return {
+        "status": _status_for_percent(percent, 70, 90),
+        "usage_percent": percent,
+        "cores": psutil.cpu_count(),
+        "architecture": platform.machine(),
+    }
+
+
+def _memory_health() -> dict[str, Any]:
+    if psutil is None:
+        return {"status": "unknown", "error": "psutil is not installed"}
+    memory = psutil.virtual_memory()
+    return {
+        "status": _status_for_percent(memory.percent, 80, 90),
+        "usage_percent": memory.percent,
+        "used_bytes": memory.used,
+        "total_bytes": memory.total,
+    }
+
+
+def _disk_health() -> dict[str, Any]:
+    if psutil is None:
+        return {"status": "unknown", "error": "psutil is not installed"}
+    disk = psutil.disk_usage(os.getcwd())
+    return {
+        "status": _status_for_percent(disk.percent, 80, 90),
+        "usage_percent": disk.percent,
+        "used_bytes": disk.used,
+        "total_bytes": disk.total,
+    }
+
+
+async def _database_health() -> dict[str, Any]:
+    conn = Tortoise.get_connection("default")
+    try:
+        await conn.execute_query("SELECT 1")
+        _, rows = await conn.execute_query(
+            """
+            SELECT
+                COUNT(*)::int AS active_connections,
+                current_setting('max_connections')::int AS max_connections
+            FROM pg_stat_activity
+            """
+        )
+        row = rows[0] if rows else {}
+        return {
+            "status": "healthy",
+            "active_connections": int(row.get("active_connections") or 0),
+            "max_connections": int(row.get("max_connections") or 0),
+        }
+    except Exception as exc:
+        return {"status": "unhealthy", "error": str(exc)}
+
+
+async def _redis_health() -> dict[str, Any]:
+    try:
+        redis = await get_redis()
+        info = await redis.info()
+        hits = int(info.get("keyspace_hits") or 0)
+        misses = int(info.get("keyspace_misses") or 0)
+        return {
+            "status": "healthy",
+            "used_memory": int(info.get("used_memory") or 0),
+            "connected_clients": int(info.get("connected_clients") or 0),
+            "ops_per_sec": int(info.get("instantaneous_ops_per_sec") or 0),
+            "hit_rate": safe_rate(hits, hits + misses),
+        }
+    except Exception as exc:
+        return {"status": "unhealthy", "error": str(exc)}
+
+
+async def _queue_lengths() -> list[dict[str, Any]]:
+    try:
+        redis: Any = await get_redis()
+        lengths = []
+        for queue in WORKER_QUEUES:
+            length = await redis.llen(queue)
+            lengths.append({"queue": queue, "pending": int(length or 0)})
+        return lengths
+    except Exception as exc:
+        logger.warning("Worker queue length check failed: %s", exc)
+        return [{"queue": queue, "pending": 0} for queue in WORKER_QUEUES]
+
+
+async def _store_health_snapshot(health: dict[str, Any]) -> None:
+    try:
+        redis: Any = await get_redis()
+        snapshot = {
+            "generated_at": health.get("generated_at"),
+            "cpu_percent": health.get("cpu", {}).get("usage_percent"),
+            "memory_percent": health.get("memory", {}).get("usage_percent"),
+            "disk_percent": health.get("disk", {}).get("usage_percent"),
+            "db_connections": health.get("database", {}).get("active_connections"),
+            "redis_ops_per_sec": health.get("redis", {}).get("ops_per_sec"),
+        }
+        await redis.lpush(HEALTH_SNAPSHOT_KEY, json.dumps(snapshot, default=str))
+        await redis.ltrim(HEALTH_SNAPSHOT_KEY, 0, 120)
+        await redis.expire(HEALTH_SNAPSHOT_KEY, 86400)
+    except Exception as exc:
+        logger.warning("Storing system health snapshot failed: %s", exc)
+
+
+def _status_for_percent(value: float, warning: float, danger: float) -> str:
+    if value >= danger:
+        return "danger"
+    if value >= warning:
+        return "warning"
+    return "healthy"

--- a/backend/app/services/admin_observability.py
+++ b/backend/app/services/admin_observability.py
@@ -415,9 +415,14 @@ async def get_slow_queries(
             "SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements'"
         )
         if not extension_rows:
-            await conn.execute_query(
-                "CREATE EXTENSION IF NOT EXISTS pg_stat_statements"
-            )
+            return {
+                "available": False,
+                "reason": "pg_stat_statements extension is not created in the database",
+                "items": [],
+                "total": 0,
+                "page": page,
+                "page_size": page_size,
+            }
 
         _, rows = await conn.execute_query(
             """
@@ -1004,6 +1009,14 @@ async def _database_health() -> dict[str, Any]:
     conn = Tortoise.get_connection("default")
     try:
         await conn.execute_query("SELECT 1")
+        dialect = getattr(getattr(conn, "capabilities", None), "dialect", "")
+        if dialect != "postgres":
+            return {
+                "status": "healthy",
+                "active_connections": 1,
+                "max_connections": None,
+            }
+
         _, rows = await conn.execute_query(
             """
             SELECT

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "urllib3>=2.6.3",
     "Babel>=2.17.0",
     "msgpack>=1.1.0",
+    "psutil>=7.1.3",
 ]
 
 [tool.uv]

--- a/backend/tests/api/test_admin_observability.py
+++ b/backend/tests/api/test_admin_observability.py
@@ -1,0 +1,125 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from app.api import deps
+from app.api.v1.admin.endpoints import observability
+from app.schemas.response import BusinessError, error
+
+
+class _Permission:
+    def __init__(self, code: str):
+        self.code = code
+
+
+class _Role:
+    def __init__(self, *codes: str):
+        self.permissions = [_Permission(code) for code in codes]
+
+
+@pytest.fixture
+def admin_observability_client():
+    app = FastAPI()
+    app.include_router(observability.router, prefix="/api/v1/admin/observability")
+
+    @app.exception_handler(BusinessError)
+    async def handle_business_error(_, exc: BusinessError):
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=error(
+                code=exc.code,
+                msg=exc.msg,
+                msg_key=exc.msg_key,
+                data=exc.data,
+                **exc.kwargs,
+            ),
+        )
+
+    user = SimpleNamespace(
+        id=uuid4(),
+        is_active=True,
+        is_superuser=False,
+        roles=[],
+    )
+
+    async def fake_current_user():
+        return user
+
+    app.dependency_overrides[deps.get_current_active_user] = fake_current_user
+    client = TestClient(app)
+    try:
+        yield client, user
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_observability_requires_dashboard_permission(admin_observability_client):
+    client, user = admin_observability_client
+    user.roles = [_Role("admin:user:read")]
+
+    response = client.get("/api/v1/admin/observability/overview")
+
+    assert response.status_code == 403
+    assert response.json()["code"] == 3000
+
+
+def test_observability_allows_dashboard_permission(admin_observability_client):
+    client, user = admin_observability_client
+    user.roles = [_Role("admin:dashboard:access")]
+
+    with patch(
+        "app.api.v1.admin.endpoints.observability.admin_observability.cached_payload",
+        new=AsyncMock(return_value={"ok": True}),
+    ):
+        response = client.get("/api/v1/admin/observability/overview")
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {"ok": True}
+
+
+def test_observability_allows_superuser(admin_observability_client):
+    client, user = admin_observability_client
+    user.is_superuser = True
+
+    with patch(
+        "app.api.v1.admin.endpoints.observability.admin_observability.cached_payload",
+        new=AsyncMock(return_value={"ok": True}),
+    ):
+        response = client.get("/api/v1/admin/observability/system/health")
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {"ok": True}
+
+
+def test_observability_endpoint_shapes(admin_observability_client):
+    client, user = admin_observability_client
+    user.roles = [_Role("admin:dashboard:access")]
+
+    endpoints = [
+        "/overview",
+        "/agents",
+        f"/agent/{uuid4()}",
+        "/workflows",
+        f"/workflow/{uuid4()}",
+        "/timeouts",
+        "/throughput",
+        "/tokens",
+        "/system/health",
+        "/system/trend",
+        "/system/slow-queries",
+        "/system/workers",
+    ]
+
+    with patch(
+        "app.api.v1.admin.endpoints.observability.admin_observability.cached_payload",
+        new=AsyncMock(return_value={"items": []}),
+    ):
+        for endpoint in endpoints:
+            response = client.get(f"/api/v1/admin/observability{endpoint}")
+            assert response.status_code == 200
+            assert response.json()["data"] == {"items": []}

--- a/backend/tests/services/test_admin_observability_service.py
+++ b/backend/tests/services/test_admin_observability_service.py
@@ -1,0 +1,143 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import admin_observability
+
+
+def test_continuous_percentile_handles_empty_and_single_value():
+    assert admin_observability.continuous_percentile([], 0.5) is None
+    assert admin_observability.continuous_percentile([42], 0.95) == 42
+
+
+def test_continuous_percentile_interpolates_even_count():
+    values = [10, 20, 30, 40]
+
+    assert admin_observability.continuous_percentile(values, 0.5) == 25
+    assert admin_observability.continuous_percentile(values, 0.9) == pytest.approx(37)
+    assert admin_observability.continuous_percentile(values, 0.95) == pytest.approx(
+        38.5
+    )
+    assert admin_observability.continuous_percentile(values, 0.99) == pytest.approx(
+        39.7
+    )
+
+
+def test_extract_token_total_accepts_total_and_prompt_completion_shapes():
+    assert admin_observability.extract_token_total({"total": 12}) == 12
+    assert admin_observability.extract_token_total({"total_tokens": 13}) == 13
+    assert admin_observability.extract_token_total({"prompt": 7, "completion": 5}) == 12
+    assert (
+        admin_observability.extract_token_total(
+            {"prompt_tokens": 3, "completion_tokens": 4}
+        )
+        == 7
+    )
+    assert admin_observability.extract_token_total(None) == 0
+
+
+@pytest.mark.asyncio
+async def test_cached_payload_returns_cached_value():
+    redis = AsyncMock()
+    redis.get.return_value = '{"cached": true}'
+    producer = AsyncMock(return_value={"cached": False})
+
+    with patch("app.services.admin_observability.get_redis", return_value=redis):
+        result = await admin_observability.cached_payload("test", {}, producer)
+
+    assert result == {"cached": True}
+    producer.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cached_payload_computes_when_redis_fails():
+    redis = AsyncMock()
+    redis.get.side_effect = RuntimeError("redis down")
+    redis.setex.side_effect = RuntimeError("redis down")
+    producer = AsyncMock(return_value={"fresh": True})
+
+    with patch("app.services.admin_observability.get_redis", return_value=redis):
+        result = await admin_observability.cached_payload("test", {}, producer)
+
+    assert result == {"fresh": True}
+    producer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_overview_reports_ttft_separately_from_total_duration():
+    agent_rows = [
+        {
+            "duration_ms": 30000,
+            "first_token_ms": 900,
+            "round_status": "completed",
+            "tokens": 10,
+            "created_at": "2026-06-05T10:00:00+00:00",
+        },
+        {
+            "duration_ms": 60000,
+            "first_token_ms": 1300,
+            "round_status": "completed",
+            "tokens": 20,
+            "created_at": "2026-06-05T10:01:00+00:00",
+        },
+        {
+            "duration_ms": 90000,
+            "first_token_ms": None,
+            "round_status": "completed",
+            "tokens": 30,
+            "created_at": "2026-06-05T10:02:00+00:00",
+        },
+    ]
+    workflow_rows = [
+        {
+            "duration_ms": 120000,
+            "status": "success",
+            "tokens": 40,
+            "created_at": "2026-06-05T10:03:00+00:00",
+        }
+    ]
+
+    with (
+        patch(
+            "app.services.admin_observability.normalize_time_range",
+            return_value=(None, admin_observability.to_utc(admin_observability.now())),
+        ),
+        patch(
+            "app.services.admin_observability._agent_message_rows",
+            new=AsyncMock(return_value=agent_rows),
+        ),
+        patch(
+            "app.services.admin_observability._workflow_run_rows",
+            new=AsyncMock(return_value=workflow_rows),
+        ),
+    ):
+        result = await admin_observability.get_overview("30d")
+
+    assert result["latency"]["p95_ms"] == 115500
+    assert result["ttft"]["p95_ms"] == 1280
+
+
+@pytest.mark.asyncio
+async def test_slow_queries_returns_unavailable_when_pg_stat_statements_missing():
+    conn = MagicMock()
+    conn.execute_query = AsyncMock(side_effect=RuntimeError("relation does not exist"))
+
+    with patch(
+        "app.services.admin_observability.Tortoise.get_connection", return_value=conn
+    ):
+        result = await admin_observability.get_slow_queries(1000, 1, 20)
+
+    assert result["available"] is False
+    assert result["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_workers_return_unknown_when_inspect_fails():
+    with patch(
+        "app.services.admin_observability.celery_app.control.inspect",
+        side_effect=RuntimeError("no workers"),
+    ):
+        result = await admin_observability.get_workers()
+
+    assert result["status"] == "unknown"
+    assert result["worker_count"] == 0

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -559,6 +559,7 @@ dependencies = [
     { name = "msgpack" },
     { name = "passlib", extra = ["bcrypt"] },
     { name = "pillow" },
+    { name = "psutil" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "pyotp" },
@@ -619,6 +620,7 @@ requires-dist = [
     { name = "msgpack", specifier = ">=1.1.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pillow", specifier = ">=12.2.0" },
+    { name = "psutil", specifier = ">=7.1.3" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "pyjwt", specifier = ">=2.12.1" },
     { name = "pyotp", specifier = ">=2.9.0" },
@@ -2473,6 +2475,34 @@ wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple/" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -277,6 +277,11 @@ kubectl -n clouisle logs -f deployment/frontend
 - Check worker logs for Redis connection or auth errors.
 - Verify `REDIS_HOST` and `REDIS_PASSWORD`.
 
+**Observability slow queries are unavailable**
+- The built-in Compose and Helm PostgreSQL services start with `shared_preload_libraries=pg_stat_statements` and `pg_stat_statements.track=all`.
+- For an existing PostgreSQL container, restart/recreate the database container after applying the updated command so the preload setting takes effect.
+- For external PostgreSQL, ask the database administrator to enable `pg_stat_statements` in `shared_preload_libraries`, restart PostgreSQL, and allow the application database user to run `CREATE EXTENSION IF NOT EXISTS pg_stat_statements` or create the extension manually.
+
 **Beat running duplicate schedules**
 - Ensure only one `beat` replica is running.
 

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -7,6 +7,7 @@ services:
       POSTGRES_DB: clouisle
     ports:
       - "5432:5432"
+    command: ["postgres", "-c", "shared_preload_libraries=pg_stat_statements", "-c", "pg_stat_statements.track=all"]
     volumes:
       - postgres_data:/var/lib/postgresql/data
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-clouisle}
     ports:
       - "5432:5432"
+    command: ["postgres", "-c", "shared_preload_libraries=pg_stat_statements", "-c", "pg_stat_statements.track=all"]
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/deploy/helm/clouisle/templates/postgres-statefulset.yaml
+++ b/deploy/helm/clouisle/templates/postgres-statefulset.yaml
@@ -21,6 +21,10 @@ spec:
         - name: postgres
           image: {{ printf "%s:%s" .Values.postgresql.image.repository .Values.postgresql.image.tag | quote }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          {{- with .Values.postgresql.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: postgres
               containerPort: 5432

--- a/deploy/helm/clouisle/values.yaml
+++ b/deploy/helm/clouisle/values.yaml
@@ -193,6 +193,11 @@ postgresql:
     repository: postgres
     tag: "16"
     pullPolicy: IfNotPresent
+  extraArgs:
+    - "-c"
+    - "shared_preload_libraries=pg_stat_statements"
+    - "-c"
+    - "pg_stat_statements.track=all"
   persistence:
     enabled: true
     existingClaim: ""

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -2,6 +2,14 @@
 
 ## Active
 
+- **yun-75-admin-observability-dashboard** — Complete. Add platform-admin observability APIs and dashboard pages for AI conversation/workflow performance, timeouts, throughput, and system health. See `docs/plan/admin-observability-dashboard.md`
+  - [x] 1. Planning docs and backend API scaffolding
+  - [x] 2. Core backend observability metrics and tests
+  - [x] 3. System health, worker, throughput, and token metrics
+  - [x] 4. Frontend observability API client and route
+  - [x] 5. Six observability subpages, navigation, i18n, and generated types
+  - [x] 6. Validation and regression checks
+
 - **yun-85-admin-agent-workflow-management** — In progress. Add admin dashboard management for Agents and Workflows with tabbed lists and admin-prefixed APIs. See `docs/plan/yun-85-admin-agent-workflow-management.md`
   - [x] 1. Design docs and implementation index
   - [x] 2. Backend admin permissions and APIs

--- a/docs/plan/admin-observability-dashboard.md
+++ b/docs/plan/admin-observability-dashboard.md
@@ -22,14 +22,18 @@
 
 #### 1.1 数据源
 - **现有数据**：
-  - `Message` 表：`duration_ms`, `created_at`, `conversation_id`, `round_status`
+  - `Message` 表：`duration_ms`, `created_at`, `conversation_id`, `round_status`, `round_role`, `is_round_canonical`, `model_used`, `token_usage`
   - `Conversation` 表：`agent_id`, `created_at`, `message_count`
   - `Agent` 表：`id`, `name`, `model_id`
-  - 日志系统：timeout 日志中的 `timeout_type`, `timeout_seconds`
+  - `WorkflowRun` 表：`workflow_id`, `status`, `total_duration_ms`, `total_token_usage`, `failed_nodes`, `created_at`, `started_at`, `finished_at`
+  - `NodeExecution` 表：`run_id`, `node_type`, `status`, `execution_duration_ms`, `queue_duration_ms`, `model_used`, `total_tokens`
+  - 系统运行时：psutil、SQLAlchemy/Tortoise 连接状态、Redis INFO、Celery inspect
 
-- **新增数据**：
-  - 时序指标表（可选，用于高性能查询）
-  - 或直接从现有表聚合（初期方案）
+- **初期方案**：
+  - 直接从现有表聚合，Redis 缓存 30 秒。
+  - 不新增时序指标表；如果后续生产数据量导致聚合超过 2 秒，再追加 rollup 表。
+  - `Message` 没有 `agent_id`，Agent 维度聚合必须通过 `Conversation.agent_id` 关联。
+  - 历史 Agent 消息未持久化 `timeout_type` / `timeout_seconds`，因此 idle/global 类型只能在未来埋点后精确区分；当前版本对 Agent 历史超时类型返回 `unknown`，Workflow 超时通过 `WorkflowRun.status = timeout` 精确统计。
 
 #### 1.2 指标定义
 
@@ -276,6 +280,42 @@
 
 4. **成功率趋势**（折线图）
    - 成功率 % 随时间变化
+
+#### 2.3 企业级监控展示重设计
+
+用户反馈第一版 6 个子页面表现力不足，因此在不改变后端 API 的前提下，对 `/dashboard/observability` 进行展示层重设计：
+
+1. **页面状态与加载体验**
+   - `page.tsx` 只负责标签页、时间范围、数据拉取、错误状态和刷新状态。
+   - 内容区使用 Skeleton，不再用全页居中 spinner 覆盖已有缓存数据。
+   - Health 标签页保留 30 秒自动刷新，并在标题区展示自动刷新提示。
+
+2. **概览页：运维驾驶舱**
+   - 左侧运行状态面板按超时率、成功率、首 Token P95（有新数据时）或总耗时 P95（历史回退）推导健康 / 关注 / 严重风险。
+   - 右侧使用 Agent 请求与 Workflow 运行的堆叠面积趋势图。
+   - 下方展示请求总量、Token、峰值小时请求、流量构成与 P50/P90/P95/P99 分位条。
+   - TTFT（Time To First Token / 首 Token 延迟）与完整响应耗时分开统计；历史数据和非流式消息没有真实 TTFT，不从 `duration_ms` 反推。
+
+3. **系统健康页：依赖与资源控制台**
+   - 使用 CPU/内存趋势图作为主视觉。
+   - CPU、内存、磁盘、数据库、Redis、Worker 以依赖状态列表展示主指标、状态和百分比进度。
+   - Worker 队列展示 active/reserved/scheduled 和各队列 pending 分布。
+   - 慢查询区对 `pg_stat_statements` 不可用状态展示可操作启用提示，对可用状态展示防御式字段读取表格。
+
+4. **Agent / Workflow 性能页：排行 + 详情 Sheet**
+   - 列表展示名称、团队、请求/运行数、成功率、超时率、P95/P99、Token 等核心指标。
+   - 行点击打开右侧 Sheet，异步拉取详情，展示分位条、性能趋势图和 Workflow 节点拆解。
+   - 详情请求不阻塞主列表渲染。
+
+5. **超时分析页：分布 + 事件流**
+   - 顶部展示总事件数、最高频超时类型和 Agent 类型数据可用状态。
+   - 使用横向分布条替代简单卡片，近期事件表展示来源、实体、类型、状态、模型、耗时和时间。
+   - 对历史 Agent timeout subtype 不可精确区分的限制保留警告说明。
+
+6. **系统吞吐页：容量与 Token 分析**
+   - 顶部展示 QPS、TPS、运行中 Workflow、总 Token。
+   - 主图使用 Agent/Workflow 请求量堆叠柱状图。
+   - Token 按来源和模型使用横向分布条展示占比，缺失数据只影响 Token 区块，不隐藏吞吐图。
 
 ### 3. 后端 API 设计
 

--- a/frontend/app/(dashboard)/dashboard/observability/_components/observability-panels.tsx
+++ b/frontend/app/(dashboard)/dashboard/observability/_components/observability-panels.tsx
@@ -654,6 +654,7 @@ function EntityTable({ headers, rows, empty }: { headers: string[]; rows: Array<
               {headers.map((header, index) => (
                 <TableHead key={header} className={index > 1 ? 'text-right' : undefined}>{header}</TableHead>
               ))}
+              <TableHead className="w-8" />
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -736,7 +737,7 @@ function ResourceRow({ label, icon: Icon, data, valueKey, suffix }: { label: str
   const t = useTranslations('dashboard.observability')
   const status = String(data.status ?? 'unknown')
   const value = readNumber(data, [valueKey])
-  const progress = suffix === '%' ? Math.min(Math.max(value, 0), 100) : null
+  const progress = suffix === '%' && value !== null ? Math.min(Math.max(value, 0), 100) : null
   return (
     <div className="rounded-lg border p-3">
       <div className="flex items-center justify-between gap-3">
@@ -744,7 +745,7 @@ function ResourceRow({ label, icon: Icon, data, valueKey, suffix }: { label: str
           <div className="rounded-md bg-muted p-2"><Icon className="h-4 w-4" /></div>
           <div>
             <div className="font-medium">{label}</div>
-            <div className="text-xs text-muted-foreground">{Number.isFinite(value) ? `${value}${suffix}` : '-'}</div>
+            <div className="text-xs text-muted-foreground">{value !== null ? `${value}${suffix}` : '-'}</div>
           </div>
         </div>
         <StatusPill tone={toneForStatus(status)} label={statusLabel(status, t)} />
@@ -852,13 +853,13 @@ function timeoutTypeLabel(type: string | null | undefined, t: ObservabilityTrans
   return keys.has(normalized) ? t(`timeoutTypes.${normalized}`) : normalized
 }
 
-function readNumber(row: Record<string, unknown>, keys: string[]) {
+function readNumber(row: Record<string, unknown>, keys: string[]): number | null {
   for (const key of keys) {
     const value = row[key]
     if (typeof value === 'number' && Number.isFinite(value)) return value
     if (typeof value === 'string' && value.trim() && Number.isFinite(Number(value))) return Number(value)
   }
-  return 0
+  return null
 }
 
 function readString(row: Record<string, unknown>, keys: string[]) {
@@ -869,7 +870,8 @@ function readString(row: Record<string, unknown>, keys: string[]) {
   return '-'
 }
 
-function formatNumber(value: number) {
+function formatNumber(value: number | null | undefined) {
+  if (value == null) return '-'
   return new Intl.NumberFormat().format(value)
 }
 

--- a/frontend/app/(dashboard)/dashboard/observability/_components/observability-panels.tsx
+++ b/frontend/app/(dashboard)/dashboard/observability/_components/observability-panels.tsx
@@ -1,0 +1,930 @@
+'use client'
+
+import * as React from 'react'
+import { useTranslations } from 'next-intl'
+import {
+  AlertTriangle,
+  ChevronRight,
+  Cpu,
+  Database,
+  HardDrive,
+  Info,
+  Server,
+  Workflow,
+} from 'lucide-react'
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { CHART_COLOR_ORDER, CHART_GRID_COLOR, CHART_TOOLTIP_STYLE } from '@/lib/chart-theme'
+import {
+  observabilityApi,
+  type AgentDetailResponse,
+  type AgentPerformanceRow,
+  type ObservabilityOverview,
+  type ObservabilityTrendPoint,
+  type SlowQueriesResponse,
+  type SystemHealthResponse,
+  type SystemTrendResponse,
+  type ThroughputResponse,
+  type TimeoutEvent,
+  type TimeoutResponse,
+  type TokenResponse,
+  type WorkflowDetailResponse,
+  type WorkflowPerformanceRow,
+  type WorkerResponse,
+} from '@/lib/api/admin/observability'
+import type { TimeRange } from '@/components/dashboard/time-range-selector'
+
+type ObservabilityTab = 'overview' | 'health' | 'agents' | 'workflows' | 'timeouts' | 'throughput'
+type Tone = 'neutral' | 'success' | 'warning' | 'danger' | 'info'
+type ObservabilityTranslator = ReturnType<typeof useTranslations>
+
+const TONE_STYLES: Record<Tone, string> = {
+  neutral: 'bg-muted text-muted-foreground border-border',
+  success: 'bg-emerald-500/10 text-emerald-700 border-emerald-500/20 dark:text-emerald-300',
+  warning: 'bg-amber-500/10 text-amber-700 border-amber-500/20 dark:text-amber-300',
+  danger: 'bg-destructive/10 text-destructive border-destructive/20',
+  info: 'bg-sky-500/10 text-sky-700 border-sky-500/20 dark:text-sky-300',
+}
+
+interface OverviewPanelProps {
+  overview: ObservabilityOverview | null
+  throughput: ThroughputResponse | null
+}
+
+interface HealthPanelProps {
+  health: SystemHealthResponse | null
+  trend: SystemTrendResponse | null
+  slowQueries: SlowQueriesResponse | null
+  workers: WorkerResponse | null
+}
+
+export function ObservabilitySkeleton({ tab }: { tab: ObservabilityTab }) {
+  const tableRows = tab === 'agents' || tab === 'workflows' || tab === 'timeouts'
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Skeleton key={index} className="h-24 rounded-xl" />
+        ))}
+      </div>
+      {tableRows ? (
+        <Skeleton className="h-[420px] rounded-xl" />
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-12">
+          <Skeleton className="h-[360px] rounded-xl lg:col-span-5" />
+          <Skeleton className="h-[360px] rounded-xl lg:col-span-7" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function ErrorState({ onRetry }: { onRetry: () => void }) {
+  const t = useTranslations('dashboard.observability')
+  return (
+    <Alert variant="destructive">
+      <AlertTriangle className="h-4 w-4" />
+      <AlertTitle>{t('states.errorTitle')}</AlertTitle>
+      <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <span>{t('states.errorDescription')}</span>
+        <Button variant="outline" size="sm" onClick={onRetry}>{t('actions.retry')}</Button>
+      </AlertDescription>
+    </Alert>
+  )
+}
+
+export function OverviewPanel({ overview, throughput }: OverviewPanelProps) {
+  const t = useTranslations('dashboard.observability')
+  if (!overview) return <ObservabilityEmpty />
+
+  const risk = getRiskLevel(
+    overview.rates.timeout_rate,
+    overview.rates.overall_success_rate,
+    overview.latency.p95_ms,
+    overview.ttft?.p95_ms ?? null
+  )
+  const trafficTotal = overview.totals.agent_requests + overview.totals.workflow_runs
+  const distribution = [
+    { label: t('overview.agentRequests'), value: overview.totals.agent_requests, tone: 'info' as Tone },
+    { label: t('overview.workflowRuns'), value: overview.totals.workflow_runs, tone: 'success' as Tone },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-6 lg:grid-cols-12">
+        <Card className="lg:col-span-5">
+          <CardHeader className="pb-2">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <CardTitle>{t('overview.operationalStatus')}</CardTitle>
+                <CardDescription>{t('overview.operationalStatusDesc')}</CardDescription>
+              </div>
+              <StatusPill tone={risk.tone} label={t(`risk.${risk.key}`)} />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div>
+              <div className="text-2xl font-semibold tracking-tight">{t(`overview.${risk.summaryKey}`)}</div>
+              <div className="mt-2 text-sm text-muted-foreground">{t('states.cacheTtl', { seconds: overview.cache_ttl_seconds })}</div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <ConsoleMetric label={t('metrics.timeoutRate')} value={formatPercent(overview.rates.timeout_rate)} tone={risk.tone} />
+              <ConsoleMetric label={t('metrics.successRate')} value={formatPercent(overview.rates.overall_success_rate)} tone="success" />
+              <ConsoleMetric label={t('metrics.p95Latency')} value={formatDuration(overview.latency.p95_ms)} />
+              <ConsoleMetric label={t('metrics.p95Ttft')} value={formatDuration(overview.ttft?.p95_ms)} />
+              <ConsoleMetric label={t('metrics.currentQps')} value={String(overview.throughput.current_qps)} />
+            </div>
+            <PercentileStrip values={overview.latency} />
+          </CardContent>
+        </Card>
+
+        <ObservabilityChartCard className="lg:col-span-7" title={t('charts.requestTrend')} description={t('charts.requestTrendDesc')} empty={!throughput?.buckets.length}>
+          <ResponsiveContainer width="100%" height={310}>
+            <AreaChart data={throughput?.buckets ?? []}>
+              <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
+              <XAxis dataKey="bucket" tickFormatter={formatBucket} minTickGap={24} />
+              <YAxis />
+              <Tooltip contentStyle={CHART_TOOLTIP_STYLE} labelFormatter={formatBucket} />
+              <Legend />
+              <Area name={t('overview.agentRequests')} type="monotone" dataKey="agent_requests" stackId="requests" stroke={CHART_COLOR_ORDER[0]} fill={CHART_COLOR_ORDER[0]} fillOpacity={0.35} />
+              <Area name={t('overview.workflowRuns')} type="monotone" dataKey="workflow_runs" stackId="requests" stroke={CHART_COLOR_ORDER[1]} fill={CHART_COLOR_ORDER[1]} fillOpacity={0.35} />
+            </AreaChart>
+          </ResponsiveContainer>
+        </ObservabilityChartCard>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <ConsoleMetric label={t('metrics.totalRequests')} value={formatNumber(overview.totals.total_requests)} description={t('metrics.agentWorkflowBreakdown', { agents: overview.totals.agent_requests, workflows: overview.totals.workflow_runs })} />
+        <ConsoleMetric label={t('metrics.totalTokens')} value={formatCompactNumber(overview.totals.total_tokens)} description={t('metrics.selectedRange')} />
+        <ConsoleMetric label={t('metrics.peakHourly')} value={formatNumber(overview.throughput.peak_hourly_requests)} description={t('overview.requestsBySource')} />
+        <ConsoleMetric label={t('overview.trafficMix')} value={formatPercent(percentOf(overview.totals.agent_requests, trafficTotal))} description={t('overview.agentRequests')} />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('overview.trafficMix')}</CardTitle>
+          <CardDescription>{t('overview.requestsBySource')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <DistributionBarList items={distribution} total={trafficTotal} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export function HealthPanel({ health, trend, slowQueries, workers }: HealthPanelProps) {
+  const t = useTranslations('dashboard.observability')
+  if (!health) return <ObservabilityEmpty />
+
+  const worker = workers ?? health.workers
+  const dependencies = [
+    { label: 'CPU', icon: Cpu, data: health.cpu, valueKey: 'usage_percent', suffix: '%' },
+    { label: t('health.memory'), icon: Server, data: health.memory, valueKey: 'usage_percent', suffix: '%' },
+    { label: t('health.disk'), icon: HardDrive, data: health.disk, valueKey: 'usage_percent', suffix: '%' },
+    { label: t('health.database'), icon: Database, data: health.database, valueKey: 'active_connections', suffix: '' },
+    { label: 'Redis', icon: Database, data: health.redis, valueKey: 'ops_per_sec', suffix: ' ops/s' },
+    { label: 'Worker', icon: Workflow, data: workerHealthData(worker), valueKey: 'worker_count', suffix: '' },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-6 lg:grid-cols-12">
+        <ObservabilityChartCard className="lg:col-span-8" title={t('health.resourceUsage')} description={t('charts.systemTrendDesc')} empty={!trend?.items.length}>
+          <ResponsiveContainer width="100%" height={320}>
+            <LineChart data={trend?.items ?? []}>
+              <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
+              <XAxis dataKey="generated_at" tickFormatter={formatBucket} minTickGap={24} />
+              <YAxis />
+              <Tooltip contentStyle={CHART_TOOLTIP_STYLE} labelFormatter={formatBucket} />
+              <Legend />
+              <Line name="CPU" type="monotone" dataKey="cpu_percent" stroke={CHART_COLOR_ORDER[0]} strokeWidth={2} dot={false} />
+              <Line name={t('health.memory')} type="monotone" dataKey="memory_percent" stroke={CHART_COLOR_ORDER[1]} strokeWidth={2} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </ObservabilityChartCard>
+
+        <Card className="lg:col-span-4">
+          <CardHeader>
+            <CardTitle>{t('health.dependencies')}</CardTitle>
+            <CardDescription>{t('states.autoRefreshHint')}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {dependencies.map((item) => (
+              <ResourceRow key={item.label} {...item} />
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-12">
+        <Card className="lg:col-span-5">
+          <CardHeader>
+            <CardTitle>{t('health.workerQueues')}</CardTitle>
+            <CardDescription>{t('health.workerQueuesDesc')}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            {worker.error && (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>{t('health.workerError')}</AlertTitle>
+                <AlertDescription>{worker.error}</AlertDescription>
+              </Alert>
+            )}
+            <div className="grid grid-cols-3 gap-3">
+              <ConsoleMetric label={t('health.activeTasks')} value={formatNumber(worker.active_tasks)} />
+              <ConsoleMetric label={t('health.reservedTasks')} value={formatNumber(worker.reserved_tasks)} />
+              <ConsoleMetric label={t('health.scheduledTasks')} value={formatNumber(worker.scheduled_tasks)} />
+            </div>
+            <DistributionBarList items={(worker.queues ?? []).map((queue) => ({ label: queue.queue, value: queue.pending, tone: queue.pending > 0 ? 'warning' : 'neutral' }))} total={Math.max(...(worker.queues ?? []).map((queue) => queue.pending), 1)} valueLabel={t('health.pending')} />
+          </CardContent>
+        </Card>
+
+        <Card className="lg:col-span-7">
+          <CardHeader>
+            <CardTitle>{t('health.slowQueries')}</CardTitle>
+            <CardDescription>{t('health.slowQueriesDesc')}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <SlowQueriesContent slowQueries={slowQueries} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+export function AgentsPanel({ rows, timeRange }: { rows: AgentPerformanceRow[]; timeRange: TimeRange }) {
+  const t = useTranslations('dashboard.observability')
+  const [detail, setDetail] = React.useState<AgentDetailResponse | null>(null)
+  const [isOpen, setIsOpen] = React.useState(false)
+  const [isLoading, setIsLoading] = React.useState(false)
+
+  const openDetail = async (row: AgentPerformanceRow) => {
+    setIsOpen(true)
+    setIsLoading(true)
+    try {
+      setDetail(await observabilityApi.getAgentDetail(row.agent_id, timeRange))
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <EntityTable
+        empty={rows.length === 0}
+        headers={[t('tables.name'), t('tables.team'), t('tables.requests'), t('tables.successRate'), t('tables.timeoutRate'), t('tables.ttftP95'), 'P95', 'P99', t('tables.tokens'), t('tables.avgTokens')]}
+        rows={rows.map((row) => ({
+          key: row.agent_id,
+          onClick: () => openDetail(row),
+          cells: [
+            <EntityName key="name" name={row.agent_name || row.agent_id} id={row.agent_id} />,
+            row.team_name || '-',
+            formatNumber(row.request_count),
+            <StatusValue key="success" value={formatPercent(row.success_rate)} tone={row.success_rate < 95 ? 'danger' : row.success_rate < 99 ? 'warning' : 'success'} />,
+            <StatusValue key="timeout" value={formatPercent(row.timeout_rate)} tone={row.timeout_rate >= 5 ? 'danger' : row.timeout_rate >= 1 ? 'warning' : 'neutral'} />,
+            formatDuration(row.ttft_p95_ms),
+            formatDuration(row.p95_ms),
+            formatDuration(row.p99_ms ?? null),
+            formatCompactNumber(row.total_tokens),
+            formatNumber(row.avg_tokens),
+          ],
+        }))}
+      />
+      <AgentDetailSheet open={isOpen} onOpenChange={setIsOpen} detail={detail} isLoading={isLoading} />
+    </>
+  )
+}
+
+export function WorkflowsPanel({ rows, timeRange }: { rows: WorkflowPerformanceRow[]; timeRange: TimeRange }) {
+  const t = useTranslations('dashboard.observability')
+  const [detail, setDetail] = React.useState<WorkflowDetailResponse | null>(null)
+  const [isOpen, setIsOpen] = React.useState(false)
+  const [isLoading, setIsLoading] = React.useState(false)
+
+  const openDetail = async (row: WorkflowPerformanceRow) => {
+    setIsOpen(true)
+    setIsLoading(true)
+    try {
+      setDetail(await observabilityApi.getWorkflowDetail(row.workflow_id, timeRange))
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <EntityTable
+        empty={rows.length === 0}
+        headers={[t('tables.name'), t('tables.team'), t('tables.runs'), t('tables.successRate'), t('tables.timeoutRate'), t('tables.failedNodes'), t('details.avgNodes'), 'P95', t('tables.tokens')]}
+        rows={rows.map((row) => ({
+          key: row.workflow_id,
+          onClick: () => openDetail(row),
+          cells: [
+            <EntityName key="name" name={row.workflow_name || row.workflow_id} id={row.workflow_id} />,
+            row.team_name || '-',
+            formatNumber(row.run_count),
+            <StatusValue key="success" value={formatPercent(row.success_rate)} tone={row.success_rate < 95 ? 'danger' : row.success_rate < 99 ? 'warning' : 'success'} />,
+            <StatusValue key="timeout" value={formatPercent(row.timeout_rate)} tone={row.timeout_rate >= 5 ? 'danger' : row.timeout_rate >= 1 ? 'warning' : 'neutral'} />,
+            formatNumber(row.failed_nodes),
+            row.avg_nodes == null ? '-' : formatNumber(row.avg_nodes),
+            formatDuration(row.p95_ms),
+            formatCompactNumber(row.total_tokens),
+          ],
+        }))}
+      />
+      <WorkflowDetailSheet open={isOpen} onOpenChange={setIsOpen} detail={detail} isLoading={isLoading} />
+    </>
+  )
+}
+
+export function TimeoutsPanel({ data }: { data: TimeoutResponse | null }) {
+  const t = useTranslations('dashboard.observability')
+  if (!data) return <ObservabilityEmpty />
+
+  const distribution = Object.entries(data.distribution ?? {}).map(([label, value]) => ({
+    label: timeoutTypeLabel(label, t),
+    value,
+    tone: label === 'workflow' ? 'warning' as Tone : 'info' as Tone,
+  }))
+  const topType = [...distribution].sort((a, b) => b.value - a.value)[0]
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-3">
+        <ConsoleMetric label={t('timeouts.totalEvents')} value={formatNumber(data.total)} />
+        <ConsoleMetric label={t('timeouts.mostFrequentType')} value={topType?.label ?? '-'} />
+        <ConsoleMetric label={t('timeouts.typeAvailable')} value={data.agent_timeout_type_available ? t('status.success') : t('status.unknown')} tone={data.agent_timeout_type_available ? 'success' : 'warning'} />
+      </div>
+      {!data.agent_timeout_type_available && (
+        <Alert variant="warning">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>{t('timeouts.limitedTitle')}</AlertTitle>
+          <AlertDescription>{data.note || t('timeouts.limitedDescription')}</AlertDescription>
+        </Alert>
+      )}
+      <div className="grid gap-6 lg:grid-cols-12">
+        <Card className="lg:col-span-4">
+          <CardHeader>
+            <CardTitle>{t('timeouts.distribution')}</CardTitle>
+            <CardDescription>{t('timeouts.distributionDesc')}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <DistributionBarList items={distribution} total={data.total || 1} />
+          </CardContent>
+        </Card>
+        <Card className="lg:col-span-8">
+          <CardHeader>
+            <CardTitle>{t('timeouts.recentEvents')}</CardTitle>
+            <CardDescription>{t('timeouts.note')}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <TimeoutEventsTable rows={data.items} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+export function ThroughputPanel({ throughput, tokens }: { throughput: ThroughputResponse | null; tokens: TokenResponse | null }) {
+  const t = useTranslations('dashboard.observability')
+  if (!throughput) return <ObservabilityEmpty />
+
+  const totalTokens = tokens?.total_tokens ?? 0
+  const sourceItems = (tokens?.by_source ?? []).map((item) => ({ label: sourceLabel(item.source, t), value: item.tokens, tone: item.source === 'workflow' ? 'success' as Tone : 'info' as Tone }))
+  const modelItems = (tokens?.by_model ?? []).slice(0, 8).map((item) => ({ label: item.model, value: item.tokens, tone: 'neutral' as Tone }))
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <ConsoleMetric label={t('metrics.currentQps')} value={String(throughput.current.qps)} description="QPS" />
+        <ConsoleMetric label={t('metrics.currentTps')} value={String(throughput.current.tps)} description="TPS" />
+        <ConsoleMetric label={t('throughput.runningWorkflows')} value={formatNumber(throughput.current.running_workflows)} tone={throughput.current.running_workflows > 0 ? 'info' : 'neutral'} />
+        <ConsoleMetric label={t('metrics.totalTokens')} value={formatCompactNumber(totalTokens)} description={t('metrics.selectedRange')} />
+      </div>
+      <div className="grid gap-6 lg:grid-cols-12">
+        <ObservabilityChartCard className="lg:col-span-8" title={t('throughput.requestVolume')} description={t('charts.throughputTrendDesc')} empty={!throughput.buckets.length}>
+          <ResponsiveContainer width="100%" height={320}>
+            <BarChart data={throughput.buckets}>
+              <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
+              <XAxis dataKey="bucket" tickFormatter={formatBucket} minTickGap={24} />
+              <YAxis />
+              <Tooltip contentStyle={CHART_TOOLTIP_STYLE} labelFormatter={formatBucket} />
+              <Legend />
+              <Bar name={t('overview.agentRequests')} dataKey="agent_requests" stackId="requests" fill={CHART_COLOR_ORDER[0]} radius={[4, 4, 0, 0]} />
+              <Bar name={t('overview.workflowRuns')} dataKey="workflow_runs" stackId="requests" fill={CHART_COLOR_ORDER[1]} radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </ObservabilityChartCard>
+        <Card className="lg:col-span-4">
+          <CardHeader>
+            <CardTitle>{t('throughput.tokenBySource')}</CardTitle>
+            <CardDescription>{t('throughput.tokens')}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {sourceItems.length ? <DistributionBarList items={sourceItems} total={totalTokens || 1} /> : <ObservabilityEmpty description={t('throughput.noTokenData')} />}
+          </CardContent>
+        </Card>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('throughput.tokenByModel')}</CardTitle>
+          <CardDescription>{t('throughput.share')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {modelItems.length ? <DistributionBarList items={modelItems} total={totalTokens || 1} showPercent /> : <ObservabilityEmpty description={t('throughput.noTokenData')} />}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function AgentDetailSheet({ open, onOpenChange, detail, isLoading }: { open: boolean; onOpenChange: (open: boolean) => void; detail: AgentDetailResponse | null; isLoading: boolean }) {
+  const t = useTranslations('dashboard.observability')
+  const agent = detail?.agent
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="p-0 sm:max-w-2xl">
+        <SheetHeader className="border-b px-6 py-4">
+          <SheetTitle>{t('details.agentTitle')}</SheetTitle>
+          <SheetDescription>{agent ? agent.agent_name || agent.agent_id : t('details.noAgent')}</SheetDescription>
+        </SheetHeader>
+        <div className="flex-1 space-y-6 overflow-y-auto px-6 py-4">
+          {isLoading ? <DetailSkeleton /> : agent ? (
+            <>
+              <div className="grid grid-cols-2 gap-3">
+                <ConsoleMetric label={t('tables.requests')} value={formatNumber(agent.request_count)} />
+                <ConsoleMetric label={t('tables.successRate')} value={formatPercent(agent.success_rate)} />
+                <ConsoleMetric label={t('tables.timeoutRate')} value={formatPercent(agent.timeout_rate)} />
+                <ConsoleMetric label={t('tables.ttftP95')} value={formatDuration(agent.ttft_p95_ms)} />
+                <ConsoleMetric label={t('details.avgTokens')} value={formatNumber(agent.avg_tokens)} />
+              </div>
+              <PercentileStrip values={agent} />
+              <DetailTrendChart data={detail?.trend ?? []} countKey="request_count" />
+            </>
+          ) : <ObservabilityEmpty />}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function WorkflowDetailSheet({ open, onOpenChange, detail, isLoading }: { open: boolean; onOpenChange: (open: boolean) => void; detail: WorkflowDetailResponse | null; isLoading: boolean }) {
+  const t = useTranslations('dashboard.observability')
+  const workflow = detail?.workflow
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="p-0 sm:max-w-3xl">
+        <SheetHeader className="border-b px-6 py-4">
+          <SheetTitle>{t('details.workflowTitle')}</SheetTitle>
+          <SheetDescription>{workflow ? workflow.workflow_name || workflow.workflow_id : t('details.noWorkflow')}</SheetDescription>
+        </SheetHeader>
+        <div className="flex-1 space-y-6 overflow-y-auto px-6 py-4">
+          {isLoading ? <DetailSkeleton /> : workflow ? (
+            <>
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                <ConsoleMetric label={t('tables.runs')} value={formatNumber(workflow.run_count)} />
+                <ConsoleMetric label={t('tables.successRate')} value={formatPercent(workflow.success_rate)} />
+                <ConsoleMetric label={t('tables.timeoutRate')} value={formatPercent(workflow.timeout_rate)} />
+                <ConsoleMetric label={t('details.avgNodes')} value={workflow.avg_nodes == null ? '-' : formatNumber(workflow.avg_nodes)} />
+              </div>
+              <DetailTrendChart data={detail?.trend ?? []} countKey="run_count" />
+              <NodeBreakdownTable rows={detail?.nodes ?? []} />
+            </>
+          ) : <ObservabilityEmpty />}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function DetailTrendChart({ data, countKey }: { data: ObservabilityTrendPoint[]; countKey: 'request_count' | 'run_count' }) {
+  const t = useTranslations('dashboard.observability')
+  return (
+    <ObservabilityChartCard title={t('details.performanceTrend')} description={t('details.percentiles')} empty={!data.length}>
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
+          <XAxis dataKey="bucket" tickFormatter={formatBucket} minTickGap={24} />
+          <YAxis />
+          <Tooltip contentStyle={CHART_TOOLTIP_STYLE} labelFormatter={formatBucket} />
+          <Legend />
+          <Line name="P95" type="monotone" dataKey="p95_ms" stroke={CHART_COLOR_ORDER[0]} dot={false} />
+          <Line name={t('common.count')} type="monotone" dataKey={countKey} stroke={CHART_COLOR_ORDER[1]} dot={false} />
+        </LineChart>
+      </ResponsiveContainer>
+    </ObservabilityChartCard>
+  )
+}
+
+function NodeBreakdownTable({ rows }: { rows: WorkflowDetailResponse['nodes'] }) {
+  const t = useTranslations('dashboard.observability')
+  if (!rows.length) return <ObservabilityEmpty />
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('details.nodeBreakdown')}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{t('details.nodeType')}</TableHead>
+              <TableHead className="text-right">{t('details.executionCount')}</TableHead>
+              <TableHead className="text-right">{t('details.failedCount')}</TableHead>
+              <TableHead className="text-right">{t('details.avgDuration')}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.node_type}>
+                <TableCell className="font-medium">{row.node_type}</TableCell>
+                <TableCell className="text-right">{formatNumber(row.execution_count)}</TableCell>
+                <TableCell className="text-right">{formatNumber(row.failed_count)}</TableCell>
+                <TableCell className="text-right">{formatDuration(row.avg_duration_ms)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}
+
+function SlowQueriesContent({ slowQueries }: { slowQueries: SlowQueriesResponse | null }) {
+  const t = useTranslations('dashboard.observability')
+  if (!slowQueries) return <ObservabilityEmpty />
+  if (!slowQueries.available) {
+    return (
+      <Alert variant="warning">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertTitle>{t('health.slowQueriesUnavailable')}</AlertTitle>
+        <AlertDescription>{t('health.slowQueriesSetupHint')}</AlertDescription>
+      </Alert>
+    )
+  }
+  if (!slowQueries.items.length) return <ObservabilityEmpty description={t('health.noSlowQueries')} />
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>{t('health.query')}</TableHead>
+          <TableHead className="text-right">{t('health.calls')}</TableHead>
+          <TableHead className="text-right">{t('health.meanTime')}</TableHead>
+          <TableHead className="text-right">{t('health.totalTime')}</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {slowQueries.items.map((row, index) => (
+          <TableRow key={index}>
+            <TableCell className="max-w-[420px] truncate font-mono text-xs">{readString(row, ['query', 'statement'])}</TableCell>
+            <TableCell className="text-right">{formatNumber(readNumber(row, ['calls']))}</TableCell>
+            <TableCell className="text-right">{formatDuration(readNumber(row, ['avg_ms', 'mean_exec_time', 'mean_time', 'duration_ms']))}</TableCell>
+            <TableCell className="text-right">{formatDuration(readNumber(row, ['total_ms', 'total_exec_time', 'total_time']))}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+function TimeoutEventsTable({ rows }: { rows: TimeoutEvent[] }) {
+  const t = useTranslations('dashboard.observability')
+  if (!rows.length) return <ObservabilityEmpty />
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>{t('tables.source')}</TableHead>
+          <TableHead>{t('tables.name')}</TableHead>
+          <TableHead>{t('tables.type')}</TableHead>
+          <TableHead>{t('tables.status')}</TableHead>
+          <TableHead>{t('tables.model')}</TableHead>
+          <TableHead className="text-right">{t('tables.duration')}</TableHead>
+          <TableHead className="text-right">{t('tables.time')}</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((row, index) => (
+          <TableRow key={`${row.source}-${row.entity_id}-${row.created_at}-${index}`}>
+            <TableCell><StatusPill tone={row.source === 'workflow' ? 'success' : 'info'} label={sourceLabel(row.source, t)} /></TableCell>
+            <TableCell className="font-medium">{row.entity_name}</TableCell>
+            <TableCell>{timeoutTypeLabel(row.timeout_type, t)}</TableCell>
+            <TableCell><StatusPill tone={row.status === 'timeout' || row.status === 'error' ? 'warning' : 'neutral'} label={statusLabel(row.status, t)} /></TableCell>
+            <TableCell>{row.model || '-'}</TableCell>
+            <TableCell className="text-right">{formatDuration(row.duration_ms)}</TableCell>
+            <TableCell className="text-right">{formatBucket(row.created_at)}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+function EntityTable({ headers, rows, empty }: { headers: string[]; rows: Array<{ key: string; cells: React.ReactNode[]; onClick?: () => void }>; empty: boolean }) {
+  if (empty) return <ObservabilityEmpty />
+  return (
+    <Card>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {headers.map((header, index) => (
+                <TableHead key={header} className={index > 1 ? 'text-right' : undefined}>{header}</TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.key} role="button" tabIndex={0} className="cursor-pointer" onClick={row.onClick} onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  row.onClick?.()
+                }
+              }}>
+                {row.cells.map((cell, index) => (
+                  <TableCell key={index} className={index > 1 ? 'text-right' : undefined}>{cell}</TableCell>
+                ))}
+                <TableCell className="w-8 text-right"><ChevronRight className="ml-auto h-4 w-4 text-muted-foreground" /></TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}
+
+function EntityName({ name, id }: { name: string; id: string }) {
+  return (
+    <div className="min-w-[180px]">
+      <div className="font-medium">{name}</div>
+      <div className="text-xs text-muted-foreground">{id.slice(0, 8)}</div>
+    </div>
+  )
+}
+
+function ConsoleMetric({ label, value, description, tone = 'neutral' }: { label: string; value: string; description?: string; tone?: Tone }) {
+  return (
+    <div className="rounded-lg border bg-card/60 p-4">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</div>
+        {tone !== 'neutral' && <span className={`h-2 w-2 rounded-full ${toneDotClass(tone)}`} />}
+      </div>
+      <div className="mt-2 text-2xl font-semibold tracking-tight">{value}</div>
+      {description && <div className="mt-1 truncate text-xs text-muted-foreground">{description}</div>}
+    </div>
+  )
+}
+
+function ObservabilityChartCard({ title, description, empty, className, children }: { title: string; description?: string; empty?: boolean; className?: string; children: React.ReactNode }) {
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+      </CardHeader>
+      <CardContent>
+        {empty ? <ObservabilityEmpty /> : children}
+      </CardContent>
+    </Card>
+  )
+}
+
+function PercentileStrip({ values }: { values: { p50_ms: number | null; p90_ms: number | null; p95_ms: number | null; p99_ms?: number | null } }) {
+  const items = [
+    ['P50', values.p50_ms],
+    ['P90', values.p90_ms],
+    ['P95', values.p95_ms],
+    ['P99', values.p99_ms ?? null],
+  ] as const
+  return (
+    <div className="grid grid-cols-4 gap-2">
+      {items.map(([label, value]) => (
+        <div key={label} className="rounded-md bg-muted/60 px-3 py-2">
+          <div className="text-xs text-muted-foreground">{label}</div>
+          <div className="font-medium">{formatDuration(value)}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ResourceRow({ label, icon: Icon, data, valueKey, suffix }: { label: string; icon: React.ElementType; data: Record<string, unknown>; valueKey: string; suffix: string }) {
+  const t = useTranslations('dashboard.observability')
+  const status = String(data.status ?? 'unknown')
+  const value = readNumber(data, [valueKey])
+  const progress = suffix === '%' ? Math.min(Math.max(value, 0), 100) : null
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="rounded-md bg-muted p-2"><Icon className="h-4 w-4" /></div>
+          <div>
+            <div className="font-medium">{label}</div>
+            <div className="text-xs text-muted-foreground">{Number.isFinite(value) ? `${value}${suffix}` : '-'}</div>
+          </div>
+        </div>
+        <StatusPill tone={toneForStatus(status)} label={statusLabel(status, t)} />
+      </div>
+      {progress !== null && <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted"><div className={`h-full ${toneBarClass(toneForStatus(status))}`} style={{ width: `${progress}%` }} /></div>}
+    </div>
+  )
+}
+
+function DistributionBarList({ items, total, valueLabel, showPercent }: { items: Array<{ label: string; value: number; tone?: Tone }>; total: number; valueLabel?: string; showPercent?: boolean }) {
+  if (!items.length) return <ObservabilityEmpty />
+  return (
+    <div className="space-y-4">
+      {items.map((item) => {
+        const percent = percentOf(item.value, total)
+        const tone = item.tone ?? 'neutral'
+        return (
+          <div key={item.label} className="space-y-1.5">
+            <div className="flex items-center justify-between gap-3 text-sm">
+              <span className="truncate font-medium">{item.label}</span>
+              <span className="text-muted-foreground">{formatCompactNumber(item.value)}{valueLabel ? ` ${valueLabel}` : ''}{showPercent ? ` · ${formatPercent(percent)}` : ''}</span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-muted">
+              <div className={`h-full ${toneBarClass(tone)}`} style={{ width: `${Math.max(percent, item.value > 0 ? 2 : 0)}%` }} />
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function StatusPill({ tone, label }: { tone: Tone; label: string }) {
+  return <Badge variant="outline" className={TONE_STYLES[tone]}>{label}</Badge>
+}
+
+function StatusValue({ value, tone }: { value: string; tone: Tone }) {
+  return <span className={toneTextClass(tone)}>{value}</span>
+}
+
+function ObservabilityEmpty({ description }: { description?: string }) {
+  const t = useTranslations('dashboard.observability')
+  return (
+    <div className="flex min-h-36 flex-col items-center justify-center rounded-lg border border-dashed p-6 text-center">
+      <Info className="mb-2 h-5 w-5 text-muted-foreground" />
+      <div className="font-medium">{t('states.emptyTitle')}</div>
+      <div className="mt-1 text-sm text-muted-foreground">{description ?? t('states.emptyDescription')}</div>
+    </div>
+  )
+}
+
+function DetailSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-20 rounded-xl" />
+      <Skeleton className="h-40 rounded-xl" />
+      <Skeleton className="h-52 rounded-xl" />
+    </div>
+  )
+}
+
+function workerHealthData(worker: WorkerResponse): Record<string, unknown> {
+  return {
+    status: worker.status,
+    worker_count: worker.worker_count,
+    active_tasks: worker.active_tasks,
+    reserved_tasks: worker.reserved_tasks,
+    scheduled_tasks: worker.scheduled_tasks,
+    error: worker.error,
+  }
+}
+
+function getRiskLevel(timeoutRate: number, successRate: number, p95: number | null, ttftP95: number | null): { key: 'healthy' | 'warning' | 'critical'; summaryKey: 'healthSummaryHealthy' | 'healthSummaryWarning' | 'healthSummaryCritical'; tone: Tone } {
+  if (timeoutRate >= 5 || successRate < 95 || (ttftP95 != null ? ttftP95 >= 10000 : (p95 ?? 0) >= 30000)) {
+    return { key: 'critical', summaryKey: 'healthSummaryCritical', tone: 'danger' }
+  }
+  if (timeoutRate >= 1 || successRate < 99 || (ttftP95 != null ? ttftP95 >= 3000 : (p95 ?? 0) >= 10000)) {
+    return { key: 'warning', summaryKey: 'healthSummaryWarning', tone: 'warning' }
+  }
+  return { key: 'healthy', summaryKey: 'healthSummaryHealthy', tone: 'success' }
+}
+
+function toneForStatus(status: string): Tone {
+  if (status === 'danger' || status === 'unhealthy' || status === 'failed' || status === 'error') return 'danger'
+  if (status === 'warning' || status === 'unknown' || status === 'timeout') return 'warning'
+  if (status === 'healthy' || status === 'success') return 'success'
+  if (status === 'running') return 'info'
+  return 'neutral'
+}
+
+function statusLabel(status: string | null | undefined, t: ObservabilityTranslator) {
+  const normalized = status || 'unknown'
+  const keys = new Set(['healthy', 'warning', 'danger', 'unhealthy', 'unknown', 'success', 'failed', 'running', 'pending', 'cancelled', 'timeout', 'error'])
+  return keys.has(normalized) ? t(`status.${normalized}`) : normalized
+}
+
+function sourceLabel(source: string | null | undefined, t: ObservabilityTranslator) {
+  if (source === 'agent' || source === 'workflow' || source === 'system') return t(`sources.${source}`)
+  return t('sources.unknown')
+}
+
+function timeoutTypeLabel(type: string | null | undefined, t: ObservabilityTranslator) {
+  const normalized = type || 'unknown'
+  const keys = new Set(['unknown', 'idle', 'global', 'workflow', 'agent'])
+  return keys.has(normalized) ? t(`timeoutTypes.${normalized}`) : normalized
+}
+
+function readNumber(row: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = row[key]
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+    if (typeof value === 'string' && value.trim() && Number.isFinite(Number(value))) return Number(value)
+  }
+  return 0
+}
+
+function readString(row: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = row[key]
+    if (typeof value === 'string' && value.trim()) return value
+  }
+  return '-'
+}
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat().format(value)
+}
+
+function formatCompactNumber(value: number) {
+  return new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 }).format(value)
+}
+
+function formatPercent(value: number) {
+  return `${value.toFixed(1)}%`
+}
+
+function formatDuration(value: number | null | undefined) {
+  if (value == null) return '-'
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}s`
+  return `${Math.round(value)}ms`
+}
+
+function formatBucket(value: string | null | undefined) {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString(undefined, { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
+}
+
+function percentOf(value: number, total: number) {
+  if (!total) return 0
+  return Math.round((value / total) * 1000) / 10
+}
+
+function toneDotClass(tone: Tone) {
+  return {
+    neutral: 'bg-muted-foreground',
+    success: 'bg-emerald-500',
+    warning: 'bg-amber-500',
+    danger: 'bg-destructive',
+    info: 'bg-sky-500',
+  }[tone]
+}
+
+function toneBarClass(tone: Tone) {
+  return {
+    neutral: 'bg-muted-foreground/50',
+    success: 'bg-emerald-500',
+    warning: 'bg-amber-500',
+    danger: 'bg-destructive',
+    info: 'bg-sky-500',
+  }[tone]
+}
+
+function toneTextClass(tone: Tone) {
+  return {
+    neutral: 'text-foreground',
+    success: 'text-emerald-700 dark:text-emerald-300',
+    warning: 'text-amber-700 dark:text-amber-300',
+    danger: 'text-destructive',
+    info: 'text-sky-700 dark:text-sky-300',
+  }[tone]
+}

--- a/frontend/app/(dashboard)/dashboard/observability/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/observability/page.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import * as React from 'react'
+import { useTranslations } from 'next-intl'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { RefreshCw } from 'lucide-react'
+
+import { RoutePermissionGuard } from '@/components/auth/permission-guard'
+import { TimeRangeSelector, type TimeRange } from '@/components/dashboard/time-range-selector'
+import { Header } from '@/components/layout/header'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  observabilityApi,
+  type AgentPerformanceRow,
+  type ObservabilityOverview,
+  type SlowQueriesResponse,
+  type SystemHealthResponse,
+  type SystemTrendResponse,
+  type ThroughputResponse,
+  type TimeoutResponse,
+  type TokenResponse,
+  type WorkflowPerformanceRow,
+  type WorkerResponse,
+} from '@/lib/api/admin/observability'
+import {
+  AgentsPanel,
+  ErrorState,
+  HealthPanel,
+  ObservabilitySkeleton,
+  OverviewPanel,
+  ThroughputPanel,
+  TimeoutsPanel,
+  WorkflowsPanel,
+} from './_components/observability-panels'
+
+type ObservabilityTab = 'overview' | 'health' | 'agents' | 'workflows' | 'timeouts' | 'throughput'
+
+const TAB_VALUES: ObservabilityTab[] = ['overview', 'health', 'agents', 'workflows', 'timeouts', 'throughput']
+
+export default function ObservabilityPage() {
+  const t = useTranslations('dashboard.observability')
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [activeTab, setActiveTab] = React.useState<ObservabilityTab>('overview')
+  const [timeRange, setTimeRange] = React.useState<TimeRange>('30d')
+  const [isLoading, setIsLoading] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [lastUpdatedAt, setLastUpdatedAt] = React.useState<Date | null>(null)
+  const [overview, setOverview] = React.useState<ObservabilityOverview | null>(null)
+  const [throughput, setThroughput] = React.useState<ThroughputResponse | null>(null)
+  const [tokens, setTokens] = React.useState<TokenResponse | null>(null)
+  const [agents, setAgents] = React.useState<AgentPerformanceRow[]>([])
+  const [workflows, setWorkflows] = React.useState<WorkflowPerformanceRow[]>([])
+  const [timeouts, setTimeouts] = React.useState<TimeoutResponse | null>(null)
+  const [health, setHealth] = React.useState<SystemHealthResponse | null>(null)
+  const [systemTrend, setSystemTrend] = React.useState<SystemTrendResponse | null>(null)
+  const [slowQueries, setSlowQueries] = React.useState<SlowQueriesResponse | null>(null)
+  const [workers, setWorkers] = React.useState<WorkerResponse | null>(null)
+
+  React.useEffect(() => {
+    const tab = searchParams.get('tab') as ObservabilityTab | null
+    if (tab && TAB_VALUES.includes(tab)) {
+      setActiveTab(tab)
+    }
+  }, [searchParams])
+
+  const fetchCurrentTab = React.useCallback(async () => {
+    try {
+      setIsLoading(true)
+      setError(null)
+      if (activeTab === 'overview') {
+        const [overviewData, throughputData] = await Promise.all([
+          observabilityApi.getOverview(timeRange),
+          observabilityApi.getThroughput({ time_range: timeRange }),
+        ])
+        setOverview(overviewData)
+        setThroughput(throughputData)
+      } else if (activeTab === 'health') {
+        const [healthData, trendData, slowQueryData, workerData] = await Promise.all([
+          observabilityApi.getSystemHealth(),
+          observabilityApi.getSystemTrend(),
+          observabilityApi.getSlowQueries({ page_size: 10 }),
+          observabilityApi.getWorkers(),
+        ])
+        setHealth(healthData)
+        setSystemTrend(trendData)
+        setSlowQueries(slowQueryData)
+        setWorkers(workerData)
+      } else if (activeTab === 'agents') {
+        const data = await observabilityApi.getAgents({ time_range: timeRange, page_size: 20 })
+        setAgents(data.items)
+      } else if (activeTab === 'workflows') {
+        const data = await observabilityApi.getWorkflows({ time_range: timeRange, page_size: 20 })
+        setWorkflows(data.items)
+      } else if (activeTab === 'timeouts') {
+        const data = await observabilityApi.getTimeouts({ time_range: timeRange, page_size: 20 })
+        setTimeouts(data)
+      } else if (activeTab === 'throughput') {
+        const [throughputData, tokenData] = await Promise.all([
+          observabilityApi.getThroughput({ time_range: timeRange }),
+          observabilityApi.getTokens(timeRange),
+        ])
+        setThroughput(throughputData)
+        setTokens(tokenData)
+      }
+      setLastUpdatedAt(new Date())
+    } catch (fetchError) {
+      console.error('[Observability] Failed to fetch data:', fetchError)
+      setError(t('states.errorDescription'))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [activeTab, timeRange, t])
+
+  React.useEffect(() => {
+    fetchCurrentTab()
+  }, [fetchCurrentTab])
+
+  React.useEffect(() => {
+    if (activeTab !== 'health') return
+    const timer = window.setInterval(fetchCurrentTab, 30000)
+    return () => window.clearInterval(timer)
+  }, [activeTab, fetchCurrentTab])
+
+  const handleTabChange = (value: string) => {
+    const newTab = value as ObservabilityTab
+    setActiveTab(newTab)
+    router.push(`/dashboard/observability?tab=${newTab}`, { scroll: false })
+  }
+
+  const showSkeleton = isLoading && !hasTabData(activeTab, { overview, health, agents, workflows, timeouts, throughput })
+
+  return (
+    <RoutePermissionGuard>
+      <div className="flex h-full flex-col">
+        <Header />
+        <div className="flex-1 overflow-auto p-4">
+          <div className="space-y-6">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="max-w-3xl">
+                <div className="flex flex-wrap items-center gap-3">
+                  <h1 className="text-3xl font-bold tracking-tight">{t('title')}</h1>
+                  {activeTab === 'health' && <Badge variant="outline">{t('states.autoRefreshHint')}</Badge>}
+                </div>
+                <p className="text-muted-foreground mt-1">{t('description')}</p>
+                {lastUpdatedAt && (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {t('states.lastUpdated', { time: lastUpdatedAt.toLocaleTimeString() })}
+                  </p>
+                )}
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                {activeTab !== 'health' && <TimeRangeSelector value={timeRange} onChange={setTimeRange} />}
+                <Button variant="outline" size="icon" onClick={fetchCurrentTab} disabled={isLoading} aria-label={t('actions.refresh')}>
+                  <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+                </Button>
+              </div>
+            </div>
+
+            <Tabs value={activeTab} onValueChange={handleTabChange}>
+              <TabsList className="flex h-auto w-full flex-wrap justify-start">
+                {TAB_VALUES.map((tab) => (
+                  <TabsTrigger key={tab} value={tab}>{t(`tabs.${tab}`)}</TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+
+            {error && <ErrorState onRetry={fetchCurrentTab} />}
+            {showSkeleton && <ObservabilitySkeleton tab={activeTab} />}
+            {!showSkeleton && activeTab === 'overview' && <OverviewPanel overview={overview} throughput={throughput} />}
+            {!showSkeleton && activeTab === 'health' && (
+              <HealthPanel health={health} trend={systemTrend} slowQueries={slowQueries} workers={workers} />
+            )}
+            {!showSkeleton && activeTab === 'agents' && <AgentsPanel rows={agents} timeRange={timeRange} />}
+            {!showSkeleton && activeTab === 'workflows' && <WorkflowsPanel rows={workflows} timeRange={timeRange} />}
+            {!showSkeleton && activeTab === 'timeouts' && <TimeoutsPanel data={timeouts} />}
+            {!showSkeleton && activeTab === 'throughput' && <ThroughputPanel throughput={throughput} tokens={tokens} />}
+          </div>
+        </div>
+      </div>
+    </RoutePermissionGuard>
+  )
+}
+
+function hasTabData(
+  tab: ObservabilityTab,
+  data: {
+    overview: ObservabilityOverview | null
+    health: SystemHealthResponse | null
+    agents: AgentPerformanceRow[]
+    workflows: WorkflowPerformanceRow[]
+    timeouts: TimeoutResponse | null
+    throughput: ThroughputResponse | null
+  }
+) {
+  if (tab === 'overview') return Boolean(data.overview)
+  if (tab === 'health') return Boolean(data.health)
+  if (tab === 'agents') return data.agents.length > 0
+  if (tab === 'workflows') return data.workflows.length > 0
+  if (tab === 'timeouts') return Boolean(data.timeouts)
+  return Boolean(data.throughput)
+}

--- a/frontend/components/layout/app-sidebar.tsx
+++ b/frontend/components/layout/app-sidebar.tsx
@@ -195,6 +195,12 @@ export function AppSidebar({ variant = 'inset', collapsible = 'icon', side = 'le
 
   const monitoringItems = [
     {
+      title: t('observability'),
+      url: '/dashboard/observability',
+      icon: Activity,
+      permission: ROUTE_PERMISSION_MAP['/dashboard/observability'],
+    },
+    {
       title: t('notifications'),
       url: '/notifications',
       icon: Bell,
@@ -240,7 +246,7 @@ export function AppSidebar({ variant = 'inset', collapsible = 'icon', side = 'le
     (item) => !item.permission || hasPermission(item.permission)
   )
 
-  const isActive = (url: string) => pathname.startsWith(url)
+  const isActive = (url: string) => (url === '/dashboard' ? pathname === url : pathname.startsWith(url))
 
   return (
     <Sidebar variant={variant} collapsible={collapsible} side={side}>

--- a/frontend/i18n/en/dashboard.json
+++ b/frontend/i18n/en/dashboard.json
@@ -154,6 +154,187 @@
         "forceChangeDesc": "Users required to change password",
         "allGood": "All passwords are up to date"
       }
+    },
+    "observability": {
+      "title": "Observability",
+      "description": "Monitor AI conversation and workflow performance, timeouts, throughput, and system health.",
+      "tabs": {
+        "overview": "Overview",
+        "health": "System Health",
+        "agents": "Agent Performance",
+        "workflows": "Workflow Performance",
+        "timeouts": "Timeout Analysis",
+        "throughput": "System Throughput"
+      },
+      "actions": {
+        "refresh": "Refresh",
+        "retry": "Retry",
+        "viewDetails": "View details",
+        "closeDetails": "Close details"
+      },
+      "states": {
+        "loading": "Loading observability data",
+        "refreshing": "Refreshing",
+        "emptyTitle": "No data yet",
+        "emptyDescription": "There is no observability data for this view yet.",
+        "errorTitle": "Observability data could not be loaded",
+        "errorDescription": "Check service health and try again.",
+        "lastUpdated": "Last updated {time}",
+        "cacheTtl": "Cached for {seconds}s to reduce dashboard load.",
+        "autoRefreshHint": "Auto-refreshes every 30s"
+      },
+      "status": {
+        "healthy": "Healthy",
+        "warning": "Warning",
+        "danger": "Critical",
+        "unhealthy": "Unhealthy",
+        "unknown": "Unknown",
+        "success": "Success",
+        "failed": "Failed",
+        "running": "Running",
+        "pending": "Pending",
+        "cancelled": "Cancelled",
+        "timeout": "Timeout",
+        "error": "Error"
+      },
+      "sources": {
+        "agent": "Agent",
+        "workflow": "Workflow",
+        "system": "System",
+        "unknown": "Unknown"
+      },
+      "risk": {
+        "healthy": "Healthy",
+        "warning": "Watch",
+        "critical": "Critical"
+      },
+      "metrics": {
+        "totalRequests": "Total Requests",
+        "agentWorkflowBreakdown": "Agents {agents} · Workflows {workflows}",
+        "p95Latency": "P95 Latency",
+        "p95Ttft": "P95 TTFT",
+        "firstTokenLatency": "First token latency",
+        "timeoutRate": "Timeout Rate",
+        "successRate": "Success Rate",
+        "successRateValue": "Success {value}",
+        "currentQps": "Current QPS",
+        "currentTps": "Current TPS",
+        "peakHourly": "Peak Hourly",
+        "totalTokens": "Total Tokens",
+        "selectedRange": "Selected range"
+      },
+      "overview": {
+        "operationalStatus": "Operational Status",
+        "operationalStatusDesc": "A compact readout for request reliability, latency, and load.",
+        "trafficMix": "Traffic Mix",
+        "latencyPercentiles": "Latency Percentiles",
+        "requestsBySource": "Requests by source",
+        "agentRequests": "Agent Requests",
+        "workflowRuns": "Workflow Runs",
+        "healthSummaryHealthy": "Systems are operating within expected bounds.",
+        "healthSummaryWarning": "Some indicators need attention before they become incidents.",
+        "healthSummaryCritical": "Reliability or latency is outside the safe operating range."
+      },
+      "charts": {
+        "requestTrend": "Request Trend",
+        "requestTrendDesc": "Agent requests and workflow runs over time",
+        "systemTrend": "System Resource Trend",
+        "systemTrendDesc": "Recent CPU and memory samples cached from health checks",
+        "throughputTrend": "Throughput Trend",
+        "throughputTrendDesc": "Combined agent and workflow request volume"
+      },
+      "health": {
+        "memory": "Memory",
+        "disk": "Disk",
+        "database": "Database",
+        "resourceUsage": "Resource Usage",
+        "dependencies": "Dependencies",
+        "workerQueues": "Worker Queues",
+        "workerQueuesDesc": "Celery task pressure by queue and reservation state.",
+        "activeTasks": "Active",
+        "reservedTasks": "Reserved",
+        "scheduledTasks": "Scheduled",
+        "pending": "pending",
+        "queue": "Queue",
+        "slowQueries": "Slow Queries",
+        "slowQueriesDesc": "PostgreSQL statements ranked by execution time.",
+        "query": "Query",
+        "calls": "Calls",
+        "meanTime": "Mean Time",
+        "totalTime": "Total Time",
+        "workerError": "Worker inspection failed",
+        "noSlowQueries": "No slow queries were reported for the current threshold.",
+        "slowQueriesUnavailable": "Slow query data unavailable",
+        "slowQueriesSetupHint": "Enable pg_stat_statements in PostgreSQL shared_preload_libraries, restart PostgreSQL, then refresh this page."
+      },
+      "tables": {
+        "name": "Name",
+        "team": "Team",
+        "requests": "Requests",
+        "runs": "Runs",
+        "successRate": "Success Rate",
+        "timeoutRate": "Timeout Rate",
+        "ttftP95": "TTFT P95",
+        "tokens": "Tokens",
+        "avgTokens": "Avg Tokens",
+        "failedNodes": "Failed Nodes",
+        "source": "Source",
+        "type": "Type",
+        "status": "Status",
+        "model": "Model",
+        "duration": "Duration",
+        "time": "Time"
+      },
+      "details": {
+        "agentTitle": "Agent Detail",
+        "workflowTitle": "Workflow Detail",
+        "id": "ID",
+        "team": "Team",
+        "performanceTrend": "Performance Trend",
+        "percentiles": "P95 latency and request volume in the selected range.",
+        "nodeBreakdown": "Node Breakdown",
+        "noAgent": "No agent selected",
+        "noWorkflow": "No workflow selected",
+        "failedRate": "Failed Rate",
+        "avgTokens": "Avg Tokens",
+        "avgNodes": "Avg Nodes",
+        "nodeType": "Node Type",
+        "executionCount": "Executions",
+        "failedCount": "Failures",
+        "avgDuration": "Avg Duration"
+      },
+      "common": {
+        "count": "Count"
+      },
+      "timeouts": {
+        "limitedTitle": "Historical Agent timeout types are limited",
+        "limitedDescription": "Messages do not currently persist idle/global timeout subtype, so historical Agent timeout type is shown as unknown. Workflow timeouts are exact.",
+        "distribution": "Timeout Distribution",
+        "distributionDesc": "Timeout events grouped by persisted subtype.",
+        "recentEvents": "Recent Events",
+        "totalEvents": "Total Events",
+        "mostFrequentType": "Most Frequent Type",
+        "typeAvailable": "Agent Type Data",
+        "note": "Recent timeout events in the selected range"
+      },
+      "timeoutTypes": {
+        "unknown": "Unknown",
+        "idle": "Idle",
+        "global": "Global",
+        "workflow": "Workflow",
+        "agent": "Agent"
+      },
+      "throughput": {
+        "currentLoad": "Current Load",
+        "runningWorkflows": "Running Workflows",
+        "requestVolume": "Request Volume",
+        "tokenBySource": "Token by Source",
+        "tokenByModel": "Token by Model",
+        "model": "Model",
+        "tokens": "Tokens",
+        "share": "Share of total tokens",
+        "noTokenData": "No token data is available for this range."
+      }
     }
   }
 }

--- a/frontend/i18n/en/nav.json
+++ b/frontend/i18n/en/nav.json
@@ -26,6 +26,7 @@
     "logout": "Log out",
     "logoutSuccess": "Logged out successfully",
     "auditLogs": "Audit Logs",
+    "observability": "Observability",
     "memories": "Memories"
   }
 }

--- a/frontend/i18n/types/dashboard.ts
+++ b/frontend/i18n/types/dashboard.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-31T04:20:24.498Z
+// GENERATED — 2026-06-05T15:52:08.393Z
 // Source: i18n/en/dashboard.json
 export type DashboardMessages = {
   dashboard: {
@@ -155,6 +155,187 @@ export type DashboardMessages = {
         forceChange: string
         forceChangeDesc: string
         allGood: string
+      }
+    }
+    observability: {
+      title: string
+      description: string
+      tabs: {
+        overview: string
+        health: string
+        agents: string
+        workflows: string
+        timeouts: string
+        throughput: string
+      }
+      actions: {
+        refresh: string
+        retry: string
+        viewDetails: string
+        closeDetails: string
+      }
+      states: {
+        loading: string
+        refreshing: string
+        emptyTitle: string
+        emptyDescription: string
+        errorTitle: string
+        errorDescription: string
+        lastUpdated: string
+        cacheTtl: string
+        autoRefreshHint: string
+      }
+      status: {
+        healthy: string
+        warning: string
+        danger: string
+        unhealthy: string
+        unknown: string
+        success: string
+        failed: string
+        running: string
+        pending: string
+        cancelled: string
+        timeout: string
+        error: string
+      }
+      sources: {
+        agent: string
+        workflow: string
+        system: string
+        unknown: string
+      }
+      risk: {
+        healthy: string
+        warning: string
+        critical: string
+      }
+      metrics: {
+        totalRequests: string
+        agentWorkflowBreakdown: string
+        p95Latency: string
+        p95Ttft: string
+        firstTokenLatency: string
+        timeoutRate: string
+        successRate: string
+        successRateValue: string
+        currentQps: string
+        currentTps: string
+        peakHourly: string
+        totalTokens: string
+        selectedRange: string
+      }
+      overview: {
+        operationalStatus: string
+        operationalStatusDesc: string
+        trafficMix: string
+        latencyPercentiles: string
+        requestsBySource: string
+        agentRequests: string
+        workflowRuns: string
+        healthSummaryHealthy: string
+        healthSummaryWarning: string
+        healthSummaryCritical: string
+      }
+      charts: {
+        requestTrend: string
+        requestTrendDesc: string
+        systemTrend: string
+        systemTrendDesc: string
+        throughputTrend: string
+        throughputTrendDesc: string
+      }
+      health: {
+        memory: string
+        disk: string
+        database: string
+        resourceUsage: string
+        dependencies: string
+        workerQueues: string
+        workerQueuesDesc: string
+        activeTasks: string
+        reservedTasks: string
+        scheduledTasks: string
+        pending: string
+        queue: string
+        slowQueries: string
+        slowQueriesDesc: string
+        query: string
+        calls: string
+        meanTime: string
+        totalTime: string
+        workerError: string
+        noSlowQueries: string
+        slowQueriesUnavailable: string
+        slowQueriesSetupHint: string
+      }
+      tables: {
+        name: string
+        team: string
+        requests: string
+        runs: string
+        successRate: string
+        timeoutRate: string
+        ttftP95: string
+        tokens: string
+        avgTokens: string
+        failedNodes: string
+        source: string
+        type: string
+        status: string
+        model: string
+        duration: string
+        time: string
+      }
+      details: {
+        agentTitle: string
+        workflowTitle: string
+        id: string
+        team: string
+        performanceTrend: string
+        percentiles: string
+        nodeBreakdown: string
+        noAgent: string
+        noWorkflow: string
+        failedRate: string
+        avgTokens: string
+        avgNodes: string
+        nodeType: string
+        executionCount: string
+        failedCount: string
+        avgDuration: string
+      }
+      common: {
+        count: string
+      }
+      timeouts: {
+        limitedTitle: string
+        limitedDescription: string
+        distribution: string
+        distributionDesc: string
+        recentEvents: string
+        totalEvents: string
+        mostFrequentType: string
+        typeAvailable: string
+        note: string
+      }
+      timeoutTypes: {
+        unknown: string
+        idle: string
+        global: string
+        workflow: string
+        agent: string
+      }
+      throughput: {
+        currentLoad: string
+        runningWorkflows: string
+        requestVolume: string
+        tokenBySource: string
+        tokenByModel: string
+        model: string
+        tokens: string
+        share: string
+        noTokenData: string
       }
     }
   }

--- a/frontend/i18n/types/nav.ts
+++ b/frontend/i18n/types/nav.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-05-31T04:54:26.525Z
+// GENERATED — 2026-06-05T15:52:08.395Z
 // Source: i18n/en/nav.json
 export type NavMessages = {
   nav: {
@@ -28,6 +28,7 @@ export type NavMessages = {
     logout: string
     logoutSuccess: string
     auditLogs: string
+    observability: string
     memories: string
   }
 }

--- a/frontend/i18n/zh/dashboard.json
+++ b/frontend/i18n/zh/dashboard.json
@@ -154,6 +154,187 @@
         "forceChangeDesc": "需要强制修改密码的用户",
         "allGood": "所有密码均正常"
       }
+    },
+    "observability": {
+      "title": "可观测性",
+      "description": "监控 AI 对话与工作流性能、超时、吞吐和系统健康状态。",
+      "tabs": {
+        "overview": "概览",
+        "health": "系统健康",
+        "agents": "Agent 性能",
+        "workflows": "Workflow 性能",
+        "timeouts": "超时分析",
+        "throughput": "系统吞吐"
+      },
+      "actions": {
+        "refresh": "刷新",
+        "retry": "重试",
+        "viewDetails": "查看详情",
+        "closeDetails": "关闭详情"
+      },
+      "states": {
+        "loading": "正在加载可观测性数据",
+        "refreshing": "正在刷新",
+        "emptyTitle": "暂无数据",
+        "emptyDescription": "当前视图还没有可观测性数据。",
+        "errorTitle": "无法加载可观测性数据",
+        "errorDescription": "请检查服务健康状态后重试。",
+        "lastUpdated": "最后更新 {time}",
+        "cacheTtl": "缓存 {seconds} 秒以降低看板负载。",
+        "autoRefreshHint": "每 30 秒自动刷新"
+      },
+      "status": {
+        "healthy": "健康",
+        "warning": "告警",
+        "danger": "严重",
+        "unhealthy": "不健康",
+        "unknown": "未知",
+        "success": "成功",
+        "failed": "失败",
+        "running": "运行中",
+        "pending": "等待中",
+        "cancelled": "已取消",
+        "timeout": "超时",
+        "error": "错误"
+      },
+      "sources": {
+        "agent": "Agent",
+        "workflow": "Workflow",
+        "system": "系统",
+        "unknown": "未知"
+      },
+      "risk": {
+        "healthy": "健康",
+        "warning": "关注",
+        "critical": "严重"
+      },
+      "metrics": {
+        "totalRequests": "总请求数",
+        "agentWorkflowBreakdown": "Agent {agents} · Workflow {workflows}",
+        "p95Latency": "P95 延迟",
+        "p95Ttft": "P95 首 Token",
+        "firstTokenLatency": "首 Token 延迟",
+        "timeoutRate": "超时率",
+        "successRate": "成功率",
+        "successRateValue": "成功率 {value}",
+        "currentQps": "当前 QPS",
+        "currentTps": "当前 TPS",
+        "peakHourly": "峰值小时请求",
+        "totalTokens": "总 Token",
+        "selectedRange": "所选时间范围"
+      },
+      "overview": {
+        "operationalStatus": "运行状态",
+        "operationalStatusDesc": "聚合展示请求可靠性、延迟和负载。",
+        "trafficMix": "流量构成",
+        "latencyPercentiles": "延迟分位",
+        "requestsBySource": "按来源统计请求",
+        "agentRequests": "Agent 请求",
+        "workflowRuns": "Workflow 运行",
+        "healthSummaryHealthy": "系统运行在预期范围内。",
+        "healthSummaryWarning": "部分指标需要关注，避免演变为事故。",
+        "healthSummaryCritical": "可靠性或延迟已超出安全运行范围。"
+      },
+      "charts": {
+        "requestTrend": "请求趋势",
+        "requestTrendDesc": "Agent 请求与 Workflow 运行随时间变化",
+        "systemTrend": "系统资源趋势",
+        "systemTrendDesc": "健康检查缓存的近期 CPU 与内存采样",
+        "throughputTrend": "吞吐趋势",
+        "throughputTrendDesc": "Agent 与 Workflow 合并请求量"
+      },
+      "health": {
+        "memory": "内存",
+        "disk": "磁盘",
+        "database": "数据库",
+        "resourceUsage": "资源使用",
+        "dependencies": "依赖状态",
+        "workerQueues": "Worker 队列",
+        "workerQueuesDesc": "按队列和任务保留状态查看 Celery 压力。",
+        "activeTasks": "活跃",
+        "reservedTasks": "已保留",
+        "scheduledTasks": "已调度",
+        "pending": "等待中",
+        "queue": "队列",
+        "slowQueries": "慢查询",
+        "slowQueriesDesc": "按执行时间排序的 PostgreSQL 语句。",
+        "query": "查询",
+        "calls": "调用次数",
+        "meanTime": "平均耗时",
+        "totalTime": "总耗时",
+        "workerError": "Worker 检查失败",
+        "noSlowQueries": "当前阈值下没有慢查询。",
+        "slowQueriesUnavailable": "慢查询数据不可用",
+        "slowQueriesSetupHint": "请在 PostgreSQL shared_preload_libraries 中启用 pg_stat_statements，重启 PostgreSQL 后刷新本页。"
+      },
+      "tables": {
+        "name": "名称",
+        "team": "团队",
+        "requests": "请求数",
+        "runs": "运行次数",
+        "successRate": "成功率",
+        "timeoutRate": "超时率",
+        "ttftP95": "首 Token P95",
+        "tokens": "Token",
+        "avgTokens": "平均 Token",
+        "failedNodes": "失败节点",
+        "source": "来源",
+        "type": "类型",
+        "status": "状态",
+        "model": "模型",
+        "duration": "耗时",
+        "time": "时间"
+      },
+      "details": {
+        "agentTitle": "Agent 详情",
+        "workflowTitle": "Workflow 详情",
+        "id": "ID",
+        "team": "团队",
+        "performanceTrend": "性能趋势",
+        "percentiles": "所选时间范围内的 P95 延迟与请求量。",
+        "nodeBreakdown": "节点拆解",
+        "noAgent": "未选择 Agent",
+        "noWorkflow": "未选择 Workflow",
+        "failedRate": "失败率",
+        "avgTokens": "平均 Token",
+        "avgNodes": "平均节点数",
+        "nodeType": "节点类型",
+        "executionCount": "执行次数",
+        "failedCount": "失败次数",
+        "avgDuration": "平均耗时"
+      },
+      "common": {
+        "count": "数量"
+      },
+      "timeouts": {
+        "limitedTitle": "历史 Agent 超时类型受限",
+        "limitedDescription": "消息当前未持久化 idle/global 超时子类型，因此历史 Agent 超时类型显示为 unknown。Workflow 超时统计是精确的。",
+        "distribution": "超时分布",
+        "distributionDesc": "按已持久化子类型聚合超时事件。",
+        "recentEvents": "近期事件",
+        "totalEvents": "事件总数",
+        "mostFrequentType": "最高频类型",
+        "typeAvailable": "Agent 类型数据",
+        "note": "所选时间范围内的近期超时事件"
+      },
+      "timeoutTypes": {
+        "unknown": "未知",
+        "idle": "空闲",
+        "global": "全局",
+        "workflow": "Workflow",
+        "agent": "Agent"
+      },
+      "throughput": {
+        "currentLoad": "当前负载",
+        "runningWorkflows": "运行中 Workflow",
+        "requestVolume": "请求量",
+        "tokenBySource": "按来源统计 Token",
+        "tokenByModel": "按模型统计 Token",
+        "model": "模型",
+        "tokens": "Token",
+        "share": "总 Token 占比",
+        "noTokenData": "该时间范围内没有 Token 数据。"
+      }
     }
   }
 }

--- a/frontend/i18n/zh/nav.json
+++ b/frontend/i18n/zh/nav.json
@@ -26,6 +26,7 @@
     "logout": "退出登录",
     "logoutSuccess": "已成功退出登录",
     "auditLogs": "审计日志",
+    "observability": "可观测性",
     "memories": "记忆"
   }
 }

--- a/frontend/lib/api/admin/index.ts
+++ b/frontend/lib/api/admin/index.ts
@@ -43,3 +43,21 @@ export { adminToolsApi } from './tools'
 export { adminSkillsApi, type AdminSkill, type AdminSkillDetail, type AdminSkillListParams } from './skills'
 export { adminAgentsApi, type AdminAgent, type AdminAgentDetail, type AdminAgentListParams } from './agents'
 export { adminWorkflowsApi, type AdminWorkflow, type AdminWorkflowDetail, type AdminWorkflowListParams } from './workflows'
+
+export { observabilityApi } from './observability'
+export type {
+  ObservabilityTimeRange,
+  ObservabilityOverview,
+  ObservabilityPage,
+  AgentPerformanceRow,
+  WorkflowPerformanceRow,
+  AgentDetailResponse,
+  WorkflowDetailResponse,
+  TimeoutResponse,
+  ThroughputResponse,
+  TokenResponse,
+  SystemHealthResponse,
+  SystemTrendResponse,
+  SlowQueriesResponse,
+  WorkerResponse,
+} from './observability'

--- a/frontend/lib/api/admin/observability.ts
+++ b/frontend/lib/api/admin/observability.ts
@@ -1,0 +1,251 @@
+import { api } from '../client'
+
+export type ObservabilityTimeRange = '7d' | '30d' | '90d' | 'all'
+export type ObservabilitySortOrder = 'asc' | 'desc'
+
+export interface ObservabilityPercentiles {
+  p50_ms: number | null
+  p90_ms: number | null
+  p95_ms: number | null
+  p99_ms?: number | null
+}
+
+export interface ObservabilityOverview {
+  time_range: ObservabilityTimeRange
+  generated_at: string
+  cache_ttl_seconds: number
+  totals: {
+    agent_requests: number
+    workflow_runs: number
+    total_requests: number
+    total_tokens: number
+  }
+  rates: {
+    agent_success_rate: number
+    workflow_success_rate: number
+    overall_success_rate: number
+    timeout_rate: number
+  }
+  latency: ObservabilityPercentiles
+  ttft?: ObservabilityPercentiles
+  throughput: {
+    current_qps: number
+    peak_hourly_requests: number
+  }
+}
+
+export interface ObservabilityPage<T> {
+  items: T[]
+  total: number
+  page: number
+  page_size: number
+  time_range?: ObservabilityTimeRange
+}
+
+export interface AgentPerformanceRow extends ObservabilityPercentiles {
+  agent_id: string
+  agent_name: string | null
+  team_name: string | null
+  request_count: number
+  success_count: number
+  error_count: number
+  timeout_count: number
+  total_tokens: number
+  ttft_p50_ms?: number | null
+  ttft_p90_ms?: number | null
+  ttft_p95_ms?: number | null
+  ttft_p99_ms?: number | null
+  success_rate: number
+  timeout_rate: number
+  avg_tokens: number
+}
+
+export interface WorkflowPerformanceRow extends ObservabilityPercentiles {
+  workflow_id: string
+  workflow_name: string | null
+  team_name: string | null
+  run_count: number
+  success_count: number
+  error_count: number
+  timeout_count: number
+  failed_nodes: number
+  avg_nodes: number | null
+  total_tokens: number
+  success_rate: number
+  timeout_rate: number
+  avg_tokens: number
+}
+
+export interface ObservabilityTrendPoint {
+  bucket: string
+  request_count?: number
+  run_count?: number
+  p50_ms?: number | null
+  p90_ms?: number | null
+  p95_ms?: number | null
+  ttft_p95_ms?: number | null
+  success_rate?: number
+  timeout_count?: number
+  failed_nodes?: number
+}
+
+export interface AgentDetailResponse {
+  time_range: ObservabilityTimeRange
+  agent: AgentPerformanceRow | null
+  trend: ObservabilityTrendPoint[]
+}
+
+export interface WorkflowDetailResponse {
+  time_range: ObservabilityTimeRange
+  workflow: WorkflowPerformanceRow | null
+  trend: ObservabilityTrendPoint[]
+  nodes: Array<{
+    node_type: string
+    execution_count: number
+    failed_count: number
+    avg_duration_ms: number | null
+  }>
+}
+
+export interface TimeoutEvent {
+  source: 'agent' | 'workflow'
+  entity_id: string | null
+  entity_name: string
+  model: string | null
+  timeout_type: string
+  created_at: string | null
+  duration_ms: number | null
+  status: string | null
+}
+
+export interface TimeoutResponse extends ObservabilityPage<TimeoutEvent> {
+  distribution: Record<string, number>
+  agent_timeout_type_available: boolean
+  note: string
+}
+
+export interface ThroughputResponse {
+  time_range: ObservabilityTimeRange
+  granularity: string
+  current: {
+    qps: number
+    tps: number
+    running_workflows: number
+  }
+  buckets: Array<{
+    bucket: string
+    agent_requests: number
+    workflow_runs: number
+    total_requests: number
+  }>
+}
+
+export interface TokenResponse {
+  time_range: ObservabilityTimeRange
+  total_tokens: number
+  by_source: Array<{ source: string; tokens: number }>
+  by_model: Array<{ model: string; tokens: number }>
+}
+
+export interface SystemHealthResponse {
+  generated_at: string
+  cache_ttl_seconds: number
+  cpu: Record<string, unknown>
+  memory: Record<string, unknown>
+  disk: Record<string, unknown>
+  database: Record<string, unknown>
+  redis: Record<string, unknown>
+  workers: WorkerResponse
+}
+
+export interface SystemTrendResponse {
+  items: Array<Record<string, unknown>>
+}
+
+export interface SlowQueriesResponse {
+  available: boolean
+  reason: string | null
+  items: Array<Record<string, unknown>>
+  total: number
+  page: number
+  page_size: number
+}
+
+export interface WorkerResponse {
+  status: string
+  worker_count: number
+  active_tasks: number
+  reserved_tasks: number
+  scheduled_tasks: number
+  queues: Array<{ queue: string; pending: number }>
+  error?: string
+}
+
+function withParams(path: string, params: Record<string, string | number | undefined>) {
+  const query = new URLSearchParams()
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined) {
+      query.set(key, String(value))
+    }
+  })
+  const serialized = query.toString()
+  return serialized ? `${path}?${serialized}` : path
+}
+
+export const observabilityApi = {
+  getOverview: (timeRange: ObservabilityTimeRange = '30d'): Promise<ObservabilityOverview> =>
+    api.get<ObservabilityOverview>(withParams('/admin/observability/overview', { time_range: timeRange })),
+
+  getAgents: (params: {
+    time_range?: ObservabilityTimeRange
+    page?: number
+    page_size?: number
+    sort_by?: string
+    sort_order?: ObservabilitySortOrder
+  } = {}): Promise<ObservabilityPage<AgentPerformanceRow>> =>
+    api.get<ObservabilityPage<AgentPerformanceRow>>(withParams('/admin/observability/agents', params)),
+
+  getAgentDetail: (agentId: string, timeRange: ObservabilityTimeRange = '30d'): Promise<AgentDetailResponse> =>
+    api.get<AgentDetailResponse>(withParams(`/admin/observability/agent/${agentId}`, { time_range: timeRange })),
+
+  getWorkflows: (params: {
+    time_range?: ObservabilityTimeRange
+    page?: number
+    page_size?: number
+    sort_by?: string
+    sort_order?: ObservabilitySortOrder
+  } = {}): Promise<ObservabilityPage<WorkflowPerformanceRow>> =>
+    api.get<ObservabilityPage<WorkflowPerformanceRow>>(withParams('/admin/observability/workflows', params)),
+
+  getWorkflowDetail: (workflowId: string, timeRange: ObservabilityTimeRange = '30d'): Promise<WorkflowDetailResponse> =>
+    api.get<WorkflowDetailResponse>(withParams(`/admin/observability/workflow/${workflowId}`, { time_range: timeRange })),
+
+  getTimeouts: (params: {
+    time_range?: ObservabilityTimeRange
+    source?: 'all' | 'agent' | 'workflow'
+    page?: number
+    page_size?: number
+  } = {}): Promise<TimeoutResponse> =>
+    api.get<TimeoutResponse>(withParams('/admin/observability/timeouts', params)),
+
+  getThroughput: (params: {
+    time_range?: ObservabilityTimeRange
+    granularity?: 'hour' | 'day'
+  } = {}): Promise<ThroughputResponse> =>
+    api.get<ThroughputResponse>(withParams('/admin/observability/throughput', params)),
+
+  getTokens: (timeRange: ObservabilityTimeRange = '30d'): Promise<TokenResponse> =>
+    api.get<TokenResponse>(withParams('/admin/observability/tokens', { time_range: timeRange })),
+
+  getSystemHealth: (): Promise<SystemHealthResponse> =>
+    api.get<SystemHealthResponse>('/admin/observability/system/health'),
+
+  getSystemTrend: (): Promise<SystemTrendResponse> =>
+    api.get<SystemTrendResponse>('/admin/observability/system/trend'),
+
+  getSlowQueries: (params: { threshold_ms?: number; page?: number; page_size?: number } = {}): Promise<SlowQueriesResponse> =>
+    api.get<SlowQueriesResponse>(withParams('/admin/observability/system/slow-queries', params)),
+
+  getWorkers: (): Promise<WorkerResponse> =>
+    api.get<WorkerResponse>('/admin/observability/system/workers'),
+}

--- a/frontend/lib/route-permissions.ts
+++ b/frontend/lib/route-permissions.ts
@@ -17,6 +17,7 @@ export interface SiteSettingsNavItem {
 
 export const ROUTE_PERMISSION_CONFIG: RoutePermissionConfig[] = [
   { path: '/dashboard', permission: 'admin:dashboard:access' },
+  { path: '/dashboard/observability', permission: 'admin:dashboard:access', matchMode: 'prefix' },
   { path: '/teams', permission: 'team:read' },
   { path: '/knowledge-bases', permission: 'admin:knowledge-base:read' },
   { path: '/activities', permission: 'conversation:read' },


### PR DESCRIPTION
## Summary
- Add platform-admin observability APIs for overview, Agent/Workflow performance, timeouts, throughput, tokens, system health, slow queries, and workers
- Add enterprise-style /dashboard/observability UI with six monitoring tabs, drilldown sheets, i18n, navigation, and route permissions
- Persist streamed Agent TTFT (first token latency) separately from total duration and expose it in observability metrics
- Enable pg_stat_statements for bundled PostgreSQL deployments and document slow-query setup

## Validation
- cd backend && uv run ruff check app/models/agent.py app/core/init_data.py app/main.py app/api/v1/endpoints/chat.py app/services/admin_observability.py app/schemas/agent.py tests/services/test_admin_observability_service.py
- cd backend && uv run ruff format --check app/models/agent.py app/core/init_data.py app/main.py app/api/v1/endpoints/chat.py app/services/admin_observability.py app/schemas/agent.py tests/services/test_admin_observability_service.py
- cd backend && PYTHONPATH=. uv run mypy app/services/admin_observability.py app/api/v1/endpoints/chat.py
- cd backend && PYTHONPATH=. uv run pytest tests/services/test_admin_observability_service.py
- cd frontend && bun run i18n:gen-types && bun run i18n:lint --strict
- cd frontend && bun run lint && bun run build

Refs YUN-75

🤖 Generated with [Claude Code](https://claude.com/claude-code)