### PR TITLE
YUN-92: Expand prompt generation context

### DIFF
--- a/backend/app/api/v1/endpoints/prompt_generator.py
+++ b/backend/app/api/v1/endpoints/prompt_generator.py
@@ -37,6 +37,8 @@ class PromptGenerateContext(BaseModel):
         None, description="Linked knowledge bases"
     )
     variables: list[dict] | None = Field(None, description="Defined variables")
+    rag_mode: str | None = Field(None, description="RAG retrieval mode")
+    capabilities: dict | None = Field(None, description="Enabled runtime capabilities")
 
 
 class PromptStyle(BaseModel):
@@ -132,39 +134,114 @@ def build_context_string(context: PromptGenerateContext | None, language: str) -
     if not context:
         return "无额外上下文" if language == "zh" else "No additional context"
 
+    def label(zh: str, en: str) -> str:
+        return zh if language == "zh" else en
+
+    def compact_json(value: object) -> str:
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
     parts = []
 
     if context.agent_name:
-        label = "Agent 名称" if language == "zh" else "Agent Name"
-        parts.append(f"- {label}: {context.agent_name}")
+        parts.append(f"- {label('Agent 名称', 'Agent Name')}: {context.agent_name}")
 
     if context.agent_description:
-        label = "Agent 描述" if language == "zh" else "Agent Description"
-        parts.append(f"- {label}: {context.agent_description}")
+        parts.append(
+            f"- {label('Agent 描述', 'Agent Description')}: {context.agent_description}"
+        )
+
+    if context.rag_mode:
+        parts.append(f"- {label('RAG 模式', 'RAG Mode')}: {context.rag_mode}")
+
+    capabilities = context.capabilities or {}
+    enabled_capabilities = []
+    capability_names = {
+        "enable_vision": label("视觉理解", "Vision"),
+        "enable_file_upload": label("文件上传", "File Upload"),
+        "enable_user_input_request": label("用户输入请求", "User Input Request"),
+        "enable_memory": label("记忆", "Memory"),
+        "enable_image_generation": label("图片生成", "Image Generation"),
+        "enable_video_generation": label("视频生成", "Video Generation"),
+    }
+    for key, name in capability_names.items():
+        if capabilities.get(key):
+            enabled_capabilities.append(name)
+    if enabled_capabilities:
+        parts.append(
+            f"- {label('已启用能力', 'Enabled Capabilities')}: {', '.join(enabled_capabilities)}"
+        )
+
+    capability_configs = {
+        "file_upload_config": capabilities.get("file_upload_config"),
+        "memory_config": capabilities.get("memory_config"),
+        "image_generation_config": capabilities.get("image_generation_config"),
+        "video_generation_config": capabilities.get("video_generation_config"),
+    }
+    active_capability_configs = {
+        key: value for key, value in capability_configs.items() if value
+    }
+    if active_capability_configs:
+        parts.append(
+            f"- {label('能力配置', 'Capability Configs')}: {compact_json(active_capability_configs)}"
+        )
 
     if context.tools:
-        label = "可用工具" if language == "zh" else "Available Tools"
-        tool_names = [
-            t.get("name", t.get("display_name", "unknown")) for t in context.tools
-        ]
-        parts.append(f"- {label}: {', '.join(tool_names)}")
+        tool_items = []
+        for tool in context.tools:
+            name = tool.get("display_name") or tool.get("name") or "unknown"
+            tool_type = tool.get("type") or "unknown"
+            description = tool.get("description")
+            config = tool.get("config")
+            item = f"{name}({tool_type})"
+            if description:
+                item += f": {description}"
+            if config:
+                item += f" config={compact_json(config)}"
+            tool_items.append(item)
+        parts.append(f"- {label('可用工具', 'Available Tools')}: {'; '.join(tool_items)}")
 
     if context.knowledge_bases:
-        label = "关联知识库" if language == "zh" else "Linked Knowledge Bases"
-        kb_names = [kb.get("name", "unknown") for kb in context.knowledge_bases]
-        parts.append(f"- {label}: {', '.join(kb_names)}")
+        kb_items = []
+        for kb in context.knowledge_bases:
+            name = kb.get("name", "unknown")
+            description = kb.get("description")
+            config = kb.get("config")
+            item = str(name)
+            if description:
+                item += f": {description}"
+            if config:
+                item += f" config={compact_json(config)}"
+            kb_items.append(item)
+        parts.append(
+            f"- {label('关联知识库', 'Linked Knowledge Bases')}: {'; '.join(kb_items)}"
+        )
 
     if context.variables:
-        label = "自定义变量" if language == "zh" else "Custom Variables"
-        var_list = []
-        for v in context.variables:
-            var_name = v.get("name", "unknown")
-            var_label = v.get("label", "")
-            if var_label:
-                var_list.append(f"{var_name}({var_label})")
-            else:
-                var_list.append(var_name)
-        parts.append(f"- {label}: {', '.join(var_list)}")
+        variable_items = []
+        for variable in context.variables:
+            name = variable.get("name", "unknown")
+            variable_type = variable.get("type", "unknown")
+            required = variable.get("required")
+            label_text = variable.get("label")
+            details = [f"type={variable_type}"]
+            if required is not None:
+                details.append(f"required={required}")
+            if label_text:
+                details.append(f"label={label_text}")
+            for key in (
+                "default",
+                "description",
+                "options",
+                "min",
+                "max",
+                "maxLength",
+                "fileConfig",
+            ):
+                value = variable.get(key)
+                if value not in (None, "", []):
+                    details.append(f"{key}={compact_json(value)}")
+            variable_items.append(f"{name}({', '.join(details)})")
+        parts.append(f"- {label('自定义变量', 'Custom Variables')}: {'; '.join(variable_items)}")
 
     if not parts:
         return "无额外上下文" if language == "zh" else "No additional context"

--- a/backend/app/api/v1/endpoints/prompt_generator.py
+++ b/backend/app/api/v1/endpoints/prompt_generator.py
@@ -238,7 +238,7 @@ def build_context_string(context: PromptGenerateContext | None, language: str) -
                 "fileConfig",
             ):
                 value = variable.get(key)
-                if value not in (None, "", []):
+                if value not in (None, "", [], {}):
                     details.append(f"{key}={compact_json(value)}")
             variable_items.append(f"{name}({', '.join(details)})")
         parts.append(f"- {label('自定义变量', 'Custom Variables')}: {'; '.join(variable_items)}")

--- a/backend/app/api/v1/endpoints/prompt_generator.py
+++ b/backend/app/api/v1/endpoints/prompt_generator.py
@@ -198,7 +198,9 @@ def build_context_string(context: PromptGenerateContext | None, language: str) -
             if config:
                 item += f" config={compact_json(config)}"
             tool_items.append(item)
-        parts.append(f"- {label('可用工具', 'Available Tools')}: {'; '.join(tool_items)}")
+        parts.append(
+            f"- {label('可用工具', 'Available Tools')}: {'; '.join(tool_items)}"
+        )
 
     if context.knowledge_bases:
         kb_items = []
@@ -241,7 +243,9 @@ def build_context_string(context: PromptGenerateContext | None, language: str) -
                 if value not in (None, "", [], {}):
                     details.append(f"{key}={compact_json(value)}")
             variable_items.append(f"{name}({', '.join(details)})")
-        parts.append(f"- {label('自定义变量', 'Custom Variables')}: {'; '.join(variable_items)}")
+        parts.append(
+            f"- {label('自定义变量', 'Custom Variables')}: {'; '.join(variable_items)}"
+        )
 
     if not parts:
         return "无额外上下文" if language == "zh" else "No additional context"

--- a/frontend/app/(platform)/app/apps/[id]/_components/agent-orchestration-form.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/_components/agent-orchestration-form.tsx
@@ -369,23 +369,38 @@ export function AgentOrchestrationForm({
           (tc.type === 'skill' && t.id === tc.skill_id)
       )
       return {
+        ...tc,
         name: tc.name || tool?.name,
         display_name: tool?.display_name ?? tc.name ?? undefined,
+        description: tool?.description ?? undefined,
       }
-    }).filter((t) => t.name),
+    }).filter((t) => t.name || t.tool_id || t.server_id || t.skill_id),
     knowledge_bases: knowledgeBases
-      .filter((kb) =>
-        knowledgeBaseConfigs.some((c) => c.knowledge_base_id === kb.id)
-      )
-      .map((kb) => ({
-        name: kb.name,
-        description: kb.description ?? undefined,
-      })),
-    variables: variables.map((v) => ({
-      name: v.name,
-      label: v.label ?? undefined,
-    })),
-  }), [agent.name, agent.description, toolsConfig, availableTools, knowledgeBases, knowledgeBaseConfigs, variables])
+      .map((kb) => {
+        const config = knowledgeBaseConfigs.find((c) => c.knowledge_base_id === kb.id)
+        if (!config) return null
+        return {
+          name: kb.name,
+          description: kb.description ?? undefined,
+          config,
+        }
+      })
+      .filter((kb): kb is NonNullable<typeof kb> => kb !== null),
+    variables,
+    rag_mode: ragMode,
+    capabilities: {
+      enable_vision: enableVision,
+      enable_file_upload: enableFileUpload,
+      file_upload_config: enableFileUpload ? fileUploadConfig : null,
+      enable_user_input_request: enableUserInputRequest,
+      enable_memory: enableMemory,
+      memory_config: enableMemory ? memoryConfig : null,
+      enable_image_generation: enableImageGeneration,
+      image_generation_config: enableImageGeneration ? imageGenerationConfig : null,
+      enable_video_generation: enableVideoGeneration,
+      video_generation_config: enableVideoGeneration ? videoGenerationConfig : null,
+    },
+  }), [agent.name, agent.description, toolsConfig, availableTools, knowledgeBases, knowledgeBaseConfigs, variables, ragMode, enableVision, enableFileUpload, fileUploadConfig, enableUserInputRequest, enableMemory, memoryConfig, enableImageGeneration, imageGenerationConfig, enableVideoGeneration, videoGenerationConfig])
 
   return (
     <div className="space-y-3">

--- a/frontend/app/(platform)/app/apps/[id]/_components/agent-orchestration-form.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/_components/agent-orchestration-form.tsx
@@ -376,16 +376,14 @@ export function AgentOrchestrationForm({
       }
     }).filter((t) => t.name || t.tool_id || t.server_id || t.skill_id),
     knowledge_bases: knowledgeBases
-      .map((kb) => {
-        const config = knowledgeBaseConfigs.find((c) => c.knowledge_base_id === kb.id)
-        if (!config) return null
-        return {
-          name: kb.name,
-          description: kb.description ?? undefined,
-          config,
-        }
-      })
-      .filter((kb): kb is NonNullable<typeof kb> => kb !== null),
+      .filter((kb) =>
+        knowledgeBaseConfigs.some((c) => c.knowledge_base_id === kb.id)
+      )
+      .map((kb) => ({
+        name: kb.name,
+        description: kb.description ?? undefined,
+        config: knowledgeBaseConfigs.find((c) => c.knowledge_base_id === kb.id)!,
+      })),
     variables,
     rag_mode: ragMode,
     capabilities: {

--- a/frontend/lib/api/prompts.ts
+++ b/frontend/lib/api/prompts.ts
@@ -1,13 +1,49 @@
 import { api, ApiError, type ApiResponse } from './client'
+import type {
+  AgentKnowledgeBaseConfig,
+  FileUploadConfig,
+  ImageGenerationConfig,
+  MemoryConfig,
+  RAGMode,
+  ToolConfig,
+  VariableDefinition,
+  VideoGenerationConfig,
+} from './agents'
 
 // ============ Types ============
+
+export interface PromptGenerateToolContext extends ToolConfig {
+  display_name?: string | null
+  description?: string | null
+}
+
+export interface PromptGenerateKnowledgeBaseContext {
+  name: string
+  description?: string | null
+  config?: AgentKnowledgeBaseConfig | null
+}
+
+export interface PromptGenerateCapabilitiesContext {
+  enable_vision?: boolean
+  enable_file_upload?: boolean
+  file_upload_config?: FileUploadConfig | null
+  enable_user_input_request?: boolean
+  enable_memory?: boolean
+  memory_config?: MemoryConfig | null
+  enable_image_generation?: boolean
+  image_generation_config?: ImageGenerationConfig | null
+  enable_video_generation?: boolean
+  video_generation_config?: VideoGenerationConfig | null
+}
 
 export interface PromptGenerateContext {
   agent_name?: string | null
   agent_description?: string | null
-  tools?: { name?: string; display_name?: string }[] | null
-  knowledge_bases?: { name: string; description?: string }[] | null
-  variables?: { name: string; label?: string }[] | null
+  tools?: PromptGenerateToolContext[] | null
+  knowledge_bases?: PromptGenerateKnowledgeBaseContext[] | null
+  variables?: VariableDefinition[] | null
+  rag_mode?: RAGMode | null
+  capabilities?: PromptGenerateCapabilitiesContext | null
 }
 
 export interface PromptStyle {


### PR DESCRIPTION
## Summary
- Pass full Agent orchestration environment into prompt generation, including capabilities, RAG mode, tool details, knowledge base retrieval config, and full variable definitions.
- Expand backend prompt context formatting so generated system prompts match the configured runtime environment.

Fixes YUN-92

## Test plan
- [x] `uv run python -m py_compile backend/app/api/v1/endpoints/prompt_generator.py`
- [x] `uv run ruff check app/api/v1/endpoints/prompt_generator.py`
- [x] `cd frontend && bun run lint`