### PR TITLE
Fix app management regressions

### DIFF
--- a/backend/app/api/v1/admin/endpoints/agents.py
+++ b/backend/app/api/v1/admin/endpoints/agents.py
@@ -130,10 +130,11 @@ async def get_agent_filter_options(
     current_user: User = Depends(deps.PermissionChecker("admin:app:read")),
 ) -> Any:
     teams = await Team.all().order_by("name")
-    creator_values = (
-        await Agent.filter(created_by__isnull=False)
+    creator_values = cast(
+        list[str],
+        await Agent.filter(created_by_id__not_isnull=True)
         .distinct()
-        .values_list("created_by__username", flat=True)
+        .values_list("created_by__username", flat=True),
     )
     creator_values = sorted(creator_values)
     return success(

--- a/backend/app/api/v1/admin/endpoints/agents.py
+++ b/backend/app/api/v1/admin/endpoints/agents.py
@@ -132,7 +132,8 @@ async def get_agent_filter_options(
     teams = await Team.all().order_by("name")
     creator_values = cast(
         list[str],
-        await Agent.filter(created_by_id__not_isnull=True)
+        await Agent.filter(created_by_id__isnull=False)
+        .order_by("created_by__username")
         .distinct()
         .values_list("created_by__username", flat=True),
     )

--- a/backend/app/api/v1/admin/endpoints/workflows.py
+++ b/backend/app/api/v1/admin/endpoints/workflows.py
@@ -121,7 +121,8 @@ async def get_workflow_filter_options(
     teams = await Team.all().order_by("name")
     creator_values = cast(
         list[str],
-        await Workflow.filter(created_by_id__not_isnull=True)
+        await Workflow.filter(created_by_id__isnull=False)
+        .order_by("created_by__username")
         .distinct()
         .values_list("created_by__username", flat=True),
     )

--- a/backend/app/api/v1/admin/endpoints/workflows.py
+++ b/backend/app/api/v1/admin/endpoints/workflows.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -119,10 +119,11 @@ async def get_workflow_filter_options(
     current_user: User = Depends(deps.PermissionChecker("admin:app:read")),
 ) -> Any:
     teams = await Team.all().order_by("name")
-    creator_values = (
-        await Workflow.filter(created_by__isnull=False)
+    creator_values = cast(
+        list[str],
+        await Workflow.filter(created_by_id__not_isnull=True)
         .distinct()
-        .values_list("created_by__username", flat=True)
+        .values_list("created_by__username", flat=True),
     )
     creator_values = sorted(creator_values)
     return success(

--- a/backend/app/core/email.py
+++ b/backend/app/core/email.py
@@ -82,9 +82,9 @@ async def send_email(
         if body_html:
             msg.attach(MIMEText(body_html, "html", "utf-8"))
 
-        # 确定是否使用 TLS/SSL
-        use_tls = config["encryption"] == "tls"
-        start_tls = config["encryption"] == "starttls"
+        encryption = config["encryption"]
+        use_tls = encryption == "ssl"
+        start_tls = encryption == "tls"
 
         # 发送邮件
         await aiosmtplib.send(

--- a/backend/app/models/workflow.py
+++ b/backend/app/models/workflow.py
@@ -145,6 +145,7 @@ class Workflow(models.Model):
         null=True,
         description="Creator",
     )
+    created_by_id: UUID | None  # type: ignore[assignment]
     created_at = fields.DatetimeField(auto_now_add=True)
     updated_at = fields.DatetimeField(auto_now=True)
 

--- a/frontend/app/(auth)/login/_components/login-redirect.tsx
+++ b/frontend/app/(auth)/login/_components/login-redirect.tsx
@@ -2,16 +2,37 @@
 
 import { useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { authApi } from '@/lib/api'
 
 export function LoginRedirect() {
   const router = useRouter()
   const searchParams = useSearchParams()
 
   useEffect(() => {
-    const token = typeof window !== 'undefined' ? localStorage.getItem('access_token') : null
-    if (!token) return
-    const redirect = searchParams?.get('redirect')
-    router.replace(redirect || '/app')
+    let cancelled = false
+
+    async function redirectIfAuthenticated() {
+      const token = typeof window !== 'undefined' ? localStorage.getItem('access_token') : null
+      if (!token) return
+
+      try {
+        await authApi.getCurrentUser({ skipAuthRedirect: true, silent: true })
+        if (cancelled) return
+
+        const redirect = searchParams?.get('redirect')
+        router.replace(redirect || '/app')
+      } catch {
+        if (typeof window !== 'undefined') {
+          localStorage.removeItem('access_token')
+        }
+      }
+    }
+
+    redirectIfAuthenticated()
+
+    return () => {
+      cancelled = true
+    }
   }, [router, searchParams])
 
   return null

--- a/frontend/app/(auth)/login/_components/login-redirect.tsx
+++ b/frontend/app/(auth)/login/_components/login-redirect.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { authApi } from '@/lib/api'
+import { ApiError } from '@/lib/api/client'
 
 export function LoginRedirect() {
   const router = useRouter()
@@ -21,8 +22,12 @@ export function LoginRedirect() {
 
         const redirect = searchParams?.get('redirect')
         router.replace(redirect || '/app')
-      } catch {
-        if (typeof window !== 'undefined') {
+      } catch (error) {
+        if (
+          typeof window !== 'undefined' &&
+          error instanceof ApiError &&
+          (error.code === 401 || error.code === 403)
+        ) {
           localStorage.removeItem('access_token')
         }
       }

--- a/frontend/app/(platform)/app/apps/_components/app-create-dialog.tsx
+++ b/frontend/app/(platform)/app/apps/_components/app-create-dialog.tsx
@@ -55,6 +55,8 @@ interface AppCreateDialogProps {
 
 type AppType = 'agent' | 'workflow'
 
+const EMPTY_TEAMS: Team[] = []
+
 export function AppCreateDialog({
   open,
   onOpenChange,
@@ -64,7 +66,7 @@ export function AppCreateDialog({
     createWorkflow: workflowsApi.createWorkflow,
   },
   teamId,
-  teams = [],
+  teams = EMPTY_TEAMS,
   initialType = 'agent',
   allowedTypes = ['agent', 'workflow'],
   agentEditHref = (id: string) => `/app/apps/${id}`,

--- a/frontend/lib/api/auth.ts
+++ b/frontend/lib/api/auth.ts
@@ -124,8 +124,11 @@ export const authApi = {
   /**
    * 获取当前用户信息
    */
-  getCurrentUser: async (options?: { skipAuthRedirect?: boolean }): Promise<User> => {
-    return api.get<User>('/users/me', { skipAuthRedirect: options?.skipAuthRedirect })
+  getCurrentUser: async (options?: { skipAuthRedirect?: boolean; silent?: boolean }): Promise<User> => {
+    return api.get<User>('/users/me', {
+      skipAuthRedirect: options?.skipAuthRedirect,
+      silent: options?.silent,
+    })
   },
 
   /**


### PR DESCRIPTION
## Summary
- Fix SMTP encryption mapping so SSL and STARTTLS modes map to the correct aiosmtplib options.
- Validate stored login tokens before redirecting from the login page.
- Fix admin Agent/Workflow filter queries and keep the create-app dialog input stable while typing.

## Test plan
- [x] `uv --directory backend run ruff check app/api/v1/admin/endpoints/agents.py app/api/v1/admin/endpoints/workflows.py app/models/workflow.py`
- [x] Tortoise in-memory query validation for Agent/Workflow creator filters
- [x] `bun run --cwd frontend lint`
- [ ] Browser-create app dialog verification blocked locally by login redirect/no credentials