### PR TITLE
Fix password history validation and support email login

### DIFF
--- a/backend/app/api/v1/endpoints/login.py
+++ b/backend/app/api/v1/endpoints/login.py
@@ -3,7 +3,6 @@ from typing import Any, Optional
 
 import jwt
 from fastapi import APIRouter, Depends, Request, BackgroundTasks, Form
-from tortoise.exceptions import DoesNotExist
 
 from app.api import deps
 from app.core import security
@@ -71,7 +70,7 @@ async def get_captcha() -> Any:
 @router.post("/login/access-token", response_model=Response[Token])
 async def login_access_token(
     request: Request,
-    username: str = Form(...),
+    identifier: str = Form(..., alias="username"),
     password: str = Form(...),
     captcha_id: Optional[str] = Form(None),
     captcha_answer: Optional[str] = Form(None),
@@ -105,16 +104,20 @@ async def login_access_token(
                 msg_key="captcha_invalid",
             )
 
-    try:
-        user = await User.get(username=username)
-    except DoesNotExist:
+    # Allow login by username or email
+    if "@" in identifier:
+        user = await User.filter(email=identifier).first()
+    else:
+        user = await User.filter(username=identifier).first()
+
+    if not user:
         # 记录失败的登录（用户不存在）
         await AuditLogService.log(
             user=None,
             action="login_failed",
             resource_type="user",
             resource_id=None,
-            resource_name=username,
+            resource_name=identifier,
             operation="read",
             status="failed",
             request=request,
@@ -1093,8 +1096,6 @@ async def reset_password(
     # Reset login attempts
     user.failed_login_attempts = 0
     user.locked_until = None  # type: ignore[assignment]
-    # Force password change after admin reset
-    user.force_password_change = True
     await user.save()
 
     # 记录密码重置

--- a/backend/app/api/v1/endpoints/login.py
+++ b/backend/app/api/v1/endpoints/login.py
@@ -106,7 +106,7 @@ async def login_access_token(
 
     # Allow login by username or email
     if "@" in identifier:
-        user = await User.filter(email=identifier).first()
+        user = await User.filter(email__iexact=identifier).first()
     else:
         user = await User.filter(username=identifier).first()
 

--- a/backend/app/services/password_expiration.py
+++ b/backend/app/services/password_expiration.py
@@ -6,15 +6,12 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from passlib.context import CryptContext
-
+from app.core import security
 from app.models.user import User
 from app.models.password_history import PasswordHistory
 from app.models.site_setting import SiteSetting
 
 logger = logging.getLogger(__name__)
-
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 class PasswordExpirationService:
@@ -161,9 +158,10 @@ class PasswordExpirationService:
             .limit(history_count)
         )
 
-        # Check against each historical password using bcrypt
+        # Check against each historical password using the same bcrypt
+        # normalization as password creation.
         for entry in history_entries:
-            if pwd_context.verify(new_password, entry.hashed_password):
+            if security.verify_password(new_password, entry.hashed_password):
                 return True
 
         return False

--- a/frontend/app/(auth)/login/_components/login-form.tsx
+++ b/frontend/app/(auth)/login/_components/login-form.tsx
@@ -559,7 +559,7 @@ export function LoginForm() {
           )}
 
       <div className="space-y-2">
-        <Label htmlFor="username">{t('username')}</Label>
+        <Label htmlFor="username">{t('usernameOrEmail')}</Label>
         <Input
           id="username"
           type="text"

--- a/frontend/i18n/en/auth.json
+++ b/frontend/i18n/en/auth.json
@@ -25,6 +25,7 @@
     "forgotPassword": "Forgot password?",
     "email": "Email",
     "username": "Username",
+    "usernameOrEmail": "Username or email",
     "usernamePlaceholder": "Enter your username",
     "usernameOrEmailPlaceholder": "Enter your username or email",
     "emailPlaceholder": "Enter your email address",

--- a/frontend/i18n/types/activities.ts
+++ b/frontend/i18n/types/activities.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.146Z
+// GENERATED — 2026-06-11T08:12:52.086Z
 // Source: i18n/en/activities.json
 export type ActivitiesMessages = {
   activities: {

--- a/frontend/i18n/types/agents.ts
+++ b/frontend/i18n/types/agents.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.150Z
+// GENERATED — 2026-06-11T08:12:52.090Z
 // Source: i18n/en/agents.json
 export type AgentsMessages = {
   agents: {

--- a/frontend/i18n/types/apiKeys.ts
+++ b/frontend/i18n/types/apiKeys.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.151Z
+// GENERATED — 2026-06-11T08:12:52.090Z
 // Source: i18n/en/apiKeys.json
 export type ApiKeysMessages = {
   apiKeys: {

--- a/frontend/i18n/types/apps.ts
+++ b/frontend/i18n/types/apps.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.151Z
+// GENERATED — 2026-06-11T08:12:52.091Z
 // Source: i18n/en/apps.json
 export type AppsMessages = {
   apps: {

--- a/frontend/i18n/types/auditLogs.ts
+++ b/frontend/i18n/types/auditLogs.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.151Z
+// GENERATED — 2026-06-11T08:12:52.091Z
 // Source: i18n/en/auditLogs.json
 export type AuditLogsMessages = {
   auditLogs: {

--- a/frontend/i18n/types/auth.ts
+++ b/frontend/i18n/types/auth.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.152Z
+// GENERATED — 2026-06-11T08:12:52.092Z
 // Source: i18n/en/auth.json
 export type AuthMessages = {
   auth: {
@@ -27,6 +27,7 @@ export type AuthMessages = {
     forgotPassword: string
     email: string
     username: string
+    usernameOrEmail: string
     usernamePlaceholder: string
     usernameOrEmailPlaceholder: string
     emailPlaceholder: string

--- a/frontend/i18n/types/chat.ts
+++ b/frontend/i18n/types/chat.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.152Z
+// GENERATED — 2026-06-11T08:12:52.094Z
 // Source: i18n/en/chat.json
 export type ChatMessages = {
   chat: {

--- a/frontend/i18n/types/common.ts
+++ b/frontend/i18n/types/common.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.153Z
+// GENERATED — 2026-06-11T08:12:52.094Z
 // Source: i18n/en/common.json
 export type CommonMessages = {
   common: {

--- a/frontend/i18n/types/conversations.ts
+++ b/frontend/i18n/types/conversations.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.153Z
+// GENERATED — 2026-06-11T08:12:52.094Z
 // Source: i18n/en/conversations.json
 export type ConversationsMessages = {
   conversations: {

--- a/frontend/i18n/types/dashboard.ts
+++ b/frontend/i18n/types/dashboard.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.154Z
+// GENERATED — 2026-06-11T08:12:52.095Z
 // Source: i18n/en/dashboard.json
 export type DashboardMessages = {
   dashboard: {

--- a/frontend/i18n/types/embed.ts
+++ b/frontend/i18n/types/embed.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.154Z
+// GENERATED — 2026-06-11T08:12:52.095Z
 // Source: i18n/en/embed.json
 export type EmbedMessages = {
   embed: {

--- a/frontend/i18n/types/errors.ts
+++ b/frontend/i18n/types/errors.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.155Z
+// GENERATED — 2026-06-11T08:12:52.095Z
 // Source: i18n/en/errors.json
 export type ErrorsMessages = {
   errors: {

--- a/frontend/i18n/types/knowledgeBases.ts
+++ b/frontend/i18n/types/knowledgeBases.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.155Z
+// GENERATED — 2026-06-11T08:12:52.096Z
 // Source: i18n/en/knowledgeBases.json
 export type KnowledgeBasesMessages = {
   knowledgeBases: {

--- a/frontend/i18n/types/memories.ts
+++ b/frontend/i18n/types/memories.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.155Z
+// GENERATED — 2026-06-11T08:12:52.096Z
 // Source: i18n/en/memories.json
 export type MemoriesMessages = {
   memories: {

--- a/frontend/i18n/types/models.ts
+++ b/frontend/i18n/types/models.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.156Z
+// GENERATED — 2026-06-11T08:12:52.097Z
 // Source: i18n/en/models.json
 export type ModelsMessages = {
   models: {

--- a/frontend/i18n/types/nav.ts
+++ b/frontend/i18n/types/nav.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.157Z
+// GENERATED — 2026-06-11T08:12:52.097Z
 // Source: i18n/en/nav.json
 export type NavMessages = {
   nav: {

--- a/frontend/i18n/types/notifications.ts
+++ b/frontend/i18n/types/notifications.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.157Z
+// GENERATED — 2026-06-11T08:12:52.098Z
 // Source: i18n/en/notifications.json
 export type NotificationsMessages = {
   notifications: {

--- a/frontend/i18n/types/packages.ts
+++ b/frontend/i18n/types/packages.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.158Z
+// GENERATED — 2026-06-11T08:12:52.098Z
 // Source: i18n/en/packages.json
 export type PackagesMessages = {
   packages: {

--- a/frontend/i18n/types/permissions.ts
+++ b/frontend/i18n/types/permissions.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.158Z
+// GENERATED — 2026-06-11T08:12:52.098Z
 // Source: i18n/en/permissions.json
 export type PermissionsMessages = {
   permissions: {

--- a/frontend/i18n/types/platform.ts
+++ b/frontend/i18n/types/platform.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.159Z
+// GENERATED — 2026-06-11T08:12:52.099Z
 // Source: i18n/en/platform.json
 export type PlatformMessages = {
   platform: {

--- a/frontend/i18n/types/promptGenerator.ts
+++ b/frontend/i18n/types/promptGenerator.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.159Z
+// GENERATED — 2026-06-11T08:12:52.099Z
 // Source: i18n/en/promptGenerator.json
 export type PromptGeneratorMessages = {
   promptGenerator: {

--- a/frontend/i18n/types/publicChat.ts
+++ b/frontend/i18n/types/publicChat.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.160Z
+// GENERATED — 2026-06-11T08:12:52.099Z
 // Source: i18n/en/publicChat.json
 export type PublicChatMessages = {
   publicChat: {

--- a/frontend/i18n/types/roles.ts
+++ b/frontend/i18n/types/roles.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.160Z
+// GENERATED — 2026-06-11T08:12:52.100Z
 // Source: i18n/en/roles.json
 export type RolesMessages = {
   roles: {

--- a/frontend/i18n/types/run.ts
+++ b/frontend/i18n/types/run.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.160Z
+// GENERATED — 2026-06-11T08:12:52.100Z
 // Source: i18n/en/run.json
 export type RunMessages = {
   run: {

--- a/frontend/i18n/types/settings.ts
+++ b/frontend/i18n/types/settings.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.161Z
+// GENERATED — 2026-06-11T08:12:52.100Z
 // Source: i18n/en/settings.json
 export type SettingsMessages = {
   settings: {

--- a/frontend/i18n/types/siteSettings.ts
+++ b/frontend/i18n/types/siteSettings.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.161Z
+// GENERATED — 2026-06-11T08:12:52.100Z
 // Source: i18n/en/siteSettings.json
 export type SiteSettingsMessages = {
   siteSettings: {

--- a/frontend/i18n/types/sso.ts
+++ b/frontend/i18n/types/sso.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.162Z
+// GENERATED — 2026-06-11T08:12:52.101Z
 // Source: i18n/en/sso.json
 export type SsoMessages = {
   sso: {

--- a/frontend/i18n/types/teams.ts
+++ b/frontend/i18n/types/teams.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.162Z
+// GENERATED — 2026-06-11T08:12:52.101Z
 // Source: i18n/en/teams.json
 export type TeamsMessages = {
   teams: {

--- a/frontend/i18n/types/tools.ts
+++ b/frontend/i18n/types/tools.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.163Z
+// GENERATED — 2026-06-11T08:12:52.102Z
 // Source: i18n/en/tools.json
 export type ToolsMessages = {
   tools: {

--- a/frontend/i18n/types/users.ts
+++ b/frontend/i18n/types/users.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.163Z
+// GENERATED — 2026-06-11T08:12:52.102Z
 // Source: i18n/en/users.json
 export type UsersMessages = {
   users: {

--- a/frontend/i18n/types/workflow.ts
+++ b/frontend/i18n/types/workflow.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-06-10T06:40:00.164Z
+// GENERATED — 2026-06-11T08:12:52.103Z
 // Source: i18n/en/workflow.json
 export type WorkflowMessages = {
   workflow: {

--- a/frontend/i18n/zh/auth.json
+++ b/frontend/i18n/zh/auth.json
@@ -25,6 +25,7 @@
     "forgotPassword": "忘记密码？",
     "email": "邮箱",
     "username": "用户名",
+    "usernameOrEmail": "用户名或邮箱",
     "usernamePlaceholder": "请输入用户名",
     "usernameOrEmailPlaceholder": "请输入用户名或邮箱",
     "emailPlaceholder": "请输入邮箱地址",


### PR DESCRIPTION
## Summary
- Fix password history checks that could fail when verifying long passwords by reusing the same bcrypt normalization used during password creation/reset.
- Allow users to log in with email in addition to username.
- Remove the unconditional forced password change after password reset, so the login flow no longer forces password change regardless of site settings.
- Update frontend login label text to reflect email login support and regenerate related i18n types.

## Test plan
- Verify a user can log in with username.
- Verify a user can log in with email.
- Verify password history validation works for normal and long passwords.
- Verify a password reset no longer always forces password change on next login.
- Verify frontend login form label displays as expected in EN/ZH.