### PR TITLE
fix: add audit logging coverage

### DIFF
--- a/backend/app/api/v1/admin/endpoints/sso.py
+++ b/backend/app/api/v1/admin/endpoints/sso.py
@@ -206,6 +206,7 @@ async def delete_provider(
 @router.post("/providers/{provider_id}/test", response_model=Response[dict])
 async def test_provider_connection(
     provider_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("admin:sso:update")),
 ):
     """Test SSO provider connection (admin)"""
@@ -257,6 +258,7 @@ async def test_provider_connection(
                 status="failed",
                 error_message=str(e),
                 metadata={"provider": provider.name},
+                request=request,
             )
         return success(
             data={

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -858,6 +858,7 @@ async def unpublish_agent(
 @router.post("/{agent_id}/duplicate", response_model=Response[AgentOut])
 async def duplicate_agent(
     agent_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("agent:create")),
 ) -> Any:
     """Duplicate an agent."""
@@ -919,6 +920,20 @@ async def duplicate_agent(
 
     # Reload with relations
     new_agent = await Agent.get(id=new_agent.id).prefetch_related("team", "created_by")
+
+    # 记录审计日志
+    await AuditLogService.log(
+        user=current_user,
+        action="duplicate_agent",
+        resource_type="agent",
+        resource_id=new_agent.id,
+        resource_name=new_agent.name,
+        operation="create",
+        status="success",
+        request=request,
+        metadata={"source_agent_id": str(agent.id), "source_agent_name": agent.name},
+    )
+
     agent_data = await build_agent_out(new_agent)
     return success(data=agent_data, msg_key="agent_duplicated")
 

--- a/backend/app/api/v1/endpoints/conversations.py
+++ b/backend/app/api/v1/endpoints/conversations.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 from tortoise.expressions import Q
 from tortoise.functions import Count
 
@@ -32,6 +32,7 @@ from app.schemas.response import (
 )
 from app.api.v1.endpoints.chat import build_message_round_payloads
 from app.services.message_branching import get_visible_conversation_messages
+from app.services.audit_log import AuditLogService
 
 
 router = APIRouter()
@@ -530,6 +531,7 @@ async def get_conversation_detail(
 @router.delete("/{conversation_id}", response_model=Response[dict])
 async def delete_conversation_admin(
     conversation_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("conversation:delete")),
 ) -> Any:
     """
@@ -586,8 +588,20 @@ async def delete_conversation_admin(
         message_count=F("message_count") - conversation.message_count,
     )
 
+    conv_title = conversation.title or str(conversation_id)
     # Delete conversation (cascades to messages)
     await conversation.delete()
+
+    await AuditLogService.log(
+        user=current_user,
+        action="delete_conversation",
+        resource_type="conversation",
+        resource_id=conversation_id,
+        resource_name=conv_title,
+        operation="delete",
+        status="success",
+        request=request,
+    )
 
     return success(data={"id": str(conversation_id)}, msg_key="conversation_deleted")
 
@@ -595,6 +609,7 @@ async def delete_conversation_admin(
 @router.delete("", response_model=Response[dict])
 async def batch_delete_conversations(
     ids: list[UUID] = Query(..., description="Conversation IDs to delete"),
+    request: Request = None,
     current_user: User = Depends(deps.PermissionChecker("conversation:delete")),
 ) -> Any:
     """
@@ -656,6 +671,18 @@ async def batch_delete_conversations(
 
     # Delete conversations
     deleted_count = await Conversation.filter(id__in=ids).delete()
+
+    await AuditLogService.log(
+        user=current_user,
+        action="batch_delete_conversations",
+        resource_type="conversation",
+        resource_id=ids[0],
+        resource_name=f"{deleted_count} conversations",
+        operation="delete",
+        status="success",
+        request=request,
+        metadata={"deleted_count": deleted_count, "ids": [str(id) for id in ids]},
+    )
 
     return success(
         data={

--- a/backend/app/api/v1/endpoints/conversations.py
+++ b/backend/app/api/v1/endpoints/conversations.py
@@ -608,8 +608,9 @@ async def delete_conversation_admin(
 
 @router.delete("", response_model=Response[dict])
 async def batch_delete_conversations(
+    *,
     ids: list[UUID] = Query(..., description="Conversation IDs to delete"),
-    request: Request = None,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("conversation:delete")),
 ) -> Any:
     """

--- a/backend/app/api/v1/endpoints/embed.py
+++ b/backend/app/api/v1/endpoints/embed.py
@@ -376,9 +376,9 @@ async def embed_run_workflow(
         operation="execute",
         status="success",
         request=request,
+        api_key=api_key,
         metadata={
             "run_id": str(run.id),
-            "api_key_id": str(api_key.id),
             "source": "embed",
         },
     )

--- a/backend/app/api/v1/endpoints/embed.py
+++ b/backend/app/api/v1/endpoints/embed.py
@@ -30,6 +30,7 @@ from app.schemas.agent import ChatRequest, EmbedAgentInfo
 from app.api.v1.endpoints.chat import build_message_round_payloads
 from app.schemas.response import BusinessError, ResponseCode, success
 from app.services.message_branching import get_visible_conversation_messages
+from app.services.audit_log import AuditLogService
 
 logger = logging.getLogger(__name__)
 
@@ -364,6 +365,22 @@ async def embed_run_workflow(
         inputs=inputs,
         user_id=str(user.id),
         team_id=str(workflow.team_id) if workflow.team_id else None,
+    )
+
+    await AuditLogService.log(
+        user=user,
+        action="run_workflow_embed",
+        resource_type="workflow",
+        resource_id=workflow_id,
+        resource_name=workflow.name,
+        operation="execute",
+        status="success",
+        request=request,
+        metadata={
+            "run_id": str(run.id),
+            "api_key_id": str(api_key.id),
+            "source": "embed",
+        },
     )
 
     return success(

--- a/backend/app/api/v1/endpoints/knowledge_bases.py
+++ b/backend/app/api/v1/endpoints/knowledge_bases.py
@@ -434,6 +434,7 @@ async def list_knowledge_bases(
 async def create_knowledge_base(
     *,
     kb_in: KnowledgeBaseCreate,
+    request: Request,
     current_user: User = Depends(require_kb_create),
 ) -> Any:
     """
@@ -472,6 +473,19 @@ async def create_knowledge_base(
 
     # Reload with relations
     kb = await KnowledgeBase.get(id=kb.id).prefetch_related("team", "created_by")
+
+    # 记录审计日志
+    await AuditLogService.log(
+        user=current_user,
+        action="create_knowledge_base",
+        resource_type="knowledge_base",
+        resource_id=kb.id,
+        resource_name=kb.name,
+        operation="create",
+        status="success",
+        request=request,
+    )
+
     kb_data = await kb_with_model_info(kb)
     return success(data=kb_data, msg_key="kb_created")
 
@@ -494,6 +508,7 @@ async def update_knowledge_base(
     *,
     kb_id: UUID,
     kb_in: KnowledgeBaseUpdate,
+    request: Request,
     current_user: User = Depends(require_kb_update),
 ) -> Any:
     """
@@ -550,6 +565,19 @@ async def update_knowledge_base(
 
     # Reload with relations
     kb = await KnowledgeBase.get(id=kb_id).prefetch_related("team", "created_by")
+
+    # 记录审计日志
+    await AuditLogService.log(
+        user=current_user,
+        action="update_knowledge_base",
+        resource_type="knowledge_base",
+        resource_id=kb.id,
+        resource_name=kb.name,
+        operation="update",
+        status="success",
+        request=request,
+    )
+
     kb_data = await kb_with_model_info(kb)
     return success(data=kb_data, msg_key="kb_updated")
 
@@ -557,6 +585,7 @@ async def update_knowledge_base(
 @router.delete("/{kb_id}", response_model=Response[dict])
 async def delete_knowledge_base(
     kb_id: UUID,
+    request: Request,
     current_user: User = Depends(require_kb_delete),
 ) -> Any:
     """
@@ -564,9 +593,22 @@ async def delete_knowledge_base(
     Requires admin permission in the team.
     """
     kb = await check_kb_access(kb_id, current_user, require_write=True)
+    kb_name = kb.name
 
     # Delete all documents and chunks (cascades)
     await kb.delete()
+
+    # 记录审计日志
+    await AuditLogService.log(
+        user=current_user,
+        action="delete_knowledge_base",
+        resource_type="knowledge_base",
+        resource_id=kb_id,
+        resource_name=kb_name,
+        operation="delete",
+        status="success",
+        request=request,
+    )
 
     return success(data={"id": str(kb_id)}, msg_key="kb_deleted")
 
@@ -671,6 +713,7 @@ async def list_documents(
 @router.post("/{kb_id}/documents/upload", response_model=Response[DocumentSchema])
 async def upload_document(
     kb_id: UUID,
+    request: Request,
     file: UploadFile = File(...),
     current_user: User = Depends(require_kb_update),
 ) -> Any:
@@ -730,6 +773,20 @@ async def upload_document(
 
     # Reload with relations
     doc = await Document.get(id=doc.id).prefetch_related("uploaded_by")
+
+    # 记录审计日志
+    await AuditLogService.log(
+        user=current_user,
+        action="upload_document",
+        resource_type="document",
+        resource_id=doc.id,
+        resource_name=doc.name,
+        operation="create",
+        status="success",
+        request=request,
+        metadata={"kb_id": str(kb_id), "kb_name": kb.name, "doc_type": doc_type},
+    )
+
     return success(data=await serialize_document(doc), msg_key="document_uploaded")
 
 
@@ -737,6 +794,7 @@ async def upload_document(
 async def add_url_document(
     kb_id: UUID,
     doc_in: DocumentCreate,
+    request: Request,
     current_user: User = Depends(require_kb_update),
 ) -> Any:
     """
@@ -771,6 +829,20 @@ async def add_url_document(
 
     # Reload with relations
     doc = await Document.get(id=doc.id).prefetch_related("uploaded_by")
+
+    # 记录审计日志
+    await AuditLogService.log(
+        user=current_user,
+        action="add_url_document",
+        resource_type="document",
+        resource_id=doc.id,
+        resource_name=doc.name,
+        operation="create",
+        status="success",
+        request=request,
+        metadata={"kb_id": str(kb_id), "kb_name": kb.name, "source_url": doc_in.source_url},
+    )
+
     return success(data=await serialize_document(doc), msg_key="document_created")
 
 
@@ -806,6 +878,7 @@ async def update_document(
     kb_id: UUID,
     doc_id: UUID,
     doc_in: DocumentUpdate,
+    request: Request,
     current_user: User = Depends(require_kb_update),
 ) -> Any:
     """
@@ -825,6 +898,18 @@ async def update_document(
         doc.name = doc_in.name
         await doc.save()
 
+    await AuditLogService.log(
+        user=current_user,
+        action="update_document",
+        resource_type="document",
+        resource_id=doc_id,
+        resource_name=doc.name,
+        operation="update",
+        status="success",
+        request=request,
+        metadata={"knowledge_base_id": str(kb_id)},
+    )
+
     doc = await Document.get(id=doc_id).prefetch_related("uploaded_by")
     return success(data=await serialize_document(doc), msg_key="document_updated")
 
@@ -833,6 +918,7 @@ async def update_document(
 async def delete_document(
     kb_id: UUID,
     doc_id: UUID,
+    request: Request,
     current_user: User = Depends(require_kb_delete),
 ) -> Any:
     """
@@ -848,6 +934,8 @@ async def delete_document(
             msg_key="document_not_found",
             status_code=404,
         )
+
+    doc_name = doc.name
 
     # Cancel Celery task if document is pending or processing
     if doc.status in [DocumentStatus.PENDING.value, DocumentStatus.PROCESSING.value]:
@@ -880,6 +968,18 @@ async def delete_document(
 
     # Delete document (chunks cascade)
     await doc.delete()
+
+    await AuditLogService.log(
+        user=current_user,
+        action="delete_document",
+        resource_type="document",
+        resource_id=doc_id,
+        resource_name=doc_name,
+        operation="delete",
+        status="success",
+        request=request,
+        metadata={"knowledge_base_id": str(kb_id)},
+    )
 
     return success(data={"id": str(doc_id)}, msg_key="document_deleted")
 
@@ -984,6 +1084,7 @@ async def get_document_media(
 async def process_document(
     kb_id: UUID,
     doc_id: UUID,
+    request: Request,
     process_in: Optional[ProcessRequest] = Body(default=None),
     current_user: User = Depends(require_kb_update),
 ) -> Any:
@@ -1030,6 +1131,18 @@ async def process_document(
     except Exception:
         logger.warning("Celery task not dispatched - worker may not be running")
 
+    await AuditLogService.log(
+        user=current_user,
+        action="process_document",
+        resource_type="document",
+        resource_id=doc_id,
+        resource_name=doc.name,
+        operation="update",
+        status="success",
+        request=request,
+        metadata={"knowledge_base_id": str(kb_id)},
+    )
+
     # Reload with relations
     doc = await Document.get(id=doc.id).prefetch_related("uploaded_by")
     return success(
@@ -1045,7 +1158,8 @@ async def process_document_with_chunks(
     *,
     kb_id: UUID,
     doc_id: UUID,
-    request: ProcessWithChunksRequest,
+    request: Request,
+    process_request: ProcessWithChunksRequest,
     current_user: User = Depends(require_kb_update),
 ) -> Any:
     """
@@ -1110,7 +1224,7 @@ async def process_document_with_chunks(
         total_chars = 0
         chunks_created = []
 
-        for chunk_input in request.chunks:
+        for chunk_input in process_request.chunks:
             content = chunk_input.content.strip()
             if not content:
                 continue
@@ -1156,6 +1270,21 @@ async def process_document_with_chunks(
                 code=ResponseCode.UNKNOWN_ERROR,
                 msg_key="task_dispatch_failed",
             )
+
+        await AuditLogService.log(
+            user=current_user,
+            action="process_document_with_chunks",
+            resource_type="document",
+            resource_id=doc_id,
+            resource_name=doc.name,
+            operation="update",
+            status="success",
+            request=request,
+            metadata={
+                "knowledge_base_id": str(kb_id),
+                "chunks_count": len(chunks_created),
+            },
+        )
 
         # Reload with relations
         doc = await Document.get(id=doc.id).prefetch_related("uploaded_by")
@@ -1275,6 +1404,7 @@ async def preview_document_chunks(
 async def reprocess_document(
     kb_id: UUID,
     doc_id: UUID,
+    request: Request,
     current_user: User = Depends(require_kb_update),
 ) -> Any:
     """
@@ -1318,6 +1448,18 @@ async def reprocess_document(
 
         logging.warning("Celery task not dispatched - worker may not be running")
 
+    await AuditLogService.log(
+        user=current_user,
+        action="reprocess_document",
+        resource_type="document",
+        resource_id=doc_id,
+        resource_name=doc.name,
+        operation="update",
+        status="success",
+        request=request,
+        metadata={"knowledge_base_id": str(kb_id)},
+    )
+
     doc = await Document.get(id=doc_id).prefetch_related("uploaded_by")
     return success(
         data=await serialize_document(doc), msg_key="document_reprocess_started"
@@ -1331,6 +1473,7 @@ async def reprocess_document(
 async def retry_failed_chunks(
     kb_id: UUID,
     doc_id: UUID,
+    request: Request,
     current_user: User = Depends(require_kb_update),
 ) -> Any:
     """
@@ -1381,6 +1524,18 @@ async def retry_failed_chunks(
 
         logging.warning("Celery task not dispatched - worker may not be running")
 
+    await AuditLogService.log(
+        user=current_user,
+        action="retry_failed_chunks",
+        resource_type="document",
+        resource_id=doc_id,
+        resource_name=doc.name,
+        operation="update",
+        status="success",
+        request=request,
+        metadata={"knowledge_base_id": str(kb_id), "failed_chunks_count": failed_count},
+    )
+
     doc = await Document.get(id=doc_id).prefetch_related("uploaded_by")
     return success(
         data=await serialize_document(doc), msg_key="retry_failed_chunks_started"
@@ -1395,6 +1550,7 @@ async def retry_failed_chunk(
     kb_id: UUID,
     doc_id: UUID,
     chunk_id: UUID,
+    request: Request,
     current_user: User = Depends(require_kb_update),
 ) -> Any:
     """
@@ -1445,6 +1601,18 @@ async def retry_failed_chunk(
         doc.status = DocumentStatus.ERROR.value
         doc.error_message = "task_dispatch_failed"
         await doc.save(update_fields=["status", "error_message"])
+
+    await AuditLogService.log(
+        user=current_user,
+        action="retry_failed_chunk",
+        resource_type="document_chunk",
+        resource_id=chunk_id,
+        resource_name=f"chunk_{chunk.chunk_index}",
+        operation="update",
+        status="success",
+        request=request,
+        metadata={"knowledge_base_id": str(kb_id), "document_id": str(doc_id)},
+    )
 
     doc = await Document.get(id=doc_id).prefetch_related("uploaded_by")
     return success(
@@ -1505,6 +1673,7 @@ async def update_document_chunk(
     doc_id: UUID,
     chunk_id: UUID,
     chunk_in: DocumentChunkUpdate,
+    request: Request,
     current_user: User = Depends(require_kb_update),
 ) -> Any:
     """
@@ -1572,6 +1741,18 @@ async def update_document_chunk(
             msg_key="vector_update_failed",
         )
 
+    await AuditLogService.log(
+        user=current_user,
+        action="update_document_chunk",
+        resource_type="document_chunk",
+        resource_id=chunk_id,
+        resource_name=f"chunk_{chunk.chunk_index}",
+        operation="update",
+        status="success",
+        request=request,
+        metadata={"knowledge_base_id": str(kb_id), "document_id": str(doc_id)},
+    )
+
     return success(data=await serialize_chunk(chunk), msg_key="chunk_updated")
 
 
@@ -1583,6 +1764,7 @@ async def delete_document_chunk(
     kb_id: UUID,
     doc_id: UUID,
     chunk_id: UUID,
+    request: Request,
     current_user: User = Depends(require_kb_delete),
 ) -> Any:
     """
@@ -1606,6 +1788,9 @@ async def delete_document_chunk(
             status_code=404,
         )
 
+    chunk_index = chunk.chunk_index
+    chunk_token_count = chunk.token_count
+
     # Delete vector
     try:
         embedding_model_id = (
@@ -1620,11 +1805,11 @@ async def delete_document_chunk(
 
     # Update statistics
     kb.total_chunks = max(0, kb.total_chunks - 1)
-    kb.total_tokens = max(0, kb.total_tokens - chunk.token_count)
+    kb.total_tokens = max(0, kb.total_tokens - chunk_token_count)
     await kb.save()
 
     doc.chunk_count = max(0, doc.chunk_count - 1)
-    doc.token_count = max(0, doc.token_count - chunk.token_count)
+    doc.token_count = max(0, doc.token_count - chunk_token_count)
     await doc.save()
 
     # Delete chunk
@@ -1635,6 +1820,18 @@ async def delete_document_chunk(
     await DocumentChunk.filter(
         document_id=doc_id, chunk_index__gt=deleted_index
     ).update(chunk_index=F("chunk_index") - 1)
+
+    await AuditLogService.log(
+        user=current_user,
+        action="delete_document_chunk",
+        resource_type="document_chunk",
+        resource_id=chunk_id,
+        resource_name=f"chunk_{chunk_index}",
+        operation="delete",
+        status="success",
+        request=request,
+        metadata={"knowledge_base_id": str(kb_id), "document_id": str(doc_id)},
+    )
 
     return success(data={"id": str(chunk_id)}, msg_key="chunk_deleted")
 
@@ -1648,6 +1845,7 @@ async def create_document_chunk(
     kb_id: UUID,
     doc_id: UUID,
     chunk_in: DocumentChunkUpdate,
+    request: Request,
     after_index: int | None = None,
     current_user: User = Depends(require_kb_update),
 ) -> Any:
@@ -1716,6 +1914,18 @@ async def create_document_chunk(
 
         logging.warning(f"Failed to create vector embedding: {e}")
 
+    await AuditLogService.log(
+        user=current_user,
+        action="create_document_chunk",
+        resource_type="document_chunk",
+        resource_id=chunk.id,
+        resource_name=f"chunk_{new_index}",
+        operation="create",
+        status="success",
+        request=request,
+        metadata={"knowledge_base_id": str(kb_id), "document_id": str(doc_id)},
+    )
+
     return success(data=await serialize_chunk(chunk), msg_key="chunk_created")
 
 
@@ -1728,6 +1938,7 @@ async def rechunk_document(
     kb_id: UUID,
     doc_id: UUID,
     rechunk_in: RechunkRequest,
+    request: Request,
     current_user: User = Depends(require_kb_update),
 ) -> Any:
     """
@@ -1781,6 +1992,22 @@ async def rechunk_document(
         import logging
 
         logging.warning("Celery task not dispatched - worker may not be running")
+
+    await AuditLogService.log(
+        user=current_user,
+        action="rechunk_document",
+        resource_type="document",
+        resource_id=doc_id,
+        resource_name=doc.name,
+        operation="update",
+        status="success",
+        request=request,
+        metadata={
+            "knowledge_base_id": str(kb_id),
+            "chunk_size": rechunk_in.chunk_size,
+            "chunk_overlap": rechunk_in.chunk_overlap,
+        },
+    )
 
     doc = await Document.get(id=doc_id).prefetch_related("uploaded_by")
     return success(

--- a/backend/app/api/v1/endpoints/knowledge_bases.py
+++ b/backend/app/api/v1/endpoints/knowledge_bases.py
@@ -65,6 +65,7 @@ from app.schemas.response import (
 )
 from app.services.document_processor import document_processor
 from app.services.error_messages import is_safe_user_visible_error
+from app.services.audit_log import AuditLogService
 from app.services.vector_store import VectorStore, DimensionMismatchError
 
 router = APIRouter()
@@ -840,7 +841,11 @@ async def add_url_document(
         operation="create",
         status="success",
         request=request,
-        metadata={"kb_id": str(kb_id), "kb_name": kb.name, "source_url": doc_in.source_url},
+        metadata={
+            "kb_id": str(kb_id),
+            "kb_name": kb.name,
+            "source_url": doc_in.source_url,
+        },
     )
 
     return success(data=await serialize_document(doc), msg_key="document_created")

--- a/backend/app/api/v1/endpoints/login.py
+++ b/backend/app/api/v1/endpoints/login.py
@@ -263,7 +263,7 @@ async def login_access_token(
     await reset_login_attempts(user)
 
     # Check for login anomaly (new IP or device)
-    client_ip = request.client.host if request.client else "unknown"
+    client_ip = AuditLogService.get_client_ip(request)
     user_agent = request.headers.get("user-agent", "")
     is_anomaly, anomaly_details = await check_login_anomaly(
         user_id=user.id,
@@ -493,7 +493,7 @@ async def verify_totp(
         force_change_required = True
 
     # Check for login anomaly
-    client_ip = request.client.host if request.client else "unknown"
+    client_ip = AuditLogService.get_client_ip(request)
     user_agent = request.headers.get("user-agent", "")
     is_anomaly, anomaly_details = await check_login_anomaly(
         user_id=user.id,

--- a/backend/app/api/v1/endpoints/memories.py
+++ b/backend/app/api/v1/endpoints/memories.py
@@ -6,7 +6,7 @@ Provides CRUD operations for user memory entities and relations.
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 
 from app.api.deps import get_current_user
 from app.core.i18n import t
@@ -23,6 +23,7 @@ from app.schemas.memory import (
     MemoryGraphResponse,
 )
 from app.services.memory import MemoryService
+from app.services.audit_log import AuditLogService
 
 logger = logging.getLogger(__name__)
 
@@ -60,17 +61,30 @@ async def list_entities(
 
 @router.post("/entities", summary="Create a memory entity")
 async def create_entity(
-    request: CreateEntityRequest,
+    request: Request,
+    body: CreateEntityRequest,
     current_user: User = Depends(get_current_user),
 ):
     """Create a new memory entity manually."""
     try:
         entity = await MemoryService.create_entity(
             user_id=current_user.id,
-            name=request.name,
-            entity_type=request.entity_type,
-            description=request.description,
-            properties=request.properties,
+            name=body.name,
+            entity_type=body.entity_type,
+            description=body.description,
+            properties=body.properties,
+        )
+
+        await AuditLogService.log(
+            user=current_user,
+            action="create_memory_entity",
+            resource_type="memory_entity",
+            resource_id=entity.id,
+            resource_name=entity.name,
+            operation="create",
+            status="success",
+            request=request,
+            metadata={"entity_type": body.entity_type.value},
         )
 
         return success(EntityResponse.model_validate(entity))
@@ -126,7 +140,8 @@ async def get_entity(
 @router.put("/entities/{entity_id}", summary="Update entity")
 async def update_entity(
     entity_id: UUID,
-    request: UpdateEntityRequest,
+    request: Request,
+    body: UpdateEntityRequest,
     current_user: User = Depends(get_current_user),
 ):
     """Update a memory entity."""
@@ -144,18 +159,29 @@ async def update_entity(
             )
 
         # Update fields
-        if request.name is not None:
-            entity.name = request.name
-        if request.description is not None:
-            entity.description = request.description
-        if request.properties is not None:
-            entity.properties = {**entity.properties, **request.properties}
+        if body.name is not None:
+            entity.name = body.name
+        if body.description is not None:
+            entity.description = body.description
+        if body.properties is not None:
+            entity.properties = {**entity.properties, **body.properties}
 
         await entity.save()
 
         # Update embedding if content changed
-        if request.name or request.description:
+        if body.name or body.description:
             await MemoryService._update_entity_embedding(entity)
+
+        await AuditLogService.log(
+            user=current_user,
+            action="update_memory_entity",
+            resource_type="memory_entity",
+            resource_id=entity.id,
+            resource_name=entity.name,
+            operation="update",
+            status="success",
+            request=request,
+        )
 
         return success(EntityResponse.model_validate(entity))
     except BusinessError:
@@ -171,13 +197,31 @@ async def update_entity(
 @router.delete("/entities/{entity_id}", summary="Delete entity")
 async def delete_entity(
     entity_id: UUID,
+    request: Request,
     current_user: User = Depends(get_current_user),
 ):
     """Delete a memory entity and its relations."""
     try:
+        # Capture entity name before deletion
+        entity = await MemoryEntity.filter(
+            id=entity_id, user_id=current_user.id
+        ).first()
+        entity_name = entity.name if entity else str(entity_id)
+
         await MemoryService.delete_entity(
             user_id=current_user.id,
             entity_id=entity_id,
+        )
+
+        await AuditLogService.log(
+            user=current_user,
+            action="delete_memory_entity",
+            resource_type="memory_entity",
+            resource_id=entity_id,
+            resource_name=entity_name,
+            operation="delete",
+            status="success",
+            request=request,
         )
 
         return success(
@@ -241,18 +285,35 @@ async def list_relations(
 
 @router.post("/relations", summary="Create a memory relation")
 async def create_relation(
-    request: CreateRelationRequest,
+    request: Request,
+    body: CreateRelationRequest,
     current_user: User = Depends(get_current_user),
 ):
     """Create a new memory relation manually."""
     try:
         relation = await MemoryService.create_relation(
             user_id=current_user.id,
-            source_entity_id=request.source_entity_id,
-            target_entity_id=request.target_entity_id,
-            relation_type=request.relation_type,
-            description=request.description,
-            properties=request.properties,
+            source_entity_id=body.source_entity_id,
+            target_entity_id=body.target_entity_id,
+            relation_type=body.relation_type,
+            description=body.description,
+            properties=body.properties,
+        )
+
+        await AuditLogService.log(
+            user=current_user,
+            action="create_memory_relation",
+            resource_type="memory_relation",
+            resource_id=relation.id,
+            resource_name=str(relation.id),
+            operation="create",
+            status="success",
+            request=request,
+            metadata={
+                "source_entity_id": str(body.source_entity_id),
+                "target_entity_id": str(body.target_entity_id),
+                "relation_type": body.relation_type.value,
+            },
         )
 
         return success(RelationResponse.model_validate(relation))
@@ -281,6 +342,7 @@ async def create_relation(
 @router.delete("/relations/{relation_id}", summary="Delete relation")
 async def delete_relation(
     relation_id: UUID,
+    request: Request,
     current_user: User = Depends(get_current_user),
 ):
     """Delete a memory relation."""
@@ -288,6 +350,17 @@ async def delete_relation(
         await MemoryService.delete_relation(
             user_id=current_user.id,
             relation_id=relation_id,
+        )
+
+        await AuditLogService.log(
+            user=current_user,
+            action="delete_memory_relation",
+            resource_type="memory_relation",
+            resource_id=relation_id,
+            resource_name=str(relation_id),
+            operation="delete",
+            status="success",
+            request=request,
         )
 
         return success(

--- a/backend/app/api/v1/endpoints/prompt_generator.py
+++ b/backend/app/api/v1/endpoints/prompt_generator.py
@@ -6,7 +6,7 @@ Provides streaming SSE response for generating agent system prompts.
 import json
 import logging
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from app.core.i18n import t
 from fastapi.responses import StreamingResponse
@@ -18,6 +18,7 @@ from app.models.model import Model
 from app.schemas.response import (
     ResponseCode,
 )
+from app.services.audit_log import AuditLogService
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -320,7 +321,8 @@ def build_style_requirements(style: PromptStyle | None, language: str) -> str:
 
 @router.post("/generate")
 async def generate_prompt(
-    request: PromptGenerateRequest,
+    request: Request,
+    body: PromptGenerateRequest,
     current_user: User = Depends(deps.get_current_active_user),
 ) -> StreamingResponse:
     """
@@ -334,6 +336,20 @@ async def generate_prompt(
     - complete: Generation complete
     - error: {"code": ..., "msg": "..."}
     """
+
+    # Audit log before generation starts
+    await AuditLogService.log(
+        user=current_user,
+        action="generate_prompt",
+        resource_type="prompt",
+        operation="create",
+        status="success",
+        request=request,
+        metadata={
+            "language": body.language,
+            "has_context": body.context is not None,
+        },
+    )
 
     async def event_generator():
         try:
@@ -349,10 +365,10 @@ async def generate_prompt(
                 return
 
             # Build meta-prompt
-            language = request.language or "zh"
-            style = request.style or PromptStyle()
+            language = body.language or "zh"
+            style = body.style or PromptStyle()
 
-            context_str = build_context_string(request.context, language)
+            context_str = build_context_string(body.context, language)
             tone_desc = get_tone_description(style.tone, language)
             focus_desc = get_focus_description(style.focus, language)
             style_requirements = build_style_requirements(style, language)
@@ -361,7 +377,7 @@ async def generate_prompt(
                 META_PROMPT_ZH if language == "zh" else META_PROMPT_EN
             )
             meta_prompt = meta_prompt_template.format(
-                description=request.description,
+                description=body.description,
                 context=context_str,
                 tone_desc=tone_desc,
                 focus_desc=focus_desc,
@@ -405,6 +421,7 @@ async def generate_prompt(
 
 @router.post("/optimize")
 async def optimize_prompt(
+    request: Request,
     current_prompt: str,
     feedback: str,
     current_user: User = Depends(deps.get_current_active_user),
@@ -414,6 +431,20 @@ async def optimize_prompt(
 
     This endpoint is for iterative improvement of prompts.
     """
+
+    # Audit log before optimization starts
+    await AuditLogService.log(
+        user=current_user,
+        action="optimize_prompt",
+        resource_type="prompt",
+        operation="update",
+        status="success",
+        request=request,
+        metadata={
+            "prompt_length": len(current_prompt),
+            "feedback_length": len(feedback),
+        },
+    )
 
     async def event_generator():
         try:

--- a/backend/app/api/v1/endpoints/team_models.py
+++ b/backend/app/api/v1/endpoints/team_models.py
@@ -7,7 +7,7 @@
 from typing import Any, List
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from app.api import deps
 from app.core.i18n import t
@@ -31,6 +31,7 @@ from app.schemas.response import (
 )
 from app.schemas.team import TeamMemberRole
 from app.services.auto_notification import AutoNotificationService
+from app.services.audit_log import AuditLogService
 
 router = APIRouter()
 
@@ -108,6 +109,7 @@ async def list_team_models(
 @router.post("/{team_id}/models", response_model=Response[TeamModelResponse])
 async def add_team_model(
     team_id: UUID,
+    request: Request,
     auth_in: TeamModelCreate,
     current_user: User = Depends(deps.get_current_active_superuser),
 ) -> Any:
@@ -175,6 +177,22 @@ async def add_team_model(
         },
     )
 
+    await AuditLogService.log(
+        user=current_user,
+        action="add_team_model",
+        resource_type="team_model",
+        resource_id=team_model.id,
+        resource_name=f"{team.name} - {model.name}",
+        operation="create",
+        status="success",
+        request=request,
+        metadata={
+            "team_id": str(team_id),
+            "model_id": str(auth_in.model_id),
+            "model_name": model.name,
+        },
+    )
+
     return success(
         data={
             "id": team_model.id,
@@ -208,6 +226,7 @@ async def add_team_model(
 async def update_team_model(
     team_id: UUID,
     model_id: UUID,
+    request: Request,
     auth_in: TeamModelUpdate,
     current_user: User = Depends(deps.get_current_active_superuser),
 ) -> Any:
@@ -233,6 +252,22 @@ async def update_team_model(
         setattr(team_model, field, value)
 
     await team_model.save()
+
+    await AuditLogService.log(
+        user=current_user,
+        action="update_team_model",
+        resource_type="team_model",
+        resource_id=team_model.id,
+        resource_name=f"{team_id} - {team_model.model.name}",
+        operation="update",
+        status="success",
+        request=request,
+        metadata={
+            "team_id": str(team_id),
+            "model_id": str(model_id),
+            "updated_fields": list(update_data.keys()),
+        },
+    )
 
     return success(
         data={
@@ -267,6 +302,7 @@ async def update_team_model(
 async def remove_team_model(
     team_id: UUID,
     model_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.get_current_active_superuser),
 ) -> Any:
     """
@@ -310,6 +346,22 @@ async def remove_team_model(
         },
     )
 
+    await AuditLogService.log(
+        user=current_user,
+        action="remove_team_model",
+        resource_type="team_model",
+        resource_id=model_id,
+        resource_name=f"{team_name} - {model_name}",
+        operation="delete",
+        status="success",
+        request=request,
+        metadata={
+            "team_id": str(team_id),
+            "model_id": str(model_id),
+            "model_name": model_name,
+        },
+    )
+
     return success(
         data={"team_id": str(team_id), "model_id": str(model_id)},
         msg_key="team_model_revoked",
@@ -324,6 +376,7 @@ async def remove_team_model(
 )
 async def batch_add_team_models(
     team_id: UUID,
+    request: Request,
     batch_in: TeamModelBatchCreate,
     current_user: User = Depends(deps.get_current_active_superuser),
 ) -> Any:
@@ -413,12 +466,29 @@ async def batch_add_team_models(
             },
         )
 
+    await AuditLogService.log(
+        user=current_user,
+        action="batch_add_team_models",
+        resource_type="team_model",
+        resource_name=f"{team.name} - {len(results)} models",
+        operation="create",
+        status="success",
+        request=request,
+        metadata={
+            "team_id": str(team_id),
+            "team_name": team.name,
+            "model_count": len(results),
+            "model_ids": [str(m) for m in batch_in.model_ids],
+        },
+    )
+
     return success(data=results, msg_key="team_models_authorized")
 
 
 @router.delete("/{team_id}/models/batch", response_model=Response[dict])
 async def batch_remove_team_models(
     team_id: UUID,
+    request: Request,
     batch_in: TeamModelBatchDelete,
     current_user: User = Depends(deps.get_current_active_superuser),
 ) -> Any:
@@ -462,6 +532,22 @@ async def batch_remove_team_models(
                 "team_name": team.name,
             },
         )
+
+    await AuditLogService.log(
+        user=current_user,
+        action="batch_remove_team_models",
+        resource_type="team_model",
+        resource_name=f"{team.name} - {deleted_count} models",
+        operation="delete",
+        status="success",
+        request=request,
+        metadata={
+            "team_id": str(team_id),
+            "team_name": team.name,
+            "deleted_count": deleted_count,
+            "model_names": model_names,
+        },
+    )
 
     return success(
         data={"deleted_count": deleted_count},

--- a/backend/app/api/v1/endpoints/tools.py
+++ b/backend/app/api/v1/endpoints/tools.py
@@ -12,7 +12,7 @@ from typing import Any
 from app.services.sandbox.models import SandboxArtifact
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 
 from app.api import deps
 from app.core.i18n import has_translation, t
@@ -27,6 +27,7 @@ from app.llm.tools import tool_registry
 from app.llm.tools.mcp_client import execute_mcp_tool, list_mcp_tools
 from app.llm.tools.executors import execute_http_tool
 from app.services.error_messages import resolve_user_visible_error
+from app.services.audit_log import AuditLogService
 from app.services.sandbox.compiler import compile_code_config_job
 from app.services.sandbox.gateway import sandbox_gateway
 from app.services.sandbox.models import SandboxJobSource
@@ -652,6 +653,7 @@ async def get_mcp_tools(
 async def create_tool(
     team_id: UUID,
     tool_in: ToolCreateInput,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("tool:create")),
 ) -> Any:
     """创建自定义工具"""
@@ -685,6 +687,18 @@ async def create_tool(
         credentials=tool_in.credentials,
         is_enabled=tool_in.is_enabled,
         created_by=current_user,
+    )
+
+    await AuditLogService.log(
+        user=current_user,
+        action="create_tool",
+        resource_type="tool",
+        resource_id=tool.id,
+        resource_name=tool.name,
+        operation="create",
+        status="success",
+        request=request,
+        metadata={"team_id": str(team_id), "tool_type": tool_in.type.value},
     )
 
     return success(
@@ -755,6 +769,7 @@ async def get_tool_by_name(
 async def update_tool(
     tool_id: UUID,
     tool_in: ToolUpdateInput,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("tool:update")),
 ) -> Any:
     """更新工具"""
@@ -805,6 +820,18 @@ async def update_tool(
 
     await tool.save()
 
+    await AuditLogService.log(
+        user=current_user,
+        action="update_tool",
+        resource_type="tool",
+        resource_id=tool.id,
+        resource_name=tool.name,
+        operation="update",
+        status="success",
+        request=request,
+        metadata={"team_id": str(tool.team_id)},
+    )
+
     creator_name = tool.created_by.username if tool.created_by else None
     return success(
         data=db_tool_to_detail(tool, creator_name),
@@ -815,6 +842,7 @@ async def update_tool(
 @router.delete("/{tool_id}", response_model=Response[None])
 async def delete_tool(
     tool_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("tool:delete")),
 ) -> Any:
     """删除工具"""
@@ -828,7 +856,21 @@ async def delete_tool(
 
     await check_team_access(tool.team_id, current_user, require_admin=True)
 
+    tool_name = tool.name
+    tool_team_id = tool.team_id
     await tool.delete()
+
+    await AuditLogService.log(
+        user=current_user,
+        action="delete_tool",
+        resource_type="tool",
+        resource_id=tool_id,
+        resource_name=tool_name,
+        operation="delete",
+        status="success",
+        request=request,
+        metadata={"team_id": str(tool_team_id)},
+    )
 
     return success(
         data=None,
@@ -1122,6 +1164,7 @@ async def execute_code_directly(
 @router.post("/{tool_id}/toggle", response_model=Response[ToolDetailOut])
 async def toggle_tool(
     tool_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("tool:update")),
 ) -> Any:
     """切换工具启用状态"""
@@ -1138,6 +1181,18 @@ async def toggle_tool(
     tool.is_enabled = not tool.is_enabled
     await tool.save()
 
+    await AuditLogService.log(
+        user=current_user,
+        action="toggle_tool",
+        resource_type="tool",
+        resource_id=tool.id,
+        resource_name=tool.name,
+        operation="update",
+        status="success",
+        request=request,
+        metadata={"team_id": str(tool.team_id), "is_enabled": tool.is_enabled},
+    )
+
     creator_name = tool.created_by.username if tool.created_by else None
     return success(
         data=db_tool_to_detail(tool, creator_name),
@@ -1148,6 +1203,7 @@ async def toggle_tool(
 @router.post("/{tool_id}/duplicate", response_model=Response[ToolDetailOut])
 async def duplicate_tool(
     tool_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("tool:create")),
 ) -> Any:
     """复制工具"""
@@ -1186,6 +1242,18 @@ async def duplicate_tool(
         credentials=tool.credentials,
         is_enabled=False,  # 副本默认禁用
         created_by=current_user,
+    )
+
+    await AuditLogService.log(
+        user=current_user,
+        action="duplicate_tool",
+        resource_type="tool",
+        resource_id=new_tool.id,
+        resource_name=new_tool.name,
+        operation="create",
+        status="success",
+        request=request,
+        metadata={"team_id": str(tool.team_id), "source_tool_id": str(tool_id)},
     )
 
     return success(
@@ -1288,6 +1356,7 @@ async def get_tool_config(
 @router.post("/config", response_model=Response[dict])
 async def create_tool_config(
     data: dict,
+    request: Request,
     team_id: UUID | None = None,
     current_user: User = Depends(deps.PermissionChecker("tool:update")),
 ) -> Any:
@@ -1328,6 +1397,18 @@ async def create_tool_config(
         credentials=config_data.credentials,
     )
 
+    await AuditLogService.log(
+        user=current_user,
+        action="create_tool_config",
+        resource_type="tool_config",
+        resource_id=config.id,
+        resource_name=config_data.tool_name,
+        operation="create",
+        status="success",
+        request=request,
+        metadata={"team_id": str(team_id) if team_id else "global"},
+    )
+
     return success(
         data=ToolConfigOut.model_validate(config).model_dump(),
         msg_key="tool_config_created",
@@ -1338,6 +1419,7 @@ async def create_tool_config(
 async def update_tool_config(
     tool_name: str,
     data: dict,
+    request: Request,
     team_id: UUID | None = None,
     current_user: User = Depends(deps.PermissionChecker("tool:update")),
 ) -> Any:
@@ -1372,6 +1454,18 @@ async def update_tool_config(
     config.credentials = config_data.credentials
     await config.save()
 
+    await AuditLogService.log(
+        user=current_user,
+        action="update_tool_config",
+        resource_type="tool_config",
+        resource_id=config.id,
+        resource_name=tool_name,
+        operation="update",
+        status="success",
+        request=request,
+        metadata={"team_id": str(team_id) if team_id else "global"},
+    )
+
     return success(
         data=ToolConfigOut.model_validate(config).model_dump(),
         msg_key="tool_config_updated",
@@ -1381,6 +1475,7 @@ async def update_tool_config(
 @router.delete("/config/{tool_name}", response_model=Response[None])
 async def delete_tool_config(
     tool_name: str,
+    request: Request,
     team_id: UUID | None = None,
     current_user: User = Depends(deps.PermissionChecker("tool:delete")),
 ) -> Any:
@@ -1408,7 +1503,20 @@ async def delete_tool_config(
             status_code=404,
         )
 
+    config_id = config.id
     await config.delete()
+
+    await AuditLogService.log(
+        user=current_user,
+        action="delete_tool_config",
+        resource_type="tool_config",
+        resource_id=config_id,
+        resource_name=tool_name,
+        operation="delete",
+        status="success",
+        request=request,
+        metadata={"team_id": str(team_id) if team_id else "global"},
+    )
 
     return success(
         data=None,
@@ -1423,6 +1531,7 @@ async def delete_tool_config(
 async def share_tool(
     tool_id: UUID,
     share_data: ToolShareInput,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("tool:update")),
 ) -> Any:
     """
@@ -1481,6 +1590,22 @@ async def share_tool(
 
     # 预加载关联数据
     await share.fetch_related("tool", "shared_with_team", "shared_by")
+
+    await AuditLogService.log(
+        user=current_user,
+        action="share_tool",
+        resource_type="tool",
+        resource_id=tool_id,
+        resource_name=tool.name,
+        operation="create",
+        status="success",
+        request=request,
+        metadata={
+            "team_id": str(tool.team_id),
+            "shared_with_team_id": str(share_data.team_id),
+            "permission": share_data.permission,
+        },
+    )
 
     return success(
         data=ToolShareOut(
@@ -1556,6 +1681,7 @@ async def list_tool_shares(
 async def unshare_tool(
     tool_id: UUID,
     team_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("tool:update")),
 ) -> Any:
     """
@@ -1587,6 +1713,21 @@ async def unshare_tool(
 
     # 删除共享记录
     await share.delete()
+
+    await AuditLogService.log(
+        user=current_user,
+        action="unshare_tool",
+        resource_type="tool",
+        resource_id=tool_id,
+        resource_name=tool.name,
+        operation="delete",
+        status="success",
+        request=request,
+        metadata={
+            "team_id": str(tool.team_id),
+            "unshared_from_team_id": str(team_id),
+        },
+    )
 
     return success(
         data=None,

--- a/backend/app/api/v1/endpoints/upload.py
+++ b/backend/app/api/v1/endpoints/upload.py
@@ -468,7 +468,7 @@ async def upload_sandbox_artifact(
 
     # Log audit for authenticated users (skip for signature-only uploads)
     if authenticated is not None:
-        user, _ = authenticated
+        user, api_key = authenticated
         await AuditLogService.log(
             user=user,
             action="upload_sandbox_artifact",
@@ -477,6 +477,7 @@ async def upload_sandbox_artifact(
             operation="create",
             status="success",
             request=request,
+            api_key=api_key,
             metadata={
                 "content_type": content_type,
                 "size": upload_info["size"],

--- a/backend/app/api/v1/endpoints/upload.py
+++ b/backend/app/api/v1/endpoints/upload.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from datetime import datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, UploadFile, File, Query, Header
+from fastapi import APIRouter, Depends, UploadFile, File, Query, Header, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
@@ -27,6 +27,7 @@ from app.services.file_parser import (
     file_parser_service,
     FileParseConfig,
 )
+from app.services.audit_log import AuditLogService
 
 logger = logging.getLogger(__name__)
 
@@ -294,6 +295,7 @@ def _validate_allowed_content_type(
 
 @router.post("/image", response_model=Response[dict])
 async def upload_image(
+    request: Request,
     file: UploadFile = File(...),
     category: str = Query("general", description="文件分类：general, avatar, icon 等"),
     current_user: User = Depends(deps.get_current_active_user),
@@ -329,6 +331,22 @@ async def upload_image(
         filename=file.filename,
     )
 
+    await AuditLogService.log(
+        user=current_user,
+        action="upload_image",
+        resource_type="file",
+        resource_name=file.filename,
+        operation="create",
+        status="success",
+        request=request,
+        metadata={
+            "category": category,
+            "content_type": content_type,
+            "size": upload_info["size"],
+            "url": upload_info["url"],
+        },
+    )
+
     return success(
         data={
             "url": upload_info["url"],
@@ -343,6 +361,7 @@ async def upload_image(
 
 @router.post("/file", response_model=Response[dict])
 async def upload_file(
+    request: Request,
     file: UploadFile = File(...),
     category: str = Query("general", description="文件分类"),
     current_user: User = Depends(deps.get_current_active_user),
@@ -373,6 +392,22 @@ async def upload_file(
         filename=file.filename,
     )
 
+    await AuditLogService.log(
+        user=current_user,
+        action="upload_file",
+        resource_type="file",
+        resource_name=file.filename,
+        operation="create",
+        status="success",
+        request=request,
+        metadata={
+            "category": category,
+            "content_type": content_type,
+            "size": upload_info["size"],
+            "url": upload_info["url"],
+        },
+    )
+
     return success(
         data={
             "url": upload_info["url"],
@@ -387,6 +422,7 @@ async def upload_file(
 
 @router.post("/sandbox-artifact", response_model=Response[dict])
 async def upload_sandbox_artifact(
+    request: Request,
     file: UploadFile = File(...),
     authenticated: tuple[User, APIKey | None] | None = Depends(
         deps.get_current_user_or_api_key_optional
@@ -429,6 +465,24 @@ async def upload_sandbox_artifact(
         content_type=content_type,
         filename=file.filename,
     )
+
+    # Log audit for authenticated users (skip for signature-only uploads)
+    if authenticated is not None:
+        user, _ = authenticated
+        await AuditLogService.log(
+            user=user,
+            action="upload_sandbox_artifact",
+            resource_type="file",
+            resource_name=file.filename,
+            operation="create",
+            status="success",
+            request=request,
+            metadata={
+                "content_type": content_type,
+                "size": upload_info["size"],
+                "url": upload_info["url"],
+            },
+        )
 
     return success(
         data={
@@ -477,6 +531,7 @@ async def delete_file(
     year: str,
     month: str,
     filename: str,
+    request: Request,
     current_user: User = Depends(deps.get_current_active_superuser),
 ) -> Any:
     """
@@ -496,6 +551,20 @@ async def delete_file(
         )
 
     os.remove(file_path)
+
+    await AuditLogService.log(
+        user=current_user,
+        action="delete_file",
+        resource_type="file",
+        resource_name=f"{category}/{year}/{month}/{filename}",
+        operation="delete",
+        status="success",
+        request=request,
+        metadata={
+            "category": category,
+            "path": f"{year}/{month}/{filename}",
+        },
+    )
 
     return success(msg_key="file_deleted")
 

--- a/backend/app/api/v1/endpoints/workflows.py
+++ b/backend/app/api/v1/endpoints/workflows.py
@@ -918,7 +918,10 @@ async def duplicate_workflow(
         operation="create",
         status="success",
         request=request,
-        metadata={"source_workflow_id": str(workflow_id), "source_workflow_name": workflow.name},
+        metadata={
+            "source_workflow_id": str(workflow_id),
+            "source_workflow_name": workflow.name,
+        },
     )
 
     # Reload with relations

--- a/backend/app/api/v1/endpoints/workflows.py
+++ b/backend/app/api/v1/endpoints/workflows.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query, Header
+from fastapi import APIRouter, Depends, Query, Header, Request
 from fastapi.responses import StreamingResponse
 from tortoise.expressions import Q
 
@@ -48,6 +48,7 @@ from app.schemas.response import (
     BusinessError,
     success,
 )
+from app.services.audit_log import AuditLogService
 from app.services.workflow.errors import (
     get_public_workflow_error_key,
     translate_public_workflow_error,
@@ -465,6 +466,7 @@ async def list_workflows(
 async def create_workflow(
     *,
     workflow_in: WorkflowCreate,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:create")),
 ) -> Any:
     """Create a new workflow."""
@@ -517,6 +519,18 @@ async def create_workflow(
         definition=default_definition,
         variables=[],
         created_by=current_user,
+    )
+
+    await AuditLogService.log(
+        user=current_user,
+        action="create_workflow",
+        resource_type="workflow",
+        resource_id=workflow.id,
+        resource_name=workflow.name,
+        operation="create",
+        status="success",
+        request=request,
+        metadata={"team_id": str(workflow_in.team_id)},
     )
 
     # Reload with relations
@@ -693,6 +707,7 @@ async def update_workflow(
     *,
     workflow_id: UUID,
     workflow_in: WorkflowUpdate,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:update")),
 ) -> Any:
     """Update a workflow."""
@@ -739,6 +754,18 @@ async def update_workflow(
 
     await workflow.save()
 
+    await AuditLogService.log(
+        user=current_user,
+        action="update_workflow",
+        resource_type="workflow",
+        resource_id=workflow_id,
+        resource_name=workflow.name,
+        operation="update",
+        status="success",
+        request=request,
+        metadata={"team_id": str(workflow.team_id)},
+    )
+
     # Reload with relations
     workflow = await Workflow.get(id=workflow_id).prefetch_related("team", "created_by")
 
@@ -751,6 +778,7 @@ async def update_workflow(
 @router.delete("/{workflow_id}", response_model=Response[dict])
 async def delete_workflow(
     workflow_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:delete")),
 ) -> Any:
     """Delete a workflow and all its runs."""
@@ -758,8 +786,21 @@ async def delete_workflow(
         workflow_id, current_user, require_write=True
     )
 
+    workflow_name = workflow.name
+
     # Delete workflow (cascades to runs and node executions)
     await workflow.delete()
+
+    await AuditLogService.log(
+        user=current_user,
+        action="delete_workflow",
+        resource_type="workflow",
+        resource_id=workflow_id,
+        resource_name=workflow_name,
+        operation="delete",
+        status="success",
+        request=request,
+    )
 
     return success(data={"id": str(workflow_id)}, msg_key="workflow_deleted")
 
@@ -767,6 +808,7 @@ async def delete_workflow(
 @router.post("/{workflow_id}/publish", response_model=Response[WorkflowOut])
 async def publish_workflow(
     workflow_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:publish")),
 ) -> Any:
     """Publish a workflow and save a version snapshot."""
@@ -795,6 +837,17 @@ async def publish_workflow(
     workflow.status = WorkflowStatus.PUBLISHED
     await workflow.save()
 
+    await AuditLogService.log(
+        user=current_user,
+        action="publish_workflow",
+        resource_type="workflow",
+        resource_id=workflow_id,
+        resource_name=workflow.name,
+        operation="update",
+        status="success",
+        request=request,
+    )
+
     return success(
         data=WorkflowOut.model_validate(workflow).model_dump(),
         msg_key="workflow_published",
@@ -804,6 +857,7 @@ async def publish_workflow(
 @router.post("/{workflow_id}/unpublish", response_model=Response[WorkflowOut])
 async def unpublish_workflow(
     workflow_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:publish")),
 ) -> Any:
     """Unpublish a workflow."""
@@ -814,6 +868,17 @@ async def unpublish_workflow(
     workflow.status = WorkflowStatus.DRAFT
     await workflow.save()
 
+    await AuditLogService.log(
+        user=current_user,
+        action="unpublish_workflow",
+        resource_type="workflow",
+        resource_id=workflow_id,
+        resource_name=workflow.name,
+        operation="update",
+        status="success",
+        request=request,
+    )
+
     return success(
         data=WorkflowOut.model_validate(workflow).model_dump(),
         msg_key="workflow_unpublished",
@@ -823,6 +888,7 @@ async def unpublish_workflow(
 @router.post("/{workflow_id}/duplicate", response_model=Response[WorkflowOut])
 async def duplicate_workflow(
     workflow_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:create")),
 ) -> Any:
     """Duplicate a workflow."""
@@ -843,6 +909,18 @@ async def duplicate_workflow(
         created_by=current_user,
     )
 
+    await AuditLogService.log(
+        user=current_user,
+        action="duplicate_workflow",
+        resource_type="workflow",
+        resource_id=new_workflow.id,
+        resource_name=new_workflow.name,
+        operation="create",
+        status="success",
+        request=request,
+        metadata={"source_workflow_id": str(workflow_id), "source_workflow_name": workflow.name},
+    )
+
     # Reload with relations
     new_workflow = await Workflow.get(id=new_workflow.id).prefetch_related(
         "team", "created_by"
@@ -857,6 +935,7 @@ async def duplicate_workflow(
 @router.post("/{workflow_id}/regenerate-webhook-token", response_model=Response[dict])
 async def regenerate_webhook_token(
     workflow_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:update")),
 ) -> Any:
     """Regenerate webhook token for a workflow."""
@@ -866,6 +945,17 @@ async def regenerate_webhook_token(
 
     workflow.webhook_token = secrets.token_urlsafe(32)
     await workflow.save()
+
+    await AuditLogService.log(
+        user=current_user,
+        action="regenerate_webhook_token",
+        resource_type="workflow",
+        resource_id=workflow_id,
+        resource_name=workflow.name,
+        operation="update",
+        status="success",
+        request=request,
+    )
 
     return success(
         data={"webhook_token": workflow.webhook_token},
@@ -1031,6 +1121,7 @@ async def trigger_workflow_webhook(
 async def run_workflow(
     workflow_id: UUID,
     run_request: WorkflowRunRequest,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:run")),
 ) -> Any:
     """
@@ -1070,6 +1161,18 @@ async def run_workflow(
             team_id=str(workflow.team_id) if workflow.team_id else None,
         )
 
+        await AuditLogService.log(
+            user=current_user,
+            action="run_workflow",
+            resource_type="workflow_run",
+            resource_id=run.id,
+            resource_name=workflow.name,
+            operation="create",
+            status="success",
+            request=request,
+            metadata={"workflow_id": str(workflow_id), "is_debug": False},
+        )
+
         return success(
             data={
                 "run_id": str(run.id),
@@ -1090,6 +1193,7 @@ async def run_workflow(
 async def debug_workflow(
     workflow_id: UUID,
     run_request: WorkflowRunRequest,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:run")),
 ) -> Any:
     """
@@ -1122,6 +1226,18 @@ async def debug_workflow(
             user_id=str(current_user.id),
             team_id=str(workflow.team_id) if workflow.team_id else None,
             is_debug=True,
+        )
+
+        await AuditLogService.log(
+            user=current_user,
+            action="debug_workflow",
+            resource_type="workflow_run",
+            resource_id=run.id,
+            resource_name=workflow.name,
+            operation="create",
+            status="success",
+            request=request,
+            metadata={"workflow_id": str(workflow_id), "is_debug": True},
         )
 
         return success(
@@ -1210,6 +1326,7 @@ async def stream_workflow_run(
 @router.post("/runs/{run_id}/cancel", response_model=Response[dict])
 async def cancel_workflow_run(
     run_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:run")),
 ) -> Any:
     """Cancel a running workflow."""
@@ -1233,6 +1350,18 @@ async def cancel_workflow_run(
 
     orchestrator = WorkflowOrchestrator()
     cancelled = await orchestrator.cancel(str(run_id))
+
+    await AuditLogService.log(
+        user=current_user,
+        action="cancel_workflow_run",
+        resource_type="workflow_run",
+        resource_id=run_id,
+        resource_name=str(run_id),
+        operation="update",
+        status="success",
+        request=request,
+        metadata={"workflow_id": str(run.workflow_id), "cancelled": cancelled},
+    )
 
     if cancelled:
         return success(data={"cancelled": True}, msg_key="workflow_run_cancelled")
@@ -1368,6 +1497,7 @@ async def list_run_node_executions(
 @router.delete("/runs/{run_id}", response_model=Response[dict])
 async def delete_workflow_run(
     run_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:delete")),
 ) -> Any:
     """Delete a workflow run."""
@@ -1389,7 +1519,20 @@ async def delete_workflow_run(
     # Check write access through workflow
     await check_workflow_access(run.workflow_id, current_user, require_write=True)
 
+    workflow_id = run.workflow_id
     await run.delete()
+
+    await AuditLogService.log(
+        user=current_user,
+        action="delete_workflow_run",
+        resource_type="workflow_run",
+        resource_id=run_id,
+        resource_name=str(run_id),
+        operation="delete",
+        status="success",
+        request=request,
+        metadata={"workflow_id": str(workflow_id)},
+    )
 
     return success(data={"id": str(run_id)}, msg_key="workflow_run_deleted")
 
@@ -1459,6 +1602,7 @@ async def get_workflow_version(
 async def create_workflow_version(
     workflow_id: UUID,
     version_in: WorkflowVersionCreate,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:update")),
 ) -> Any:
     """Manually create a version snapshot of the current workflow state."""
@@ -1478,6 +1622,18 @@ async def create_workflow_version(
         created_by=current_user,
     )
 
+    await AuditLogService.log(
+        user=current_user,
+        action="create_workflow_version",
+        resource_type="workflow_version",
+        resource_id=workflow_version.id,
+        resource_name=workflow.name,
+        operation="create",
+        status="success",
+        request=request,
+        metadata={"workflow_id": str(workflow_id), "version": workflow.version},
+    )
+
     return success(
         data=WorkflowVersionOut.model_validate(workflow_version).model_dump(),
         msg_key="workflow_version_created",
@@ -1491,6 +1647,7 @@ async def restore_workflow_version(
     workflow_id: UUID,
     version: int,
     restore_in: WorkflowVersionRestore,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("workflow:update")),
 ) -> Any:
     """Restore a workflow to a specific version."""
@@ -1546,6 +1703,18 @@ async def restore_workflow_version(
 
     # Reload with relations
     workflow = await Workflow.get(id=workflow_id).prefetch_related("team", "created_by")
+
+    await AuditLogService.log(
+        user=current_user,
+        action="restore_workflow_version",
+        resource_type="workflow",
+        resource_id=workflow_id,
+        resource_name=workflow.name,
+        operation="update",
+        status="success",
+        request=request,
+        metadata={"workflow_id": str(workflow_id), "restored_from_version": version},
+    )
 
     return success(
         data=WorkflowOut.model_validate(workflow).model_dump(),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -370,7 +370,17 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         # 获取请求信息
         method = request.method
         url = str(request.url)
-        client_ip = request.client.host if request.client else "unknown"
+        # 优先从 X-Forwarded-For / X-Real-IP 获取真实客户端 IP（支持代理透传）
+        forwarded_for = request.headers.get("x-forwarded-for")
+        real_ip = request.headers.get("x-real-ip")
+        if forwarded_for:
+            client_ip = forwarded_for.split(",")[0].strip()
+        elif real_ip:
+            client_ip = real_ip.strip()
+        elif request.client:
+            client_ip = request.client.host
+        else:
+            client_ip = "unknown"
 
         # 检查是否是流式请求（SSE）
         is_stream_request = "/stream" in url or "/chat" in url


### PR DESCRIPTION
## Summary
- Add `AuditLogService.log` calls for backend write operations across agents, conversations, knowledge bases, memories, tools, workflows, uploads, team models, prompt generation, SSO, and embed workflow execution.
- Use `AuditLogService.get_client_ip` for login anomaly checks and read proxy headers in request logging so audit/security records capture the real client IP behind reverse proxies.
- Format the cherry-picked audit changes on a clean branch based on current `main`.

## Test plan
- [x] `uv run ruff format app/api/v1/admin/endpoints/sso.py app/api/v1/endpoints/agents.py app/api/v1/endpoints/conversations.py app/api/v1/endpoints/embed.py app/api/v1/endpoints/knowledge_bases.py app/api/v1/endpoints/login.py app/api/v1/endpoints/memories.py app/api/v1/endpoints/prompt_generator.py app/api/v1/endpoints/team_models.py app/api/v1/endpoints/tools.py app/api/v1/endpoints/upload.py app/api/v1/endpoints/workflows.py app/main.py`
- [x] `uv run ruff check app/api/v1/admin/endpoints/sso.py app/api/v1/endpoints/agents.py app/api/v1/endpoints/conversations.py app/api/v1/endpoints/embed.py app/api/v1/endpoints/knowledge_bases.py app/api/v1/endpoints/login.py app/api/v1/endpoints/memories.py app/api/v1/endpoints/prompt_generator.py app/api/v1/endpoints/team_models.py app/api/v1/endpoints/tools.py app/api/v1/endpoints/upload.py app/api/v1/endpoints/workflows.py app/main.py`