### PR TITLE
fix: align dashboard card spacing

### DIFF
--- a/frontend/app/(dashboard)/dashboard/_components/analytics-tab.tsx
+++ b/frontend/app/(dashboard)/dashboard/_components/analytics-tab.tsx
@@ -98,7 +98,7 @@ function StatCard({
   const displayValue = typeof value === 'number' ? formatter(animatedValue) : value
 
   return (
-    <Card className="hover:shadow-md transition-shadow">
+    <Card size="sm" className="hover:shadow-md transition-shadow">
       <CardContent className="py-0">
         <div className="flex items-start justify-between">
           <div className="space-y-2">
@@ -197,7 +197,7 @@ function AnalyticsTabComponent({ stats, workflowData, topAgentsData, isLoading, 
             />
 
             {/* System Stats */}
-            <Card>
+            <Card size="sm">
               <CardContent className="py-0">
                 <div className="space-y-3">
                   <div>

--- a/frontend/app/(dashboard)/dashboard/_components/models-tab.tsx
+++ b/frontend/app/(dashboard)/dashboard/_components/models-tab.tsx
@@ -93,7 +93,7 @@ function StatCard({
   const displayValue = typeof value === 'number' ? formatNumber(animatedValue) : value
 
   return (
-    <Card className="hover:shadow-md transition-shadow">
+    <Card size="sm" className="hover:shadow-md transition-shadow">
       <CardContent className="py-0">
         <div className="flex items-start justify-between">
           <div className="space-y-2">

--- a/frontend/app/(dashboard)/dashboard/_components/overview-tab.tsx
+++ b/frontend/app/(dashboard)/dashboard/_components/overview-tab.tsx
@@ -156,7 +156,7 @@ function StatCard({
   const displayValue = typeof value === 'number' ? formatNumber(animatedValue) : value
 
   return (
-    <Card className="hover:shadow-md transition-shadow">
+    <Card size="sm" className="hover:shadow-md transition-shadow">
       <CardContent className="py-0">
         <div className="flex items-start justify-between">
           <div className="space-y-2">
@@ -218,8 +218,8 @@ export function OverviewTab({ stats, trendsData, isLoading, totpStats }: Overvie
 
       {/* 2FA Stats */}
       {totpStats && (
-        <Card className="border-green-200 dark:border-green-900">
-          <CardContent className="pt-6">
+        <Card size="sm" className="border-green-200 dark:border-green-900">
+          <CardContent className="py-0">
             <div className="flex items-start justify-between">
               <div className="space-y-2">
                 <p className="text-sm font-medium text-muted-foreground">{t('stats.twoFactorAuth')}</p>
@@ -250,8 +250,8 @@ export function OverviewTab({ stats, trendsData, isLoading, totpStats }: Overvie
               </CardTitle>
               <CardDescription className="text-xs">{t('userGrowthDesc')}</CardDescription>
             </CardHeader>
-            <CardContent className="flex-1 pt-0">
-              <div className="h-[180px] min-w-0 w-full">
+            <CardContent className="flex flex-1 flex-col pt-0">
+              <div className="min-h-[180px] min-w-0 flex-1 w-full">
                 <ResponsiveContainer width="100%" height="100%">
                   <AreaChart data={trendsData}>
                   <defs>
@@ -339,8 +339,8 @@ export function OverviewTab({ stats, trendsData, isLoading, totpStats }: Overvie
               </CardTitle>
               <CardDescription className="text-xs">{t('activityTrendDesc')}</CardDescription>
             </CardHeader>
-            <CardContent className="flex-1 pt-0">
-              <div className="h-[180px] min-w-0 w-full">
+            <CardContent className="flex flex-1 flex-col pt-0">
+              <div className="min-h-[180px] min-w-0 flex-1 w-full">
                 <ResponsiveContainer width="100%" height="100%">
                   <AreaChart data={trendsData}>
                   <defs>

--- a/frontend/app/(dashboard)/dashboard/observability/_components/observability-panels.tsx
+++ b/frontend/app/(dashboard)/dashboard/observability/_components/observability-panels.tsx
@@ -35,6 +35,7 @@ import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '
 import { Skeleton } from '@/components/ui/skeleton'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { CHART_COLOR_ORDER, CHART_GRID_COLOR, CHART_TOOLTIP_STYLE } from '@/lib/chart-theme'
+import { cn } from '@/lib/utils'
 import {
   observabilityApi,
   type AgentDetailResponse,
@@ -159,7 +160,8 @@ export function OverviewPanel({ overview, throughput }: OverviewPanelProps) {
         </Card>
 
         <ObservabilityChartCard className="lg:col-span-7" title={t('charts.requestTrend')} description={t('charts.requestTrendDesc')} empty={!throughput?.buckets.length}>
-          <ResponsiveContainer width="100%" height={310}>
+          <div className="min-h-[310px] flex-1">
+            <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={throughput?.buckets ?? []}>
               <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
               <XAxis dataKey="bucket" tickFormatter={formatBucket} minTickGap={24} />
@@ -170,6 +172,7 @@ export function OverviewPanel({ overview, throughput }: OverviewPanelProps) {
               <Area name={t('overview.workflowRuns')} type="monotone" dataKey="workflow_runs" stackId="requests" stroke={CHART_COLOR_ORDER[1]} fill={CHART_COLOR_ORDER[1]} fillOpacity={0.35} />
             </AreaChart>
           </ResponsiveContainer>
+          </div>
         </ObservabilityChartCard>
       </div>
 
@@ -211,7 +214,8 @@ export function HealthPanel({ health, trend, slowQueries, workers }: HealthPanel
     <div className="space-y-6">
       <div className="grid gap-6 lg:grid-cols-12">
         <ObservabilityChartCard className="lg:col-span-8" title={t('health.resourceUsage')} description={t('charts.systemTrendDesc')} empty={!trend?.items.length}>
-          <ResponsiveContainer width="100%" height={320}>
+          <div className="min-h-[320px] flex-1">
+            <ResponsiveContainer width="100%" height="100%">
             <LineChart data={trend?.items ?? []}>
               <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
               <XAxis dataKey="generated_at" tickFormatter={formatBucket} minTickGap={24} />
@@ -222,6 +226,7 @@ export function HealthPanel({ health, trend, slowQueries, workers }: HealthPanel
               <Line name={t('health.memory')} type="monotone" dataKey="memory_percent" stroke={CHART_COLOR_ORDER[1]} strokeWidth={2} dot={false} />
             </LineChart>
           </ResponsiveContainer>
+          </div>
         </ObservabilityChartCard>
 
         <Card className="lg:col-span-4">
@@ -426,7 +431,8 @@ export function ThroughputPanel({ throughput, tokens }: { throughput: Throughput
       </div>
       <div className="grid gap-6 lg:grid-cols-12">
         <ObservabilityChartCard className="lg:col-span-8" title={t('throughput.requestVolume')} description={t('charts.throughputTrendDesc')} empty={!throughput.buckets.length}>
-          <ResponsiveContainer width="100%" height={320}>
+          <div className="min-h-[320px] flex-1">
+            <ResponsiveContainer width="100%" height="100%">
             <BarChart data={throughput.buckets}>
               <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
               <XAxis dataKey="bucket" tickFormatter={formatBucket} minTickGap={24} />
@@ -437,6 +443,7 @@ export function ThroughputPanel({ throughput, tokens }: { throughput: Throughput
               <Bar name={t('overview.workflowRuns')} dataKey="workflow_runs" stackId="requests" fill={CHART_COLOR_ORDER[1]} radius={[4, 4, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
+          </div>
         </ObservabilityChartCard>
         <Card className="lg:col-span-4">
           <CardHeader>
@@ -524,7 +531,8 @@ function DetailTrendChart({ data, countKey }: { data: ObservabilityTrendPoint[];
   const t = useTranslations('dashboard.observability')
   return (
     <ObservabilityChartCard title={t('details.performanceTrend')} description={t('details.percentiles')} empty={!data.length}>
-      <ResponsiveContainer width="100%" height={260}>
+      <div className="min-h-[260px] flex-1">
+        <ResponsiveContainer width="100%" height="100%">
         <LineChart data={data}>
           <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
           <XAxis dataKey="bucket" tickFormatter={formatBucket} minTickGap={24} />
@@ -535,6 +543,7 @@ function DetailTrendChart({ data, countKey }: { data: ObservabilityTrendPoint[];
           <Line name={t('common.count')} type="monotone" dataKey={countKey} stroke={CHART_COLOR_ORDER[1]} dot={false} />
         </LineChart>
       </ResponsiveContainer>
+      </div>
     </ObservabilityChartCard>
   )
 }
@@ -702,13 +711,13 @@ function ConsoleMetric({ label, value, description, tone = 'neutral' }: { label:
 
 function ObservabilityChartCard({ title, description, empty, className, children }: { title: string; description?: string; empty?: boolean; className?: string; children: React.ReactNode }) {
   return (
-    <Card className={className}>
+    <Card className={cn('flex h-full flex-col', className)}>
       <CardHeader>
         <CardTitle>{title}</CardTitle>
         {description && <CardDescription>{description}</CardDescription>}
       </CardHeader>
-      <CardContent>
-        {empty ? <ObservabilityEmpty /> : children}
+      <CardContent className="flex flex-1 flex-col">
+        {empty ? <div className="flex flex-1 items-center justify-center"><ObservabilityEmpty /></div> : children}
       </CardContent>
     </Card>
   )

--- a/frontend/components/dashboard/agent-performance-chart.tsx
+++ b/frontend/components/dashboard/agent-performance-chart.tsx
@@ -125,7 +125,7 @@ function AgentPerformanceChartComponent({ data, metric, onMetricChange, isLoadin
   }
 
   return (
-    <Card>
+    <Card className="flex h-full flex-col">
       <CardHeader>
         <div className="flex items-center justify-between">
           <div>
@@ -147,8 +147,9 @@ function AgentPerformanceChartComponent({ data, metric, onMetricChange, isLoadin
           </Select>
         </div>
       </CardHeader>
-      <CardContent>
-        <ResponsiveContainer width="100%" height={300}>
+      <CardContent className="flex flex-1 flex-col">
+        <div className="min-h-[300px] flex-1">
+          <ResponsiveContainer width="100%" height="100%">
           <BarChart
             data={data}
             margin={{ top: 5, right: 10, left: 10, bottom: 5 }}
@@ -199,7 +200,8 @@ function AgentPerformanceChartComponent({ data, metric, onMetricChange, isLoadin
               ))}
             </Bar>
           </BarChart>
-        </ResponsiveContainer>
+          </ResponsiveContainer>
+        </div>
       </CardContent>
     </Card>
   )

--- a/frontend/components/dashboard/model-distribution-chart.tsx
+++ b/frontend/components/dashboard/model-distribution-chart.tsx
@@ -63,7 +63,7 @@ export function ModelDistributionChart({ data, isLoading }: ModelDistributionCha
   }
 
   return (
-    <Card className="h-full">
+    <Card className="flex h-full flex-col">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Cpu className="h-5 w-5" />
@@ -71,8 +71,9 @@ export function ModelDistributionChart({ data, isLoading }: ModelDistributionCha
         </CardTitle>
         <CardDescription>{t('charts.modelDistributionDesc')}</CardDescription>
       </CardHeader>
-      <CardContent>
-        <ResponsiveContainer width="100%" height={300}>
+      <CardContent className="flex flex-1 flex-col">
+        <div className="min-h-[300px] flex-1">
+          <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie
               data={data as Array<ModelDistribution & Record<string, unknown>>}
@@ -110,7 +111,8 @@ export function ModelDistributionChart({ data, isLoading }: ModelDistributionCha
               }}
             />
           </PieChart>
-        </ResponsiveContainer>
+          </ResponsiveContainer>
+        </div>
       </CardContent>
     </Card>
   )

--- a/frontend/components/dashboard/team-token-usage-chart.tsx
+++ b/frontend/components/dashboard/team-token-usage-chart.tsx
@@ -73,7 +73,7 @@ export function TeamTokenUsageChart({ data, isLoading }: TeamTokenUsageChartProp
   }
 
   return (
-    <Card className="h-full">
+    <Card className="flex h-full flex-col">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Building2 className="h-5 w-5" />
@@ -81,8 +81,9 @@ export function TeamTokenUsageChart({ data, isLoading }: TeamTokenUsageChartProp
         </CardTitle>
         <CardDescription>{t('models.teamRankingDesc')}</CardDescription>
       </CardHeader>
-      <CardContent>
-        <ResponsiveContainer width="100%" height={300}>
+      <CardContent className="flex flex-1 flex-col">
+        <div className="min-h-[300px] flex-1">
+          <ResponsiveContainer width="100%" height="100%">
           <BarChart
             data={filteredData}
             margin={{ top: 5, right: 10, left: 10, bottom: 5 }}
@@ -127,7 +128,8 @@ export function TeamTokenUsageChart({ data, isLoading }: TeamTokenUsageChartProp
               ))}
             </Bar>
           </BarChart>
-        </ResponsiveContainer>
+          </ResponsiveContainer>
+        </div>
       </CardContent>
     </Card>
   )

--- a/frontend/components/dashboard/token-trend-chart.tsx
+++ b/frontend/components/dashboard/token-trend-chart.tsx
@@ -67,7 +67,7 @@ export function TokenTrendChart({ data, isLoading }: TokenTrendChartProps) {
   }
 
   return (
-    <Card className="h-full">
+    <Card className="flex h-full flex-col">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <TrendingUp className="h-5 w-5" />
@@ -75,8 +75,9 @@ export function TokenTrendChart({ data, isLoading }: TokenTrendChartProps) {
         </CardTitle>
         <CardDescription>{t('models.tokenTrendDesc')}</CardDescription>
       </CardHeader>
-      <CardContent>
-        <ResponsiveContainer width="100%" height={300}>
+      <CardContent className="flex flex-1 flex-col">
+        <div className="min-h-[300px] flex-1">
+          <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={data}>
             <defs>
               <linearGradient id="colorTokens" x1="0" y1="0" x2="0" y2="1">
@@ -121,7 +122,8 @@ export function TokenTrendChart({ data, isLoading }: TokenTrendChartProps) {
               fill="url(#colorTokens)"
             />
           </AreaChart>
-        </ResponsiveContainer>
+          </ResponsiveContainer>
+        </div>
       </CardContent>
     </Card>
   )

--- a/frontend/components/dashboard/top-agents-chart.tsx
+++ b/frontend/components/dashboard/top-agents-chart.tsx
@@ -92,7 +92,7 @@ export function TopAgentsChart({ data, metric, isLoading }: TopAgentsChartProps)
   }
 
   return (
-    <Card className="h-full">
+    <Card className="flex h-full flex-col">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Bot className="h-5 w-5" />
@@ -100,8 +100,9 @@ export function TopAgentsChart({ data, metric, isLoading }: TopAgentsChartProps)
         </CardTitle>
         <CardDescription>{t('charts.topAgentsDesc')}</CardDescription>
       </CardHeader>
-      <CardContent className="py-0">
-        <ResponsiveContainer width="100%" height={400}>
+      <CardContent className="flex flex-1 flex-col py-0">
+        <div className="min-h-[400px] flex-1">
+          <ResponsiveContainer width="100%" height="100%">
           <BarChart
             data={filteredData}
             margin={{ top: 5, right: 10, left: 10, bottom: 5 }}
@@ -152,7 +153,8 @@ export function TopAgentsChart({ data, metric, isLoading }: TopAgentsChartProps)
               ))}
             </Bar>
           </BarChart>
-        </ResponsiveContainer>
+          </ResponsiveContainer>
+        </div>
       </CardContent>
     </Card>
   )

--- a/frontend/components/dashboard/workflow-status-chart.tsx
+++ b/frontend/components/dashboard/workflow-status-chart.tsx
@@ -76,7 +76,7 @@ function WorkflowStatusChartComponent({ data, isLoading }: WorkflowStatusChartPr
   }
 
   return (
-    <Card>
+    <Card className="flex h-full flex-col">
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2">
           <CheckCircle2 className="h-5 w-5" />
@@ -84,8 +84,9 @@ function WorkflowStatusChartComponent({ data, isLoading }: WorkflowStatusChartPr
         </CardTitle>
         <CardDescription>{t('analytics.workflowStatusDesc')}</CardDescription>
       </CardHeader>
-      <CardContent className="pt-0">
-        <ResponsiveContainer width="100%" height={300}>
+      <CardContent className="flex flex-1 flex-col pt-0">
+        <div className="min-h-[300px] flex-1">
+          <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie
               data={data}
@@ -124,7 +125,8 @@ function WorkflowStatusChartComponent({ data, isLoading }: WorkflowStatusChartPr
               }}
             />
           </PieChart>
-        </ResponsiveContainer>
+          </ResponsiveContainer>
+        </div>
       </CardContent>
     </Card>
   )

--- a/frontend/components/dashboard/workflow-trigger-chart.tsx
+++ b/frontend/components/dashboard/workflow-trigger-chart.tsx
@@ -76,7 +76,7 @@ function WorkflowTriggerChartComponent({ data, isLoading }: WorkflowTriggerChart
   }
 
   return (
-    <Card>
+    <Card className="flex h-full flex-col">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Zap className="h-5 w-5" />
@@ -84,8 +84,9 @@ function WorkflowTriggerChartComponent({ data, isLoading }: WorkflowTriggerChart
         </CardTitle>
         <CardDescription>{t('analytics.workflowTriggersDesc')}</CardDescription>
       </CardHeader>
-      <CardContent>
-        <ResponsiveContainer width="100%" height={300}>
+      <CardContent className="flex flex-1 flex-col">
+        <div className="min-h-[300px] flex-1">
+          <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie
               data={data}
@@ -124,7 +125,8 @@ function WorkflowTriggerChartComponent({ data, isLoading }: WorkflowTriggerChart
               }}
             />
           </PieChart>
-        </ResponsiveContainer>
+          </ResponsiveContainer>
+        </div>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## Summary\n- Normalize dashboard stat card spacing with existing  token\n- Make dashboard and observability chart cards fill available height instead of using fixed chart containers\n- Keep non-chart list/detail cards unchanged\n\n## Validation\n- bun run lint\n- bun run build\n- git diff --check