### PR TITLE
fix: repair tool credentials and context compression reuse

### DIFF
--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -59,6 +59,8 @@ from app.core.timezone import now_utc
 from app.services.chat_context import (
     build_model_messages,
     get_context_compression_config,
+    extract_macro_summary_text,
+    persist_compacted_context_snapshot,
     prepare_model_context,
     retry_prepare_model_context,
 )
@@ -1434,6 +1436,14 @@ async def chat(
             conversation.id,
             [*branch_prefix, user_msg, assistant_msg],
         )
+        macro_summary = extract_macro_summary_text(prepared_context.messages)
+        if macro_summary:
+            await persist_compacted_context_snapshot(
+                conversation=conversation,
+                source_message_id=assistant_msg.id,
+                summary_text=macro_summary,
+                model_id=model_id,
+            )
         enqueue_session_memory_extraction(agent, conversation, assistant_msg)
 
         return success(
@@ -2370,6 +2380,16 @@ async def chat_stream(
                         conversation.id,
                         [*branch_prefix, user_msg, assistant_msg],
                     )
+                    macro_summary = extract_macro_summary_text(
+                        final_prepared_context.messages
+                    )
+                    if macro_summary:
+                        await persist_compacted_context_snapshot(
+                            conversation=conversation,
+                            source_message_id=assistant_msg.id,
+                            summary_text=macro_summary,
+                            model_id=model_id,
+                        )
                     enqueue_session_memory_extraction(
                         agent, conversation, assistant_msg
                     )
@@ -3544,6 +3564,16 @@ async def regenerate_message(
                     await stale_session_memory_if_source_outside_active_branch(
                         conversation.id
                     )
+                    macro_summary = extract_macro_summary_text(
+                        final_prepared_context.messages
+                    )
+                    if macro_summary:
+                        await persist_compacted_context_snapshot(
+                            conversation=conversation,
+                            source_message_id=new_message.id,
+                            summary_text=macro_summary,
+                            model_id=model_id,
+                        )
                     enqueue_session_memory_extraction(agent, conversation, new_message)
 
                     # Update agent and team stats for regenerated message

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -502,6 +502,34 @@ def enqueue_session_memory_extraction(
         )
 
 
+async def persist_macro_summary_best_effort(
+    *,
+    conversation: Conversation,
+    source_message_id: UUID,
+    messages: list[Any],
+    model_id: str | None,
+) -> None:
+    """Best-effort persistence for prompt-derived macro compaction summaries."""
+    macro_summary = extract_macro_summary_text(messages)
+    if not macro_summary:
+        return
+    try:
+        await persist_compacted_context_snapshot(
+            conversation=conversation,
+            source_message_id=source_message_id,
+            summary_text=macro_summary,
+            model_id=model_id,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to persist compacted context snapshot for conversation %s "
+            "message %s",
+            conversation.id,
+            source_message_id,
+            exc_info=True,
+        )
+
+
 def get_round_terminal_status(
     *,
     completed: bool,
@@ -1436,14 +1464,12 @@ async def chat(
             conversation.id,
             [*branch_prefix, user_msg, assistant_msg],
         )
-        macro_summary = extract_macro_summary_text(prepared_context.messages)
-        if macro_summary:
-            await persist_compacted_context_snapshot(
-                conversation=conversation,
-                source_message_id=assistant_msg.id,
-                summary_text=macro_summary,
-                model_id=model_id,
-            )
+        await persist_macro_summary_best_effort(
+            conversation=conversation,
+            source_message_id=assistant_msg.id,
+            messages=prepared_context.messages,
+            model_id=model_id,
+        )
         enqueue_session_memory_extraction(agent, conversation, assistant_msg)
 
         return success(
@@ -2380,16 +2406,12 @@ async def chat_stream(
                         conversation.id,
                         [*branch_prefix, user_msg, assistant_msg],
                     )
-                    macro_summary = extract_macro_summary_text(
-                        final_prepared_context.messages
+                    await persist_macro_summary_best_effort(
+                        conversation=conversation,
+                        source_message_id=assistant_msg.id,
+                        messages=final_prepared_context.messages,
+                        model_id=model_id,
                     )
-                    if macro_summary:
-                        await persist_compacted_context_snapshot(
-                            conversation=conversation,
-                            source_message_id=assistant_msg.id,
-                            summary_text=macro_summary,
-                            model_id=model_id,
-                        )
                     enqueue_session_memory_extraction(
                         agent, conversation, assistant_msg
                     )
@@ -3564,16 +3586,12 @@ async def regenerate_message(
                     await stale_session_memory_if_source_outside_active_branch(
                         conversation.id
                     )
-                    macro_summary = extract_macro_summary_text(
-                        final_prepared_context.messages
+                    await persist_macro_summary_best_effort(
+                        conversation=conversation,
+                        source_message_id=new_message.id,
+                        messages=final_prepared_context.messages,
+                        model_id=model_id,
                     )
-                    if macro_summary:
-                        await persist_compacted_context_snapshot(
-                            conversation=conversation,
-                            source_message_id=new_message.id,
-                            summary_text=macro_summary,
-                            model_id=model_id,
-                        )
                     enqueue_session_memory_extraction(agent, conversation, new_message)
 
                     # Update agent and team stats for regenerated message

--- a/backend/app/api/v1/endpoints/chat_tools.py
+++ b/backend/app/api/v1/endpoints/chat_tools.py
@@ -360,19 +360,25 @@ def _tool_accepts_credentials(handler: Any) -> bool:
     return "credentials" in inspect.signature(handler).parameters
 
 
-async def _get_builtin_tool_credentials(tool_name: str, agent: "Agent | None") -> dict[str, str]:
+async def _get_builtin_tool_credentials(
+    tool_name: str, agent: "Agent | None"
+) -> dict[str, str]:
     from app.models.tool_config import ToolConfig
 
     credentials: dict[str, str] = {}
     team_id = getattr(agent, "team_id", None) if agent else None
 
     if team_id:
-        tool_config = await ToolConfig.filter(tool_name=tool_name, team_id=team_id).first()
+        tool_config = await ToolConfig.filter(
+            tool_name=tool_name, team_id=team_id
+        ).first()
         if tool_config:
             credentials = tool_config.credentials or {}
 
     if not credentials:
-        global_config = await ToolConfig.filter(tool_name=tool_name, team_id=None).first()
+        global_config = await ToolConfig.filter(
+            tool_name=tool_name, team_id=None
+        ).first()
         if global_config:
             credentials = global_config.credentials or {}
 

--- a/backend/app/api/v1/endpoints/chat_tools.py
+++ b/backend/app/api/v1/endpoints/chat_tools.py
@@ -326,7 +326,11 @@ async def execute_tool_call(
     if (tool_info and tool_info.handler) or sandbox_tool_class:
         try:
             credentials = None
-            if tool_info and _tool_accepts_credentials(tool_info.handler):
+            if (
+                tool_info
+                and tool_info.handler
+                and _tool_accepts_credentials(tool_info.handler)
+            ):
                 credentials = await _get_builtin_tool_credentials(tool_name, agent)
             return await tool_registry.execute(
                 tool_name,

--- a/backend/app/api/v1/endpoints/chat_tools.py
+++ b/backend/app/api/v1/endpoints/chat_tools.py
@@ -325,9 +325,13 @@ async def execute_tool_call(
     sandbox_tool_class = tool_registry.get_sandbox_tool_class(tool_name)
     if (tool_info and tool_info.handler) or sandbox_tool_class:
         try:
+            credentials = None
+            if tool_info and _tool_accepts_credentials(tool_info.handler):
+                credentials = await _get_builtin_tool_credentials(tool_name, agent)
             return await tool_registry.execute(
                 tool_name,
                 arguments,
+                credentials=credentials,
                 session_id=session_id,
                 agent=agent,
                 user=user,
@@ -348,6 +352,37 @@ async def execute_tool_call(
     return json.dumps(
         {"error": t("tool_not_found", tool_name=tool_name)}, ensure_ascii=False
     )
+
+
+def _tool_accepts_credentials(handler: Any) -> bool:
+    import inspect
+
+    return "credentials" in inspect.signature(handler).parameters
+
+
+async def _get_builtin_tool_credentials(tool_name: str, agent: "Agent | None") -> dict[str, str]:
+    from app.models.tool_config import ToolConfig
+
+    credentials: dict[str, str] = {}
+    team_id = getattr(agent, "team_id", None) if agent else None
+
+    if team_id:
+        tool_config = await ToolConfig.filter(tool_name=tool_name, team_id=team_id).first()
+        if tool_config:
+            credentials = tool_config.credentials or {}
+
+    if not credentials:
+        global_config = await ToolConfig.filter(tool_name=tool_name, team_id=None).first()
+        if global_config:
+            credentials = global_config.credentials or {}
+
+    if not credentials and tool_name == "web_search":
+        from app.core.config import settings
+
+        if settings.TAVILY_API_KEY:
+            credentials["TAVILY_API_KEY"] = settings.TAVILY_API_KEY
+
+    return credentials
 
 
 async def _execute_code_tool(

--- a/backend/app/services/chat_context.py
+++ b/backend/app/services/chat_context.py
@@ -1445,6 +1445,9 @@ def _summarize_block(
     return " ; ".join(items)
 
 
+MACRO_SUMMARY_PREFIX = "Compressed earlier conversation summary:"
+
+
 def _build_macro_summary_message(
     blocks: Sequence[Sequence[Message]],
     *,
@@ -1454,7 +1457,7 @@ def _build_macro_summary_message(
     if not blocks:
         return None
 
-    lines = ["Compressed earlier conversation summary:"]
+    lines = [MACRO_SUMMARY_PREFIX]
     for index, block in enumerate(blocks, start=1):
         lines.append(
             f"- Turn {index}: {_summarize_block(block, block_summary_chars=block_summary_chars)}"
@@ -1707,6 +1710,53 @@ async def _apply_micro_compaction(
         ),
         session_memory_protected_indexes,
     )
+
+
+def extract_macro_summary_text(messages: Sequence[Message]) -> str | None:
+    for message in messages:
+        if message.role != MessageRole.ASSISTANT:
+            continue
+        content = _stringify_content(message.content).strip()
+        if content.startswith(MACRO_SUMMARY_PREFIX):
+            return content
+    return None
+
+
+async def persist_compacted_context_snapshot(
+    *,
+    conversation: Conversation,
+    source_message_id: UUID,
+    summary_text: str,
+    model_id: str | None = None,
+) -> None:
+    from app.core.timezone import now_utc
+    from app.llm.token_counter import count_tokens
+    from app.models.agent import (
+        ConversationSessionMemory,
+        ConversationSessionMemoryStatus,
+    )
+
+    if not summary_text.strip():
+        return
+
+    snapshot = await ConversationSessionMemory.filter(
+        conversation_id=conversation.id,
+    ).first()
+    if snapshot is None:
+        snapshot = await ConversationSessionMemory.create(
+            conversation_id=conversation.id,
+        )
+
+    snapshot.source_message_id = source_message_id
+    snapshot.status = ConversationSessionMemoryStatus.READY
+    snapshot.summary_text = summary_text
+    snapshot.snapshot_payload = {"overview": summary_text}
+    snapshot.token_estimate = count_tokens(summary_text, model_id=model_id or "gpt-4")
+    snapshot.extractor_model = model_id
+    snapshot.failure_count = 0
+    snapshot.last_error = None  # type: ignore[assignment]
+    snapshot.last_extracted_at = now_utc()
+    await snapshot.save()
 
 
 def _apply_budget_compaction(
@@ -1963,15 +2013,34 @@ async def prepare_model_context(
         user=user,
         protected_round_id=protected_round_id,
     )
-    untrimmed_tokens = _estimate_message_tokens(
-        untrimmed_messages,
-        model_id=model_id,
-        provider=provider,
-    )
 
     compression_enabled = bool(compression_config.get("enabled", True))
     preflight_guard_enabled = bool(
         compression_config.get("preflight_guard_enabled", True)
+    )
+    if compression_enabled and preflight_guard_enabled:
+        (
+            baseline_messages,
+            baseline_session_memory_compacted,
+            baseline_protected_indexes,
+        ) = await _apply_session_memory_compaction(
+            untrimmed_messages,
+            conversation=conversation,
+            model_id=model_id,
+            provider=provider,
+            recent_raw_turns=configured_recent_raw_turns,
+            recent_tool_turns=configured_recent_tool_turns,
+            protected_indexes=untrimmed_protected_indexes,
+            before_created_at=history_before_message_created_at,
+        )
+        if baseline_session_memory_compacted:
+            untrimmed_messages = baseline_messages
+            untrimmed_protected_indexes = baseline_protected_indexes
+
+    untrimmed_tokens = _estimate_message_tokens(
+        untrimmed_messages,
+        model_id=model_id,
+        provider=provider,
     )
     initial_pressure = _assess_context_pressure(
         before_tokens=untrimmed_tokens,

--- a/backend/app/services/chat_context.py
+++ b/backend/app/services/chat_context.py
@@ -1735,6 +1735,7 @@ async def persist_compacted_context_snapshot(
         ConversationSessionMemory,
         ConversationSessionMemoryStatus,
     )
+    from app.services.session_memory import MACRO_COMPACTION_ORIGIN
 
     if not summary_text.strip():
         return
@@ -1750,7 +1751,10 @@ async def persist_compacted_context_snapshot(
     snapshot.source_message_id = source_message_id
     snapshot.status = ConversationSessionMemoryStatus.READY
     snapshot.summary_text = summary_text
-    snapshot.snapshot_payload = {"overview": summary_text}
+    snapshot.snapshot_payload = {
+        "overview": summary_text,
+        "origin": MACRO_COMPACTION_ORIGIN,
+    }
     snapshot.token_estimate = count_tokens(summary_text, model_id=model_id or "gpt-4")
     snapshot.extractor_model = model_id
     snapshot.failure_count = 0
@@ -2018,6 +2022,14 @@ async def prepare_model_context(
     preflight_guard_enabled = bool(
         compression_config.get("preflight_guard_enabled", True)
     )
+    session_memory_compaction_kwargs = {
+        "conversation": conversation,
+        "model_id": model_id,
+        "provider": provider,
+        "recent_raw_turns": configured_recent_raw_turns,
+        "recent_tool_turns": configured_recent_tool_turns,
+        "before_created_at": history_before_message_created_at,
+    }
     if compression_enabled and preflight_guard_enabled:
         (
             baseline_messages,
@@ -2025,13 +2037,8 @@ async def prepare_model_context(
             baseline_protected_indexes,
         ) = await _apply_session_memory_compaction(
             untrimmed_messages,
-            conversation=conversation,
-            model_id=model_id,
-            provider=provider,
-            recent_raw_turns=configured_recent_raw_turns,
-            recent_tool_turns=configured_recent_tool_turns,
             protected_indexes=untrimmed_protected_indexes,
-            before_created_at=history_before_message_created_at,
+            **session_memory_compaction_kwargs,
         )
         if baseline_session_memory_compacted:
             untrimmed_messages = baseline_messages
@@ -2106,6 +2113,15 @@ async def prepare_model_context(
             tool_timeouts=tool_timeouts,
             user=user,
             protected_round_id=protected_round_id,
+        )
+        (
+            base_messages,
+            _,
+            base_protected_indexes,
+        ) = await _apply_session_memory_compaction(
+            base_messages,
+            protected_indexes=base_protected_indexes,
+            **session_memory_compaction_kwargs,
         )
 
     base_tokens = _estimate_message_tokens(

--- a/backend/app/services/session_memory.py
+++ b/backend/app/services/session_memory.py
@@ -34,6 +34,20 @@ MAX_TRANSCRIPT_CHARS_PER_MESSAGE = 1200
 MAX_LIST_ITEMS = 6
 MAX_LIST_ITEM_CHARS = 240
 MAX_OVERVIEW_CHARS = 600
+MACRO_COMPACTION_ORIGIN = "macro_compaction"
+
+
+def _should_skip_already_extracted_snapshot(
+    snapshot: ConversationSessionMemory | None,
+    source_uuid: UUID,
+) -> bool:
+    if not snapshot or snapshot.source_message_id != source_uuid:
+        return False
+    snapshot_origin = (snapshot.snapshot_payload or {}).get("origin")
+    return (
+        snapshot.status == ConversationSessionMemoryStatus.READY
+        and snapshot_origin != MACRO_COMPACTION_ORIGIN
+    )
 
 
 async def get_ready_session_memory(
@@ -140,9 +154,8 @@ async def extract_session_memory_for_message(
     snapshot = await ConversationSessionMemory.filter(
         conversation_id=conversation_uuid
     ).first()
-    if snapshot and snapshot.source_message_id == source_uuid:
-        if snapshot.status == ConversationSessionMemoryStatus.READY:
-            return {"status": "skipped", "reason": "already_extracted"}
+    if _should_skip_already_extracted_snapshot(snapshot, source_uuid):
+        return {"status": "skipped", "reason": "already_extracted"}
 
     if snapshot and snapshot.source_message_id:
         existing_source = await Message.filter(

--- a/backend/tests/services/test_chat_context_compression.py
+++ b/backend/tests/services/test_chat_context_compression.py
@@ -1,0 +1,132 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.llm.types import MessageRole
+from app.models.agent import MessageRole as ConversationMessageRole
+from app.services import chat_context
+
+
+@pytest.mark.anyio
+async def test_prepare_model_context_reuses_session_memory_before_pressure_check(
+    monkeypatch,
+):
+    conversation_id = uuid4()
+    current_user_message_id = uuid4()
+    snapshot_source_id = uuid4()
+
+    agent = SimpleNamespace(
+        id=uuid4(),
+        system_prompt="",
+        enable_memory=False,
+        enable_user_input_request=False,
+        tools_config=[],
+        context_compression_config={
+            "recent_raw_turns": 1,
+            "recent_tool_turns": 0,
+            "output_token_reserve": 50,
+            "safety_margin_tokens": 50,
+        },
+    )
+    conversation = SimpleNamespace(id=conversation_id, variables={})
+
+    old_text = "OLD_RAW_HISTORY " * 100
+    recent_text = "recent turn"
+    history = [
+        SimpleNamespace(
+            id=uuid4(),
+            role=ConversationMessageRole.USER,
+            content=old_text,
+            file_urls=None,
+            round_id=None,
+        ),
+        SimpleNamespace(
+            id=uuid4(),
+            role=ConversationMessageRole.ASSISTANT,
+            content="old answer",
+            reasoning_content=None,
+            tool_calls=None,
+            round_id=None,
+        ),
+        SimpleNamespace(
+            id=uuid4(),
+            role=ConversationMessageRole.USER,
+            content=recent_text,
+            file_urls=None,
+            round_id=None,
+        ),
+        SimpleNamespace(
+            id=snapshot_source_id,
+            role=ConversationMessageRole.ASSISTANT,
+            content="recent answer",
+            reasoning_content=None,
+            tool_calls=None,
+            round_id=None,
+        ),
+        SimpleNamespace(
+            id=current_user_message_id,
+            role=ConversationMessageRole.USER,
+            content="continue",
+            file_urls=None,
+            round_id=None,
+        ),
+    ]
+
+    async def fake_get_visible_conversation_messages(*args, **kwargs):
+        return history
+
+    async def fake_get_ready_session_memory(conversation_id):
+        return SimpleNamespace(
+            summary_text="COMPRESSED_SUMMARY",
+            source_message_id=snapshot_source_id,
+        )
+
+    async def fake_is_message_on_active_branch(*args, **kwargs):
+        return True
+
+    monkeypatch.setattr(
+        chat_context,
+        "get_visible_conversation_messages",
+        fake_get_visible_conversation_messages,
+    )
+    monkeypatch.setattr(
+        chat_context,
+        "is_message_on_active_branch",
+        fake_is_message_on_active_branch,
+    )
+    monkeypatch.setattr(
+        "app.services.session_memory.get_ready_session_memory",
+        fake_get_ready_session_memory,
+    )
+    monkeypatch.setattr(
+        chat_context,
+        "count_message_tokens",
+        lambda payload, model_id, provider=None: sum(
+            len(str(item.get("content", ""))) for item in payload
+        ),
+    )
+
+    prepared = await chat_context.prepare_model_context(
+        agent=agent,
+        conversation=conversation,
+        user_message="continue",
+        model_id="gpt-4",
+        model_context_limit=2000,
+        model_max_output_tokens=50,
+        provider=None,
+        current_user_message_id=current_user_message_id,
+        include_current_user_message=True,
+    )
+
+    contents = [message.content for message in prepared.messages]
+
+    assert "COMPRESSED_SUMMARY" in contents
+    assert not any("OLD_RAW_HISTORY" in str(content) for content in contents)
+    assert "continue" in contents
+    assert prepared.compression.before_tokens < 2000
+    assert prepared.compression.pressure_level == "normal"
+    assert all(
+        message.role in {MessageRole.SYSTEM, MessageRole.ASSISTANT, MessageRole.USER}
+        for message in prepared.messages
+    )

--- a/backend/tests/services/test_chat_context_compression.py
+++ b/backend/tests/services/test_chat_context_compression.py
@@ -137,11 +137,12 @@ async def test_session_memory_compaction_runs_again_after_file_trim(monkeypatch)
     revert to the original raw history.
     """
 
-    rebuild_calls = {"count": 0}
+    call_order = {"index": 0}
+    file_rebuild_calls = {"count": 0}
     session_memory_calls: list[int] = []
 
     async def fake_rebuild(*args, **kwargs):
-        rebuild_calls["count"] += 1
+        file_rebuild_calls["count"] += 1
         rebuilt = [
             Message(role=MessageRole.SYSTEM, content="SYSTEM"),
             Message(
@@ -153,13 +154,21 @@ async def test_session_memory_compaction_runs_again_after_file_trim(monkeypatch)
         return rebuilt, {len(rebuilt) - 1}
 
     def _apply_session_memory(messages, **kwargs):
-        phase = rebuild_calls["count"]
+        # First call = preflight (phase 2). Every later call has phase > 2
+        # and can only be produced after fake_rebuild has run, which is the
+        # exact "runs again after rebuild" contract the test enforces.
+        call_order["index"] += 1
+        phase = 1 + call_order["index"]
         session_memory_calls.append(phase)
+        # Include enough content that the post-rebuild token estimate still
+        # exceeds the trigger budget, forcing file_content_trimmed=True and
+        # therefore a second rebuild that re-invokes session memory.
+        filler = "OLD_RAW_HISTORY " * 200
         rebuilt = [
             messages[0],
             Message(
                 role=MessageRole.ASSISTANT,
-                content=f"COMPRESSED_SUMMARY phase={phase}",
+                content=f"COMPRESSED_SUMMARY phase={phase} {filler}",
             ),
             messages[-1],
         ]
@@ -225,6 +234,7 @@ async def test_session_memory_compaction_runs_again_after_file_trim(monkeypatch)
         include_current_user_message=True,
     )
 
-    assert rebuild_calls["count"] >= 1
+    assert file_rebuild_calls["count"] >= 1
     assert session_memory_calls, session_memory_calls
-    assert 1 in session_memory_calls, session_memory_calls
+    assert 2 in session_memory_calls, session_memory_calls
+    assert any(phase > 2 for phase in session_memory_calls), session_memory_calls

--- a/backend/tests/services/test_chat_context_compression.py
+++ b/backend/tests/services/test_chat_context_compression.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 import pytest
 
-from app.llm.types import MessageRole
+from app.llm.types import Message, MessageRole
 from app.models.agent import MessageRole as ConversationMessageRole
 from app.services import chat_context
 
@@ -31,13 +31,11 @@ async def test_prepare_model_context_reuses_session_memory_before_pressure_check
     )
     conversation = SimpleNamespace(id=conversation_id, variables={})
 
-    old_text = "OLD_RAW_HISTORY " * 100
-    recent_text = "recent turn"
     history = [
         SimpleNamespace(
             id=uuid4(),
             role=ConversationMessageRole.USER,
-            content=old_text,
+            content="OLD_RAW_HISTORY " * 100,
             file_urls=None,
             round_id=None,
         ),
@@ -52,7 +50,7 @@ async def test_prepare_model_context_reuses_session_memory_before_pressure_check
         SimpleNamespace(
             id=uuid4(),
             role=ConversationMessageRole.USER,
-            content=recent_text,
+            content="recent turn",
             file_urls=None,
             round_id=None,
         ),
@@ -130,3 +128,103 @@ async def test_prepare_model_context_reuses_session_memory_before_pressure_check
         message.role in {MessageRole.SYSTEM, MessageRole.ASSISTANT, MessageRole.USER}
         for message in prepared.messages
     )
+
+
+@pytest.mark.anyio
+async def test_session_memory_compaction_runs_again_after_file_trim(monkeypatch):
+    """After file-content trim rebuilds base_messages, the session-memory
+    compaction must be re-applied so the rebuilt list does not silently
+    revert to the original raw history.
+    """
+
+    rebuild_calls = {"count": 0}
+    session_memory_calls: list[int] = []
+
+    async def fake_rebuild(*args, **kwargs):
+        rebuild_calls["count"] += 1
+        rebuilt = [
+            Message(role=MessageRole.SYSTEM, content="SYSTEM"),
+            Message(
+                role=MessageRole.USER,
+                content="OLD_RAW_HISTORY " * 30,
+            ),
+            Message(role=MessageRole.USER, content="continue"),
+        ]
+        return rebuilt, {len(rebuilt) - 1}
+
+    def _apply_session_memory(messages, **kwargs):
+        phase = rebuild_calls["count"]
+        session_memory_calls.append(phase)
+        rebuilt = [
+            messages[0],
+            Message(
+                role=MessageRole.ASSISTANT,
+                content=f"COMPRESSED_SUMMARY phase={phase}",
+            ),
+            messages[-1],
+        ]
+        return rebuilt, True, {len(rebuilt) - 1}
+
+    async def _async_apply_session_memory(messages, **kwargs):
+        return _apply_session_memory(messages, **kwargs)
+
+    agent = SimpleNamespace(
+        id=uuid4(),
+        system_prompt="",
+        enable_memory=False,
+        enable_user_input_request=False,
+        tools_config=[],
+        context_compression_config={
+            "recent_raw_turns": 1,
+            "recent_tool_turns": 0,
+            "output_token_reserve": 50,
+            "safety_margin_tokens": 50,
+        },
+    )
+    conversation = SimpleNamespace(id=uuid4(), variables={})
+
+    monkeypatch.setattr(
+        chat_context,
+        "_build_messages_with_file_content",
+        fake_rebuild,
+    )
+    monkeypatch.setattr(
+        "app.services.chat_context._apply_session_memory_compaction",
+        _async_apply_session_memory,
+    )
+    monkeypatch.setattr(
+        chat_context,
+        "_estimate_message_tokens",
+        lambda messages, model_id, provider=None: sum(
+            len(str(getattr(message, "content", "") or "")) for message in messages
+        ),
+    )
+    monkeypatch.setattr(
+        chat_context,
+        "count_message_tokens",
+        lambda payload, model_id, provider=None: sum(
+            len(str(item.get("content", ""))) for item in payload
+        ),
+    )
+    monkeypatch.setattr(
+        chat_context,
+        "_trim_file_content",
+        lambda content, aggressive: (content, True),
+    )
+
+    await chat_context.prepare_model_context(
+        agent=agent,
+        conversation=conversation,
+        user_message="continue",
+        model_id="gpt-4",
+        model_context_limit=4000,
+        model_max_output_tokens=50,
+        provider=None,
+        file_content="FILE_CONTENT " * 600,
+        current_user_message_id=uuid4(),
+        include_current_user_message=True,
+    )
+
+    assert rebuild_calls["count"] >= 1
+    assert session_memory_calls, session_memory_calls
+    assert 1 in session_memory_calls, session_memory_calls

--- a/backend/tests/services/test_chat_tool_executor.py
+++ b/backend/tests/services/test_chat_tool_executor.py
@@ -135,6 +135,46 @@ class TestChatToolExecutor:
         }
 
     @pytest.mark.anyio
+    async def test_execute_builtin_tool_uses_stored_credentials(self):
+        async def handler(query, credentials=None):
+            return {"query": query, "credentials": credentials}
+
+        tool_info = ToolInfo(
+            name="web_search",
+            description="Search the web",
+            parameters=[],
+            handler=handler,
+        )
+        previous_tool = tool_registry.get_tool("web_search")
+        tool_registry._tools["web_search"] = tool_info
+        try:
+            with patch("app.models.tool_config.ToolConfig.filter") as mock_filter:
+                team_query = MagicMock()
+                team_query.first = AsyncMock(
+                    return_value=SimpleNamespace(
+                        credentials={"TAVILY_API_KEY": "team-key"}
+                    )
+                )
+                mock_filter.return_value = team_query
+
+                result = await execute_tool_call(
+                    "web_search",
+                    {"query": "latest news"},
+                    agent=SimpleNamespace(team_id="team-1"),
+                )
+        finally:
+            if previous_tool is not None:
+                tool_registry._tools["web_search"] = previous_tool
+            else:
+                tool_registry._tools.pop("web_search", None)
+
+        assert result == {
+            "query": "latest news",
+            "credentials": {"TAVILY_API_KEY": "team-key"},
+        }
+        mock_filter.assert_called_once_with(tool_name="web_search", team_id="team-1")
+
+    @pytest.mark.anyio
     async def test_execute_bash_routes_to_sandbox_tool(self):
         class FakeBashTool:
             def __init__(self, **kwargs):

--- a/backend/tests/services/test_session_memory.py
+++ b/backend/tests/services/test_session_memory.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+from app.models.agent import ConversationSessionMemoryStatus
+from app.services.session_memory import (
+    MACRO_COMPACTION_ORIGIN,
+    _should_skip_already_extracted_snapshot,
+)
+
+
+def test_macro_compaction_snapshot_does_not_skip_extractor_refresh():
+    source_id = uuid4()
+    snapshot = SimpleNamespace(
+        source_message_id=source_id,
+        status=ConversationSessionMemoryStatus.READY,
+        snapshot_payload={"origin": MACRO_COMPACTION_ORIGIN},
+    )
+
+    assert _should_skip_already_extracted_snapshot(snapshot, source_id) is False
+
+
+def test_extracted_ready_snapshot_skips_duplicate_extraction():
+    source_id = uuid4()
+    snapshot = SimpleNamespace(
+        source_message_id=source_id,
+        status=ConversationSessionMemoryStatus.READY,
+        snapshot_payload={"overview": "ready"},
+    )
+
+    assert _should_skip_already_extracted_snapshot(snapshot, source_id) is True


### PR DESCRIPTION
## Summary
- pass stored builtin tool credentials into model-triggered chat tool calls so Tavily web search can use configured API keys
- reuse/persist compressed chat context snapshots so follow-up turns count and send compressed history instead of the original full history
- add focused regression coverage for compressed context reuse

## Tests
- PYTHONPATH=. uv run pytest tests/services/test_chat_context_compression.py tests/services/test_chat_tool_executor.py -q
- uv run ruff check app/services/chat_context.py app/api/v1/endpoints/chat.py tests/services/test_chat_context_compression.py
- uv run ruff format --check app/services/chat_context.py app/api/v1/endpoints/chat.py tests/services/test_chat_context_compression.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved conversation context macro-compaction: compacted summaries are extracted and best-effort persisted after chat completion, streaming finalization, and message regeneration.
  * Enhanced built-in tool execution: when a tool handler supports credentials, stored credentials are injected (with web search falling back to app settings).
* **Bug Fixes**
  * Session memory extraction now refreshes READY snapshots that were created via macro compaction, while still skipping true duplicates.
* **Tests**
  * Added/extended coverage for earlier context reuse, re-compaction after file-content trimming, credential injection behavior, and macro-compaction skip/refetch logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->