### PR TITLE
fix: decode escape sequences in document chunk separators (YUN-108)

### DIFF
--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -534,6 +534,42 @@ DEFAULT_SEPARATORS = [
 
 CHARS_PER_TOKEN = 4
 
+# Escape sequences the user can type in a custom-separator field (e.g. "\n")
+# so that a literal backslash-n in the request body splits on a real newline.
+_ESCAPE_SEQUENCES: dict[str, str] = {
+    "\\n": "\n",
+    "\\r": "\r",
+    "\\t": "\t",
+    "\\\\": "\\",
+}
+
+
+def _decode_separator_escapes(separator: str) -> str:
+    """
+    Interpret common escape sequences in a user-supplied separator string.
+
+    The frontend renders separator hints like ``\\n\\n`` (literal backslash-n),
+    so the API receives the two-character sequence ``\\n`` rather than a real
+    newline. LangChain's splitter does a literal match, so it would never
+    split on actual newlines. This helper turns the typed escape sequences
+    into the characters they represent before they reach the splitter.
+    """
+    if "\\" not in separator:
+        return separator
+
+    decoded: list[str] = []
+    i = 0
+    while i < len(separator):
+        if separator[i] == "\\" and i + 1 < len(separator):
+            pair = separator[i : i + 2]
+            if pair in _ESCAPE_SEQUENCES:
+                decoded.append(_ESCAPE_SEQUENCES[pair])
+                i += 2
+                continue
+        decoded.append(separator[i])
+        i += 1
+    return "".join(decoded)
+
 
 def chunk_text(
     text: str,
@@ -551,11 +587,20 @@ def chunk_text(
     split with overlap=0 first, then prepend the exact trailing characters
     from the previous chunk.
 
+    When the caller provides a custom separator it is treated as a hard split
+    boundary: the text is pre-split on the (escape-decoded) separator first,
+    and each piece is then passed through the splitter so that pieces still
+    larger than ``chunk_size`` are broken down further. Without this,
+    LangChain returns the whole text as a single chunk whenever it already
+    fits in ``chunk_size``, ignoring the user's separator entirely.
+
     Args:
         text: Text to chunk
         chunk_size: Target chunk size in characters
         chunk_overlap: Overlap between chunks in characters
-        separators: Optional custom separators
+        separators: Optional custom separators. Each separator may contain
+            escape sequences (``\\n``, ``\\r``, ``\\t``, ``\\\\``) which are
+            decoded to their real characters before splitting.
 
     Returns:
         List of chunk dicts with content, chunk_index, token_count, char_count
@@ -566,19 +611,37 @@ def chunk_text(
     from langchain_text_splitters import RecursiveCharacterTextSplitter
 
     if separators:
-        custom = [s for s in separators if s]
+        custom = [_decode_separator_escapes(s) for s in separators if s]
         seps = custom + [s for s in DEFAULT_SEPARATORS if s not in custom]
     else:
         seps = list(DEFAULT_SEPARATORS)
 
-    # Split with overlap=0 to get clean boundaries
-    splitter = RecursiveCharacterTextSplitter(
-        chunk_size=chunk_size,
-        chunk_overlap=0,
-        separators=seps,
-        length_function=len,
-    )
-    texts = splitter.split_text(text)
+    # Pre-split on the user's primary custom separator so it acts as a hard
+    # boundary, even when the whole text fits within chunk_size.
+    texts = _split_on_custom_separator(text, seps[0]) if seps else [text]
+
+    # If no piece is over chunk_size we still need to honour the splitter's
+    # secondary separators (e.g. when the custom separator is not present in
+    # the text at all, leave the splitter's default behaviour in charge).
+    if len(texts) == 1 and texts[0] == text:
+        splitter = RecursiveCharacterTextSplitter(
+            chunk_size=chunk_size,
+            chunk_overlap=0,
+            separators=seps,
+            length_function=len,
+        )
+        texts = splitter.split_text(text)
+    else:
+        splitter = RecursiveCharacterTextSplitter(
+            chunk_size=chunk_size,
+            chunk_overlap=0,
+            separators=seps[1:] if len(seps) > 1 else [""],
+            length_function=len,
+        )
+        chunked: list[str] = []
+        for piece in texts:
+            chunked.extend(splitter.split_text(piece) if piece else [])
+        texts = chunked
 
     # Apply exact character-level overlap and track overlap lengths
     overlap_lengths: list[int] = [0] * len(texts)
@@ -601,6 +664,19 @@ def chunk_text(
         }
         for idx, t in enumerate(texts)
     ]
+
+
+def _split_on_custom_separator(text: str, separator: str) -> list[str]:
+    """
+    Split ``text`` on ``separator`` only when the separator actually appears.
+
+    Returns ``[text]`` unchanged when the separator is the empty-string fallback
+    or when it is not present, so the caller can fall back to the default
+    splitter.
+    """
+    if not separator or separator not in text:
+        return [text]
+    return text.split(separator)
 
 
 # Global instance

--- a/backend/tests/services/test_chunk_text_escapes.py
+++ b/backend/tests/services/test_chunk_text_escapes.py
@@ -1,0 +1,211 @@
+"""
+Tests for YUN-108: document chunking must interpret escape sequences
+(``\\n``, ``\\r``, ``\\t``, ``\\\\``) in user-supplied separator strings.
+
+The frontend renders separator hints as literal ``\\n`` (backslash + n), so
+the API receives two characters where the user means a single newline.
+LangChain's splitter does a literal match, so without decoding the escape
+sequence the chunker would never split on real newlines.
+"""
+
+from app.services.document_processor import (
+    _decode_separator_escapes,
+    chunk_text,
+)
+
+
+# ---------- _decode_separator_escapes ----------
+
+
+def test_decode_separator_escapes_decodes_newline():
+    assert _decode_separator_escapes("\\n") == "\n"
+
+
+def test_decode_separator_escapes_decodes_carriage_return():
+    assert _decode_separator_escapes("\\r") == "\r"
+
+
+def test_decode_separator_escapes_decodes_tab():
+    assert _decode_separator_escapes("\\t") == "\t"
+
+
+def test_decode_separator_escapes_decodes_double_backslash():
+    assert _decode_separator_escapes("\\\\") == "\\"
+
+
+def test_decode_separator_escapes_decodes_multiple_sequences():
+    assert _decode_separator_escapes("\\n\\n") == "\n\n"
+
+
+def test_decode_separator_escapes_leaves_unicode_punctuation_untouched():
+    # Chinese punctuation should NOT be escape-decoded — it's literal text.
+    assert _decode_separator_escapes("。") == "。"
+    assert _decode_separator_escapes("---") == "---"
+
+
+def test_decode_separator_escapes_passthrough_when_no_backslash():
+    assert _decode_separator_escapes("hello") == "hello"
+    # An already-real newline must not be altered.
+    assert _decode_separator_escapes("\n") == "\n"
+
+
+def test_decode_separator_escapes_leaves_unknown_sequences_unchanged():
+    # `\x` is not in the supported set; the backslash and the next char
+    # must be preserved verbatim.
+    assert _decode_separator_escapes("\\x") == "\\x"
+    assert _decode_separator_escapes("\\u4e2d") == "\\u4e2d"
+
+
+# ---------- chunk_text integration ----------
+
+
+def test_chunk_text_splits_on_literal_backslash_n_separator():
+    """User types `\\n` in the UI → server should split on real newlines."""
+    text = "alpha" + ("x" * 50) + "\nbeta" + ("y" * 50) + "\ngamma" + ("z" * 50)
+
+    chunks = chunk_text(
+        text,
+        chunk_size=10,
+        chunk_overlap=0,
+        separators=["\\n"],
+    )
+
+    # Three logical segments must survive, regardless of further internal splits.
+    contents = [c["content"] for c in chunks]
+    assert any(c.startswith("alpha") for c in contents)
+    assert any("beta" in c for c in contents)
+    assert any(c.startswith("gamma") or c.endswith("gamma") for c in contents)
+    # And no chunk should still contain a real newline (it has been split on it).
+    assert all("\n" not in c for c in contents)
+
+
+def test_chunk_text_splits_on_literal_backslash_n_n_separator():
+    """User types `\\n\\n` (paragraph hint) → split on real double newlines."""
+    text = (
+        "first paragraph"
+        + ("a" * 50)
+        + "\n\n"
+        + "second paragraph"
+        + ("b" * 50)
+        + "\n\n"
+        + "third paragraph"
+        + ("c" * 50)
+    )
+
+    chunks = chunk_text(
+        text,
+        chunk_size=10,
+        chunk_overlap=0,
+        separators=["\\n\\n"],
+    )
+
+    # No chunk may still contain the real ``\n\n`` separator — that's the
+    # invariant the escape-sequence decode is responsible for.
+    contents = [c["content"] for c in chunks]
+    assert all("\n\n" not in c for c in contents), contents
+
+
+def test_chunk_text_real_newline_separator_still_works():
+    """Regression: passing an actual newline as the separator still splits."""
+    text = "alpha" + ("x" * 50) + "\nbeta" + ("y" * 50) + "\ngamma" + ("z" * 50)
+
+    chunks = chunk_text(
+        text,
+        chunk_size=10,
+        chunk_overlap=0,
+        separators=["\n"],
+    )
+
+    contents = [c["content"] for c in chunks]
+    assert any(c.startswith("alpha") for c in contents)
+    assert any("beta" in c for c in contents)
+    assert any(c.startswith("gamma") or c.endswith("gamma") for c in contents)
+    assert all("\n" not in c for c in contents)
+
+
+def test_chunk_text_default_separators_still_split_on_newlines():
+    """Regression: no custom separator → original behaviour preserved."""
+    text = (
+        "alpha"
+        + ("x" * 50)
+        + "\n\n"
+        + "beta"
+        + ("y" * 50)
+        + "\n\n"
+        + "gamma"
+        + ("z" * 50)
+    )
+
+    chunks = chunk_text(
+        text,
+        chunk_size=10,
+        chunk_overlap=0,
+        separators=None,
+    )
+
+    contents = [c["content"] for c in chunks]
+    assert any(c.startswith("alpha") for c in contents)
+    assert any(c.startswith("beta") for c in contents)
+    assert any(c.startswith("gamma") for c in contents)
+    assert all("\n\n" not in c for c in contents)
+
+
+def test_chunk_text_custom_separator_splits_when_text_fits_chunk_size():
+    """
+    Regression for YUN-108 follow-up: the user types ``\\n\\n`` and expects
+    three paragraphs even when the whole document would otherwise fit in one
+    chunk. Previously LangChain's splitter returned the document as a single
+    chunk whenever ``len(text) <= chunk_size``, ignoring the custom separator
+    entirely.
+    """
+    paragraph = "段落内容 " + ("lorem ipsum " * 8)
+    text = "\n\n".join([paragraph, paragraph, paragraph])
+    # Sanity: text is short enough to fit inside the default chunk size.
+    assert len(text) < 1000
+
+    chunks = chunk_text(
+        text,
+        chunk_size=1000,
+        chunk_overlap=0,
+        separators=["\\n\\n"],
+    )
+
+    assert len(chunks) == 3, [c["content"] for c in chunks]
+    assert chunks[0]["content"].startswith("段落内容")
+    assert chunks[1]["content"].startswith("段落内容")
+    assert chunks[2]["content"].startswith("段落内容")
+    # No chunk should still contain the real ``\n\n`` separator.
+    assert all("\n\n" not in c["content"] for c in chunks)
+
+
+def test_chunk_text_custom_separator_present_in_text_still_splits():
+    """Custom separator absent from text → falls back to default splitter."""
+    text = "alpha" + ("x" * 50) + " " + "beta" + ("y" * 50)
+
+    chunks = chunk_text(
+        text,
+        chunk_size=1000,
+        chunk_overlap=0,
+        separators=["\n\n"],
+    )
+
+    # ``\n\n`` never appears, so we should get one chunk back, not zero.
+    assert len(chunks) == 1
+
+
+def test_chunk_text_custom_separator_applies_overlap():
+    """Overlap is still applied on top of the pre-split pieces."""
+    paragraph = "abcde" * 20
+    text = "\n\n".join([paragraph, paragraph, paragraph])
+
+    chunks = chunk_text(
+        text,
+        chunk_size=1000,
+        chunk_overlap=10,
+        separators=["\\n\\n"],
+    )
+
+    assert len(chunks) == 3
+    # Overlap should appear at the start of chunk 1 and 2.
+    assert chunks[1]["overlap_length"] == 10
+    assert chunks[2]["overlap_length"] == 10


### PR DESCRIPTION
## 背景
Clouisle issue #268 / Linear YUN-108：用户在 UI 上输入的自定义分隔符（例如 `\n` 或 `\n\n`）在文档分块时未生效。

## 根因
1. 前端的占位符是字面量 `\n`（反斜杠 + n），但后端从未做转义解码，langchain 的 `RecursiveCharacterTextSplitter` 是字面量匹配，所以 `\n` 永远命中不到真实的换行符。
2. 即使用户传的字符就是真实的换行符，只要 `len(text) <= chunk_size`，langchain 也会把整篇文本当成一个 chunk 返回，自定义分隔符完全被忽略。

## 修复
- 在 `app/services/document_processor.py` 中新增 `_decode_separator_escapes()`，支持 `\n`、`\r`、`\t`、`\\` 的解码；其它反斜杠序列按字面量保留。
- `chunk_text()` 在调用 langchain 之前先按用户主分隔符**预切**（`_split_on_custom_separator`），把自定义分隔符提升为硬边界，无论文本长度是否超过 `chunk_size` 都会按段落切。
- 自定义分隔符在文本中**不存在**时回退到默认切分器（行为不变）。
- overlap 仍然在预切之后正确应用。

## 测试
- `backend/tests/services/test_chunk_text_escapes.py` 新增 15 个测试：
  - 8 个单元测试覆盖 `_decode_separator_escapes` 的各种输入（已知序列、未知序列、unicode 标点、纯回退等）。
  - 7 个集成测试覆盖 `chunk_text` 真实场景：字面量 `\n`、字面量 `\n\n`、真实 `\n`、默认分隔符回退、短文本也能切、文本中无分隔符时回退、overlap 行为。
- `PYTHONPATH=. uv run pytest tests/services/test_chunk_text_escapes.py -v` 全部通过。

## 变更范围
- `backend/app/services/document_processor.py`：新增 `_ESCAPE_SEQUENCES`、`_decode_separator_escapes`、`_split_on_custom_separator`；`chunk_text` 改造为预切 + 二次切分。
- `backend/tests/services/test_chunk_text_escapes.py`：新增。

未修改任何前端代码、i18n 文本、数据库 schema。

## 已知限制（不在本次范围）
- Markdown 标题层级（h1/h2/h3）目前不被 chunker 感知；`_clean_text` 在 `clean=True` 时会把 `\n{2,}` 折叠成 `\n`，导致默认路径下段落级边界被吃光。建议作为下一阶段处理：调整 `_clean_text` 折叠策略 + 引入 `MarkdownHeaderTextSplitter` 或自写正则预切。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document chunking now supports custom separators with escape sequences (such as `\n`, `\r`, `\t`, `\\`), enabling more flexible and granular control over how documents are split into chunks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->