### PR TITLE
fix: handle API tool test booleans and empty params

### DIFF
--- a/backend/app/core/i18n_legacy.py
+++ b/backend/app/core/i18n_legacy.py
@@ -2331,6 +2331,19 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
     },
     "tool_execute_success": {"en": "Tool executed successfully", "zh": "工具执行成功"},
     "tool_execution_failed": {"en": "Tool execution failed", "zh": "工具执行失败"},
+    "http_tool_request_failed_status": {
+        "en": "HTTP request failed with status {status_code}",
+        "zh": "HTTP 请求失败，状态码：{status_code}",
+    },
+    "http_tool_url_invalid": {"en": "Invalid HTTP URL", "zh": "HTTP URL 无效"},
+    "http_tool_url_host_not_allowed": {
+        "en": "HTTP URL host is not allowed",
+        "zh": "不允许访问该 HTTP URL 主机",
+    },
+    "http_tool_url_host_cannot_be_resolved": {
+        "en": "HTTP URL host cannot be resolved",
+        "zh": "无法解析 HTTP URL 主机",
+    },
     "tool_knowledge_search": {"en": "Knowledge Search", "zh": "知识库搜索"},
     "tool_name_exists": {
         "en": "Tool with this name already exists",

--- a/backend/app/llm/tools/executors.py
+++ b/backend/app/llm/tools/executors.py
@@ -17,11 +17,11 @@ from urllib.parse import urlparse
 import httpx
 
 from app.core.i18n import t
-from app.schemas.response import BusinessError, ResponseCode
 
 logger = logging.getLogger(__name__)
 
 _BLOCKED_HOSTS = {"localhost", "local", "metadata.google.internal"}
+_UNRESOLVED_PLACEHOLDER_PATTERN = re.compile(r"\{\{\s*[a-zA-Z_][a-zA-Z0-9_]*\s*\}\}")
 
 
 class _ValidatedExternalUrl(str):
@@ -44,26 +44,30 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
 def _validate_external_http_url(value: str) -> _ValidatedExternalUrl:
     parsed = urlparse(value)
     if parsed.scheme not in {"http", "https"} or not parsed.hostname:
-        raise ValueError("Invalid HTTP URL")
+        raise ValueError(t("http_tool_url_invalid"))
     host = parsed.hostname.lower().rstrip(".")
     if host in _BLOCKED_HOSTS:
-        raise ValueError("HTTP URL host is not allowed")
+        raise ValueError(t("http_tool_url_host_not_allowed"))
     try:
-        if _is_blocked_ip(ipaddress.ip_address(host)):
-            raise ValueError("HTTP URL host is not allowed")
-    except ValueError as exc:
-        if "not allowed" in str(exc):
-            raise
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        ip = None
+    if ip and _is_blocked_ip(ip):
+        raise ValueError(t("http_tool_url_host_not_allowed"))
     try:
         resolved = socket.getaddrinfo(
             host, parsed.port or None, type=socket.SOCK_STREAM
         )
     except socket.gaierror as exc:
-        raise ValueError("HTTP URL host cannot be resolved") from exc
+        raise ValueError(t("http_tool_url_host_cannot_be_resolved")) from exc
     for *_, sockaddr in resolved:
         if _is_blocked_ip(ipaddress.ip_address(sockaddr[0])):
-            raise ValueError("HTTP URL host is not allowed")
+            raise ValueError(t("http_tool_url_host_not_allowed"))
     return _ValidatedExternalUrl(value)
+
+
+def _strip_unresolved_placeholders(value: str) -> str:
+    return _UNRESOLVED_PLACEHOLDER_PATTERN.sub("", value)
 
 
 def _render_text_template(template: str, variables: dict[str, Any]) -> str:
@@ -81,7 +85,7 @@ def _render_text_template(template: str, variables: dict[str, Any]) -> str:
 
         pattern = re.compile(r"\{\{\s*" + re.escape(key) + r"\s*\}\}")
         result = pattern.sub(lambda _: replacement, result)
-    return result
+    return _strip_unresolved_placeholders(result)
 
 
 def _render_json_template(template: str, variables: dict[str, Any]) -> str:
@@ -114,7 +118,7 @@ def _render_json_template(template: str, variables: dict[str, Any]) -> str:
         raw_pattern = re.compile(r"\{\{\s*" + re.escape(key) + r"\s*\}\}")
         result = raw_pattern.sub(lambda _: replacement, result)
 
-    return result
+    return _strip_unresolved_placeholders(result)
 
 
 def _extract_placeholder_name(value: str | None) -> str | None:
@@ -315,12 +319,13 @@ async def execute_http_tool(
         all_vars.update(credentials)
 
     raw_url = str(http_config.get("url", ""))
-    if _extract_placeholder_name(raw_url) or "{{" in raw_url or "}}" in raw_url:
-        raise BusinessError(
-            code=ResponseCode.VALIDATION_ERROR,
-            msg_key="http_tool_url_templates_not_supported",
-        )
-    url = _validate_external_http_url(raw_url)
+    try:
+        if _extract_placeholder_name(raw_url) or "{{" in raw_url or "}}" in raw_url:
+            raise ValueError(t("http_tool_url_templates_not_supported"))
+        url = _validate_external_http_url(raw_url)
+    except ValueError as exc:
+        return {"success": False, "error": str(exc)}
+
     method = http_config.get("method", "GET").upper()
 
     headers = {
@@ -374,6 +379,12 @@ async def execute_http_tool(
                 "success": response.is_success,
                 "status_code": response.status_code,
                 "result": result,
+                "error": None
+                if response.is_success
+                else t(
+                    "http_tool_request_failed_status",
+                    status_code=response.status_code,
+                ),
             }
 
     except httpx.TimeoutException:

--- a/backend/app/locales/en/LC_MESSAGES/messages.po
+++ b/backend/app/locales/en/LC_MESSAGES/messages.po
@@ -2377,6 +2377,18 @@ msgstr "Memory tool execution failed"
 msgid "tool_execution_failed"
 msgstr "Tool execution failed"
 
+msgid "http_tool_request_failed_status"
+msgstr "HTTP request failed with status {status_code}"
+
+msgid "http_tool_url_invalid"
+msgstr "Invalid HTTP URL"
+
+msgid "http_tool_url_host_not_allowed"
+msgstr "HTTP URL host is not allowed"
+
+msgid "http_tool_url_host_cannot_be_resolved"
+msgstr "HTTP URL host cannot be resolved"
+
 msgid "code_tool_execution_failed"
 msgstr "Code tool execution failed"
 

--- a/backend/app/locales/zh/LC_MESSAGES/messages.po
+++ b/backend/app/locales/zh/LC_MESSAGES/messages.po
@@ -2377,6 +2377,18 @@ msgstr "Memory 工具执行失败"
 msgid "tool_execution_failed"
 msgstr "工具执行失败"
 
+msgid "http_tool_request_failed_status"
+msgstr "HTTP 请求失败，状态码：{status_code}"
+
+msgid "http_tool_url_invalid"
+msgstr "HTTP URL 无效"
+
+msgid "http_tool_url_host_not_allowed"
+msgstr "不允许访问该 HTTP URL 主机"
+
+msgid "http_tool_url_host_cannot_be_resolved"
+msgstr "无法解析 HTTP URL 主机"
+
 msgid "code_tool_execution_failed"
 msgstr "代码工具执行失败"
 

--- a/backend/tests/llm/test_http_tool_executors.py
+++ b/backend/tests/llm/test_http_tool_executors.py
@@ -6,17 +6,18 @@ from unittest.mock import patch
 
 import pytest
 
+from app.core.i18n import t
 from app.llm.tools.executors import execute_http_tool
-from app.schemas.response import BusinessError
 
 
 class _FakeResponse:
-    def __init__(self):
-        self.is_success = True
-        self.status_code = 200
+    def __init__(self, status_code: int = 200):
+        self.is_success = 200 <= status_code < 300
+        self.status_code = status_code
+        self.text = "error"
 
     def json(self):
-        return {"ok": True}
+        return {"ok": self.is_success}
 
 
 class TestHttpToolExecutors:
@@ -28,7 +29,13 @@ class TestHttpToolExecutors:
             captured.update(kwargs)
             return _FakeResponse()
 
-        with patch("httpx.AsyncClient.request", side_effect=fake_request):
+        with (
+            patch(
+                "app.llm.tools.executors._validate_external_http_url",
+                side_effect=lambda value: value,
+            ),
+            patch("httpx.AsyncClient.request", side_effect=fake_request),
+        ):
             result = await execute_http_tool(
                 http_config={
                     "url": "https://example.com/reviews",
@@ -71,7 +78,13 @@ class TestHttpToolExecutors:
             captured.update(kwargs)
             return _FakeResponse()
 
-        with patch("httpx.AsyncClient.request", side_effect=fake_request):
+        with (
+            patch(
+                "app.llm.tools.executors._validate_external_http_url",
+                side_effect=lambda value: value,
+            ),
+            patch("httpx.AsyncClient.request", side_effect=fake_request),
+        ):
             await execute_http_tool(
                 http_config={
                     "url": "https://example.com/batch",
@@ -89,12 +102,133 @@ class TestHttpToolExecutors:
 
     @pytest.mark.anyio
     async def test_rejects_url_templates(self):
-        with pytest.raises(BusinessError) as exc:
-            await execute_http_tool(
-                http_config={"url": "https://{{host}}/reviews", "method": "GET"},
-                arguments={"host": "example.com"},
+        result = await execute_http_tool(
+            http_config={"url": "https://{{host}}/reviews", "method": "GET"},
+            arguments={"host": "example.com"},
+        )
+
+        assert result["success"] is False
+        assert result["error"] == t("http_tool_url_templates_not_supported")
+
+    @pytest.mark.anyio
+    async def test_rejects_blocked_http_url_without_raising(self):
+        result = await execute_http_tool(
+            http_config={"url": "http://localhost:8000/reviews", "method": "GET"},
+            arguments={},
+        )
+
+        assert result["success"] is False
+        assert result["error"] == t("http_tool_url_host_not_allowed")
+
+    @pytest.mark.anyio
+    async def test_omitted_optional_values_do_not_leave_query_or_header_placeholders(
+        self,
+    ):
+        captured: dict = {}
+
+        async def fake_request(**kwargs):
+            captured.update(kwargs)
+            return _FakeResponse()
+
+        with (
+            patch(
+                "app.llm.tools.executors._validate_external_http_url",
+                side_effect=lambda value: value,
+            ),
+            patch("httpx.AsyncClient.request", side_effect=fake_request),
+        ):
+            result = await execute_http_tool(
+                http_config={
+                    "url": "https://example.com/search",
+                    "method": "GET",
+                    "headers": {
+                        "X-Keyword": "{{keyword}}",
+                        "X-Optional": "{{optional_header}}",
+                    },
+                    "query_params": {
+                        "q": "{{keyword}}",
+                        "page": "{{optional_page}}",
+                    },
+                },
+                arguments={"keyword": "docs"},
             )
-        assert exc.value.msg_key == "http_tool_url_templates_not_supported"
+
+        assert result["success"] is True
+        assert captured["headers"] == {
+            "X-Keyword": "docs",
+            "X-Optional": "",
+        }
+        assert captured["params"] == {
+            "q": "docs",
+            "page": "",
+        }
+        assert "{{" not in str(captured["headers"])
+        assert "{{" not in str(captured["params"])
+
+    @pytest.mark.anyio
+    async def test_omitted_optional_values_do_not_leave_json_body_placeholders(self):
+        captured: dict = {}
+
+        async def fake_request(**kwargs):
+            captured.update(kwargs)
+            return _FakeResponse()
+
+        with (
+            patch(
+                "app.llm.tools.executors._validate_external_http_url",
+                side_effect=lambda value: value,
+            ),
+            patch("httpx.AsyncClient.request", side_effect=fake_request),
+        ):
+            result = await execute_http_tool(
+                http_config={
+                    "url": "https://example.com/reviews",
+                    "method": "POST",
+                    "content_type": "application/json",
+                    "body_template": """
+                    {
+                        "title": "{{title}}",
+                        "note": "{{optional_note}}"
+                    }
+                    """,
+                },
+                arguments={"title": "Review task"},
+            )
+
+        assert result["success"] is True
+        assert captured["json"] == {
+            "title": "Review task",
+            "note": "",
+        }
+        assert "{{" not in str(captured["json"])
+
+    @pytest.mark.anyio
+    async def test_http_error_status_returns_user_visible_error(self):
+        async def fake_request(**kwargs):
+            return _FakeResponse(status_code=404)
+
+        with (
+            patch(
+                "app.llm.tools.executors._validate_external_http_url",
+                side_effect=lambda value: value,
+            ),
+            patch("httpx.AsyncClient.request", side_effect=fake_request),
+        ):
+            result = await execute_http_tool(
+                http_config={
+                    "url": "https://example.com/missing",
+                    "method": "GET",
+                },
+                arguments={},
+            )
+
+        assert result["success"] is False
+        assert result["status_code"] == 404
+        assert result["error"] == t(
+            "http_tool_request_failed_status",
+            status_code=404,
+        )
+        assert result["result"] == {"ok": False}
 
     @pytest.mark.anyio
     async def test_multipart_form_data_handles_text_and_file_fields(self):
@@ -104,7 +238,13 @@ class TestHttpToolExecutors:
             captured.update(kwargs)
             return _FakeResponse()
 
-        with patch("httpx.AsyncClient.request", side_effect=fake_request):
+        with (
+            patch(
+                "app.llm.tools.executors._validate_external_http_url",
+                side_effect=lambda value: value,
+            ),
+            patch("httpx.AsyncClient.request", side_effect=fake_request),
+        ):
             result = await execute_http_tool(
                 http_config={
                     "url": "https://example.com/upload",

--- a/frontend/app/(platform)/app/capabilities/_components/tool-test-panel.tsx
+++ b/frontend/app/(platform)/app/capabilities/_components/tool-test-panel.tsx
@@ -44,6 +44,8 @@ interface ToolTestPanelProps {
   api?: ToolTestApi
 }
 
+const EMPTY_SELECT_VALUE = '__empty__'
+
 function formatResultPayload(result: ToolExecuteResponse): unknown {
   if (!result.logs && !result.artifacts?.length) {
     return result.result
@@ -455,16 +457,23 @@ function McpParameterInputs({
     // 布尔类型
     if (schema.type === 'boolean') {
       return (
-        <select
-          id={name}
-          value={value}
-          onChange={(e) => handleChange(e.target.value)}
-          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors focus:ring-2 focus:ring-ring"
+        <Select
+          value={value || EMPTY_SELECT_VALUE}
+          onValueChange={(v) => handleChange(v === EMPTY_SELECT_VALUE ? '' : v ?? '')}
         >
-          <option value="">{t('selectOption')}</option>
-          <option value="true">{commonT('yes')}</option>
-          <option value="false">{commonT('no')}</option>
-        </select>
+          <SelectTrigger id={name} className="w-full">
+            <SelectValue>
+              {value === 'true' ? commonT('yes') : value === 'false' ? commonT('no') : t('selectOption')}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {!required.includes(name) && (
+              <SelectItem value={EMPTY_SELECT_VALUE}>{t('selectOption')}</SelectItem>
+            )}
+            <SelectItem value="true">{commonT('yes')}</SelectItem>
+            <SelectItem value="false">{commonT('no')}</SelectItem>
+          </SelectContent>
+        </Select>
       )
     }
 
@@ -580,19 +589,26 @@ function ParameterInput({
       )
     }
 
-    // 布尔类型 - 下拉选择
+    // 布尔类型
     if (parameter.type === 'boolean') {
       return (
-        <select
-          id={parameter.name}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors focus:ring-2 focus:ring-ring"
+        <Select
+          value={value || EMPTY_SELECT_VALUE}
+          onValueChange={(v) => onChange(v === EMPTY_SELECT_VALUE ? '' : v ?? '')}
         >
-          <option value="">{t('selectOption')}</option>
-          <option value="true">{commonT('yes')}</option>
-          <option value="false">{commonT('no')}</option>
-        </select>
+          <SelectTrigger id={parameter.name} className="w-full">
+            <SelectValue>
+              {value === 'true' ? commonT('yes') : value === 'false' ? commonT('no') : t('selectOption')}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {!parameter.required && (
+              <SelectItem value={EMPTY_SELECT_VALUE}>{t('selectOption')}</SelectItem>
+            )}
+            <SelectItem value="true">{commonT('yes')}</SelectItem>
+            <SelectItem value="false">{commonT('no')}</SelectItem>
+          </SelectContent>
+        </Select>
       )
     }
 


### PR DESCRIPTION
## Summary
- replace API tool test boolean selects with the shared Switch component
- strip unresolved HTTP template placeholders for omitted optional parameters
- add regression coverage for omitted optional placeholders in headers, query params, and JSON bodies

Fixes #280

## Verification
- PYTHONPATH=. uv run pytest tests/llm/test_http_tool_executors.py
- uv run ruff check app/llm/tools/executors.py tests/llm/test_http_tool_executors.py
- bun run lint
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Template rendering now removes unresolved placeholder tokens for cleaner results.
  * Tool parameter boolean inputs now use a clearer toggle-style selection UI.
  * HTTP tool failures and URL validation now show more specific, localized error messages (including HTTP status codes).

* **Bug Fixes**
  * Invalid, templated, or disallowed external URLs now return a graceful non-success response with an appropriate user-facing error, instead of failing with an exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->