### PR TITLE
Fix single storage setting validation

### DIFF
--- a/backend/app/api/v1/admin/endpoints/site_settings.py
+++ b/backend/app/api/v1/admin/endpoints/site_settings.py
@@ -323,6 +323,7 @@ async def update_setting(
     if key == "sso_allow_password_login" and data.value is False:
         await _ensure_superadmin_sso_bound()
     await _validate_setting_value(key, data.value)
+    await _validate_storage_settings_update({key: data.value})
 
     setting = await SiteSetting.filter(key=key).first()
     if not setting:


### PR DESCRIPTION
## Summary
- apply merged storage config validation to single-setting updates
- prevent invalid object storage settings from being saved through the single-key endpoint

## Validation
- uv run --no-config ruff check app/api/v1/admin/endpoints/site_settings.py
- uv run --no-config ruff format --check app/api/v1/admin/endpoints/site_settings.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added extra validation when updating certain storage-related admin settings, helping prevent invalid configuration changes from being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->