### PR TITLE
fix: redirect SSO failures to frontend

### DIFF
--- a/backend/app/api/v1/endpoints/sso.py
+++ b/backend/app/api/v1/endpoints/sso.py
@@ -25,6 +25,29 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+async def _frontend_url() -> str:
+    from app.core.config import settings
+
+    site_url = await SiteSetting.get_value("site_url", "")
+    return (site_url or settings.FRONTEND_URL).rstrip("/")
+
+
+def _safe_sso_redirect(redirect_url: Optional[str]) -> str:
+    final_redirect = redirect_url if isinstance(redirect_url, str) else "/dashboard"
+    if final_redirect.startswith("http"):
+        return "/dashboard"
+    return final_redirect
+
+
+async def _sso_error_redirect(
+    error_code: str, redirect_url: Optional[str] = None
+) -> RedirectResponse:
+    frontend_url = await _frontend_url()
+    return RedirectResponse(
+        url=f"{frontend_url}/sso-callback?error={quote(error_code)}&redirect={quote(_safe_sso_redirect(redirect_url))}"
+    )
+
+
 # Public endpoints (no auth required)
 
 
@@ -60,32 +83,30 @@ async def sso_login(
     """Initiate SSO login flow"""
     provider = await SSOProvider.get_or_none(name=provider_name, is_enabled=True)
     if not provider:
-        raise BusinessError(
-            code=ResponseCode.SSO_PROVIDER_NOT_FOUND, msg_key="sso_provider_not_found"
-        )
+        return await _sso_error_redirect("sso_provider_not_found", redirect)
 
     session_id = secrets.token_urlsafe(32)
     expires_at = now_utc() + timedelta(minutes=10)
 
-    provider_instance = SSOService.get_provider_instance(provider)
-
-    # Build callback URL - use site_url or configured backend URL
-    from app.core.config import settings
-
-    site_url = await SiteSetting.get_value("site_url", "")
-    backend_url = getattr(settings, "BACKEND_URL", None)
-    if site_url:
-        base_url = site_url.rstrip("/")
-    elif backend_url:
-        base_url = backend_url.rstrip("/")
-    else:
-        base_url = str(request.base_url).rstrip("/")
-        if ":3000" in base_url:
-            base_url = base_url.replace(":3000", ":8000")
-
-    callback_url = f"{base_url}/api/v1/sso/callback/{provider.name}"
-
     try:
+        provider_instance = SSOService.get_provider_instance(provider)
+
+        # Build callback URL - use site_url or configured backend URL
+        from app.core.config import settings
+
+        site_url = await SiteSetting.get_value("site_url", "")
+        backend_url = getattr(settings, "BACKEND_URL", None)
+        if site_url:
+            base_url = site_url.rstrip("/")
+        elif backend_url:
+            base_url = backend_url.rstrip("/")
+        else:
+            base_url = str(request.base_url).rstrip("/")
+            if ":3000" in base_url:
+                base_url = base_url.replace(":3000", ":8000")
+
+        callback_url = f"{base_url}/api/v1/sso/callback/{provider.name}"
+
         if provider.protocol in ["oauth2", "oidc"]:
             auth_result = await provider_instance.get_authorization_url(
                 state=session_id, redirect_uri=callback_url
@@ -144,10 +165,7 @@ async def sso_login(
         logger.exception(
             "Failed to initialize SSO login for provider %s", provider_name
         )
-        raise BusinessError(
-            code=ResponseCode.SSO_AUTHENTICATION_FAILED,
-            msg_key="sso_login_failed",
-        )
+        return await _sso_error_redirect("sso_login_failed", redirect)
 
 
 @router.get("/callback/{provider_name}")
@@ -161,9 +179,7 @@ async def sso_callback(
     """Handle SSO callback"""
     provider = await SSOProvider.get_or_none(name=provider_name)
     if not provider:
-        raise BusinessError(
-            code=ResponseCode.SSO_PROVIDER_NOT_FOUND, msg_key="sso_provider_not_found"
-        )
+        return await _sso_error_redirect("sso_provider_not_found")
 
     if provider.protocol in ["oauth2", "oidc"]:
         session_id = state
@@ -173,19 +189,15 @@ async def sso_callback(
         session_id = request.query_params.get("RelayState")
 
     if not session_id:
-        raise BusinessError(
-            code=ResponseCode.SSO_SESSION_EXPIRED, msg_key="sso_session_expired"
-        )
+        return await _sso_error_redirect("sso_session_expired")
 
     session = await SSOSession.get_or_none(session_id=session_id, provider=provider)
     if not session or session.expires_at < now_utc():
-        raise BusinessError(
-            code=ResponseCode.SSO_SESSION_EXPIRED, msg_key="sso_session_expired"
-        )
-
-    provider_instance = SSOService.get_provider_instance(provider)
+        return await _sso_error_redirect("sso_session_expired")
 
     try:
+        provider_instance = SSOService.get_provider_instance(provider)
+
         # Build callback URL - use site_url or configured backend URL
         from app.core.config import settings
 
@@ -223,17 +235,11 @@ async def sso_callback(
                 callback_data=callback_data, redirect_uri=callback_url
             )
         else:
-            raise BusinessError(
-                code=ResponseCode.SSO_INVALID_CONFIGURATION,
-                msg_key="unsupported_protocol",
-            )
+            return await _sso_error_redirect("sso_login_failed", session.redirect_url)
 
         provider_user_id = user_info.get("provider_user_id")
         if not provider_user_id:
-            raise BusinessError(
-                code=ResponseCode.SSO_AUTHENTICATION_FAILED,
-                msg_key="missing_user_id",
-            )
+            return await _sso_error_redirect("sso_login_failed", session.redirect_url)
 
         mapped_data = provider_instance.map_user_attributes(user_info)
         mapped_data.update(user_info)
@@ -242,14 +248,9 @@ async def sso_callback(
             provider=provider, provider_user_id=provider_user_id, user_info=mapped_data
         )
 
-        from app.core.config import settings
-
         # Use public site_url for browser redirect, fall back to FRONTEND_URL
-        site_url = await SiteSetting.get_value("site_url", "")
-        frontend_url = (site_url or settings.FRONTEND_URL).rstrip("/")
-        final_redirect = session.redirect_url or "/dashboard"
-        if final_redirect.startswith("http"):
-            final_redirect = "/dashboard"
+        frontend_url = await _frontend_url()
+        final_redirect = _safe_sso_redirect(session.redirect_url)
 
         if not user.is_active:
             await session.delete()
@@ -298,8 +299,20 @@ async def sso_callback(
 
         return RedirectResponse(url=redirect_url)
 
-    except BusinessError:
-        raise
+    except BusinessError as e:
+        await AuditLogService.log(
+            user=None,
+            action="sso_login_failed",
+            resource_type="user",
+            resource_id=None,
+            resource_name=None,
+            operation="read",
+            status="failed",
+            request=request,
+            error_message=e.msg_key,
+            metadata={"provider": provider.name},
+        )
+        return await _sso_error_redirect("sso_login_failed", session.redirect_url)
     except Exception as e:
         await AuditLogService.log(
             user=None,
@@ -313,10 +326,7 @@ async def sso_callback(
             error_message=str(e),
             metadata={"provider": provider.name},
         )
-        raise BusinessError(
-            code=ResponseCode.SSO_AUTHENTICATION_FAILED,
-            msg_key="sso_login_failed",
-        )
+        return await _sso_error_redirect("sso_login_failed", session.redirect_url)
 
 
 @router.delete("/connections/{connection_id}", response_model=Response[None])

--- a/backend/app/api/v1/endpoints/sso.py
+++ b/backend/app/api/v1/endpoints/sso.py
@@ -2,7 +2,7 @@ import logging
 import secrets
 from datetime import timedelta
 from typing import Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -32,9 +32,30 @@ async def _frontend_url() -> str:
     return (site_url or settings.FRONTEND_URL).rstrip("/")
 
 
+def _backend_url(request: Request) -> str:
+    from app.core.config import settings
+
+    backend_url = getattr(settings, "BACKEND_URL", None)
+    if backend_url:
+        return backend_url.rstrip("/")
+
+    base_url = str(request.base_url).rstrip("/")
+    if ":3000" in base_url:
+        return base_url.replace(":3000", ":8000")
+    return base_url
+
+
 def _safe_sso_redirect(redirect_url: Optional[str]) -> str:
-    final_redirect = redirect_url if isinstance(redirect_url, str) else "/dashboard"
-    if final_redirect.startswith("http"):
+    final_redirect = redirect_url.strip() if isinstance(redirect_url, str) else ""
+    parsed = urlsplit(final_redirect)
+    if (
+        not final_redirect
+        or not final_redirect.startswith("/")
+        or final_redirect.startswith("//")
+        or parsed.scheme
+        or parsed.netloc
+        or "\\" in final_redirect
+    ):
         return "/dashboard"
     return final_redirect
 
@@ -91,21 +112,8 @@ async def sso_login(
     try:
         provider_instance = SSOService.get_provider_instance(provider)
 
-        # Build callback URL - use site_url or configured backend URL
-        from app.core.config import settings
-
-        site_url = await SiteSetting.get_value("site_url", "")
-        backend_url = getattr(settings, "BACKEND_URL", None)
-        if site_url:
-            base_url = site_url.rstrip("/")
-        elif backend_url:
-            base_url = backend_url.rstrip("/")
-        else:
-            base_url = str(request.base_url).rstrip("/")
-            if ":3000" in base_url:
-                base_url = base_url.replace(":3000", ":8000")
-
-        callback_url = f"{base_url}/api/v1/sso/callback/{provider.name}"
+        # Build callback URL from backend/API origin for IdP redirects.
+        callback_url = f"{_backend_url(request)}/api/v1/sso/callback/{provider.name}"
 
         if provider.protocol in ["oauth2", "oidc"]:
             auth_result = await provider_instance.get_authorization_url(
@@ -198,21 +206,8 @@ async def sso_callback(
     try:
         provider_instance = SSOService.get_provider_instance(provider)
 
-        # Build callback URL - use site_url or configured backend URL
-        from app.core.config import settings
-
-        site_url = await SiteSetting.get_value("site_url", "")
-        backend_url = getattr(settings, "BACKEND_URL", None)
-        if site_url:
-            base_url = site_url.rstrip("/")
-        elif backend_url:
-            base_url = backend_url.rstrip("/")
-        else:
-            base_url = str(request.base_url).rstrip("/")
-            if ":3000" in base_url:
-                base_url = base_url.replace(":3000", ":8000")
-
-        callback_url = f"{base_url}/api/v1/sso/callback/{provider.name}"
+        # Build callback URL from backend/API origin for IdP redirects.
+        callback_url = f"{_backend_url(request)}/api/v1/sso/callback/{provider.name}"
 
         if provider.protocol in ["oauth2", "oidc"]:
             callback_data = {"code": code}

--- a/backend/tests/api/test_sso_redirects.py
+++ b/backend/tests/api/test_sso_redirects.py
@@ -1,0 +1,139 @@
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+from starlette.requests import Request
+
+from app.api.v1.endpoints import sso as sso_endpoints
+from app.core.timezone import now_utc
+from app.schemas.response import BusinessError, ResponseCode
+
+
+def make_request(query_string: bytes = b"") -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/v1/sso/callback/provider",
+            "headers": [],
+            "query_string": query_string,
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "client": ("testclient", 50000),
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def frontend_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_value(key: str, default=None):
+        if key == "site_url":
+            return "http://frontend"
+        return default
+
+    monkeypatch.setattr(sso_endpoints.SiteSetting, "get_value", fake_get_value)
+
+
+def assert_redirect(response, error_code: str, redirect: str = "/dashboard") -> None:
+    assert response.status_code in {302, 303, 307}
+    assert response.headers["location"] == (
+        f"http://frontend/sso-callback?error={error_code}&redirect={redirect}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sso_error_redirect_sanitizes_absolute_redirect() -> None:
+    response = await sso_endpoints._sso_error_redirect(
+        "sso_session_expired", "https://evil.example/path"
+    )
+
+    assert_redirect(response, "sso_session_expired")
+
+
+@pytest.mark.asyncio
+async def test_sso_login_missing_provider_redirects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_or_none(**kwargs):
+        return None
+
+    monkeypatch.setattr(sso_endpoints.SSOProvider, "get_or_none", fake_get_or_none)
+
+    response = await sso_endpoints.sso_login("missing", make_request(), redirect=None)
+
+    assert_redirect(response, "sso_provider_not_found")
+
+
+@pytest.mark.asyncio
+async def test_sso_callback_missing_provider_redirects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_or_none(**kwargs):
+        return None
+
+    monkeypatch.setattr(sso_endpoints.SSOProvider, "get_or_none", fake_get_or_none)
+
+    response = await sso_endpoints.sso_callback("missing", make_request())
+
+    assert_redirect(response, "sso_provider_not_found")
+
+
+@pytest.mark.asyncio
+async def test_sso_callback_missing_session_id_redirects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_or_none(**kwargs):
+        return SimpleNamespace(name="oidc", protocol="oidc")
+
+    monkeypatch.setattr(sso_endpoints.SSOProvider, "get_or_none", fake_get_or_none)
+
+    response = await sso_endpoints.sso_callback("oidc", make_request(), state=None)
+
+    assert_redirect(response, "sso_session_expired")
+
+
+@pytest.mark.asyncio
+async def test_sso_callback_provider_exception_redirects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = SimpleNamespace(name="oidc", protocol="oidc")
+    session = SimpleNamespace(
+        code_verifier="verifier",
+        redirect_url="/app",
+        expires_at=now_utc() + timedelta(minutes=1),
+    )
+
+    async def fake_provider_get_or_none(**kwargs):
+        return provider
+
+    async def fake_session_get_or_none(**kwargs):
+        return session
+
+    class FailingProvider:
+        async def handle_callback(self, **kwargs):
+            raise BusinessError(
+                code=ResponseCode.SSO_AUTHENTICATION_FAILED,
+                msg_key="sso_login_failed",
+            )
+
+    async def fake_log(**kwargs):
+        return None
+
+    monkeypatch.setattr(
+        sso_endpoints.SSOProvider, "get_or_none", fake_provider_get_or_none
+    )
+    monkeypatch.setattr(
+        sso_endpoints.SSOSession, "get_or_none", fake_session_get_or_none
+    )
+    monkeypatch.setattr(
+        sso_endpoints.SSOService,
+        "get_provider_instance",
+        lambda provider: FailingProvider(),
+    )
+    monkeypatch.setattr(sso_endpoints.AuditLogService, "log", fake_log)
+
+    response = await sso_endpoints.sso_callback(
+        "oidc", make_request(b"state=session-id"), state="session-id", code="code"
+    )
+
+    assert_redirect(response, "sso_login_failed", "/app")

--- a/backend/tests/api/test_sso_redirects.py
+++ b/backend/tests/api/test_sso_redirects.py
@@ -41,10 +41,23 @@ def assert_redirect(response, error_code: str, redirect: str = "/dashboard") -> 
     )
 
 
+@pytest.mark.parametrize(
+    "unsafe_redirect",
+    [
+        "https://evil.example/path",
+        "//evil.example/path",
+        "javascript:alert(1)",
+        "HTTP://evil.example/path",
+        "/\\evil.example/path",
+        "",
+    ],
+)
 @pytest.mark.asyncio
-async def test_sso_error_redirect_sanitizes_absolute_redirect() -> None:
+async def test_sso_error_redirect_sanitizes_external_redirects(
+    unsafe_redirect: str,
+) -> None:
     response = await sso_endpoints._sso_error_redirect(
-        "sso_session_expired", "https://evil.example/path"
+        "sso_session_expired", unsafe_redirect
     )
 
     assert_redirect(response, "sso_session_expired")


### PR DESCRIPTION
## Summary
- redirect browser-facing SSO login/callback failures to the frontend SSO callback page
- keep success and inactive/pending approval redirects intact
- add backend tests for SSO failure redirects and redirect sanitization

## Validation
- cd backend && PYTHONPATH=. uv run pytest tests/api/test_sso_redirects.py
- cd backend && uv run ruff check app/api/v1/endpoints/sso.py tests/api/test_sso_redirects.py
- git diff --check

Linear: YUN-114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSO sign-in and callback flow so failures consistently redirect back to the frontend with specific error codes.
  * Added safer handling for externally provided redirect targets to prevent unsafe destinations.
  * Standardized redirects for missing providers, expired sessions, and authentication failures for more predictable recovery.

* **Tests**
  * Added automated coverage for SSO redirect behavior, including frontend URL generation, redirect sanitization, missing provider/session scenarios, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->