### PR TITLE
fix: persist registration locale

### DIFF
--- a/backend/app/api/v1/endpoints/login.py
+++ b/backend/app/api/v1/endpoints/login.py
@@ -32,7 +32,7 @@ from app.core.email import (
 )
 from app.core.captcha import create_captcha_proof, generate_captcha, verify_captcha
 from app.core.timezone import now_utc
-from app.core.i18n import t, get_default_language
+from app.core.i18n import t, get_default_language, normalize_language
 from app.models.user import User
 from app.models.site_setting import SiteSetting
 from app.schemas.token import Token
@@ -757,10 +757,11 @@ async def register(
     # Get registration settings
     require_approval = await SiteSetting.get_value("require_approval", False)
     email_verification = await SiteSetting.get_value("email_verification", True)
-    default_language = await SiteSetting.get_value("default_language", "en")
     force_first_login = await SiteSetting.get_value(
         "force_password_change_first_login", False
     )
+
+    registration_locale = normalize_language(user_in.locale)
 
     # Create user
     hashed_password = security.get_password_hash(user_in.password)
@@ -777,7 +778,7 @@ async def register(
         is_superuser=is_first_user,
         # First user auto-verified, or if email verification is disabled
         email_verified=is_first_user or not email_verification,
-        locale=default_language,
+        locale=registration_locale,
         # Initialize password expiration fields
         password_changed_at=now_utc(),
         force_password_change=force_first_login and not is_first_user,

--- a/backend/tests/api/test_registration_locale.py
+++ b/backend/tests/api/test_registration_locale.py
@@ -1,0 +1,142 @@
+from types import SimpleNamespace
+
+import pytest
+from starlette.requests import Request
+
+from app.api.v1.endpoints import login as login_endpoints
+from app.models import user as user_models
+from app.schemas.user import UserCreate
+
+
+class _AwaitableValue:
+    def __init__(self, value: object) -> None:
+        self.value = value
+
+    def __await__(self):
+        async def _result():
+            return self.value
+
+        return _result().__await__()
+
+
+class _FakeRoles:
+    async def add(self, role: object) -> None:
+        return None
+
+
+class _FakeUser:
+    id = "user-id"
+    username = "alice"
+    email = "alice@example.com"
+    roles = _FakeRoles()
+
+    async def save(self) -> None:
+        return None
+
+
+class _FakeFirstQuery:
+    def __init__(self, value: object = None) -> None:
+        self.value = value
+
+    async def first(self) -> object:
+        return self.value
+
+
+class _FakeGetQuery:
+    def __init__(self, value: object) -> None:
+        self.value = value
+
+    def prefetch_related(self, *_args: object) -> _AwaitableValue:
+        return _AwaitableValue(self.value)
+
+
+class _FakeAllQuery:
+    async def count(self) -> int:
+        return 0
+
+
+@pytest.mark.asyncio
+async def test_register_persists_submitted_locale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_kwargs: dict[str, object] = {}
+    created_user = _FakeUser()
+
+    async def fake_get_value(key: str, default: object = None) -> object:
+        values = {
+            "require_approval": False,
+            "email_verification": False,
+            "default_language": "en",
+            "force_password_change_first_login": False,
+        }
+        return values.get(key, default)
+
+    class FakeUserModel:
+        @staticmethod
+        def all() -> _FakeAllQuery:
+            return _FakeAllQuery()
+
+        @staticmethod
+        def filter(**_kwargs: object) -> _FakeFirstQuery:
+            return _FakeFirstQuery()
+
+        @staticmethod
+        async def create(**kwargs: object) -> _FakeUser:
+            created_kwargs.update(kwargs)
+            return created_user
+
+        @staticmethod
+        def get(**_kwargs: object) -> _FakeGetQuery:
+            return _FakeGetQuery(created_user)
+
+    class FakeRoleModel:
+        @staticmethod
+        def filter(**_kwargs: object) -> _FakeFirstQuery:
+            return _FakeFirstQuery(SimpleNamespace())
+
+    async def fake_log(**_kwargs: object) -> None:
+        return None
+
+    async def fake_serialize(user: object) -> object:
+        return user
+
+    async def fake_validate_password(_password: str) -> tuple[bool, list[str]]:
+        return True, []
+
+    monkeypatch.setattr(login_endpoints.SiteSetting, "get_value", fake_get_value)
+    monkeypatch.setattr(login_endpoints, "User", FakeUserModel)
+    monkeypatch.setattr(user_models, "Role", FakeRoleModel)
+    monkeypatch.setattr(login_endpoints, "validate_password", fake_validate_password)
+    monkeypatch.setattr(
+        login_endpoints.security, "get_password_hash", lambda _password: "hash"
+    )
+    monkeypatch.setattr(
+        login_endpoints.PasswordExpirationService,
+        "calculate_expiration_date",
+        lambda _user: _AwaitableValue(None),
+    )
+    monkeypatch.setattr(login_endpoints.AuditLogService, "log", fake_log)
+    monkeypatch.setattr(login_endpoints, "serialize_user_with_sso", fake_serialize)
+
+    await login_endpoints.register(
+        request=Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/api/v1/register",
+                "headers": [],
+                "query_string": b"",
+                "server": ("testserver", 80),
+                "scheme": "http",
+                "client": ("testclient", 50000),
+            }
+        ),
+        user_in=UserCreate(
+            username="alice",
+            email="alice@example.com",
+            password="StrongPass123!",
+            locale="zh-CN",
+        ),
+    )
+
+    assert created_kwargs["locale"] == "zh"

--- a/frontend/app/(auth)/register/_components/register-form.tsx
+++ b/frontend/app/(auth)/register/_components/register-form.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import { useRouter } from 'next/navigation'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
@@ -92,6 +92,7 @@ function RegisterLegalEntry({ label, url, text }: { label: string; url: string; 
 
 export function RegisterForm() {
   const t = useTranslations('auth')
+  const locale = useLocale()
   const router = useRouter()
 
   const [step, setStep] = React.useState<Step>('form')
@@ -305,6 +306,7 @@ export function RegisterForm() {
         terms_accepted: siteSettings?.require_terms_acceptance_on_register ? termsAccepted : undefined,
         captcha_id: captcha?.captcha_id,
         captcha_token: captchaToken || undefined,
+        locale,
       })
       setRegisteredUser(user)
 

--- a/frontend/lib/api/auth.ts
+++ b/frontend/lib/api/auth.ts
@@ -67,6 +67,7 @@ export interface RegisterData {
   terms_accepted?: boolean
   captcha_id?: string
   captcha_token?: string
+  locale?: string
 }
 
 export interface VerificationResponse {


### PR DESCRIPTION
## Summary
- submit the current frontend locale with registration requests
- normalize and persist the submitted locale as the new user's language preference
- add a focused backend regression test for registration locale persistence

## Validation
- PYTHONPATH=. uv run pytest tests/api/test_registration_locale.py
- uv run ruff check app/api/v1/endpoints/login.py tests/api/test_registration_locale.py
- uv run ruff format --check app/api/v1/endpoints/login.py tests/api/test_registration_locale.py
- git diff --check
- cd frontend && bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registration now captures and submits the app’s current language/locale during sign-up.

* **Bug Fixes**
  * New accounts will now store a normalized locale value, improving consistency across different regional formats.
  * Added coverage to ensure registration saves the expected locale value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->