### PR TITLE
fix: support embed wildcard origins

### DIFF
--- a/backend/app/api/v1/endpoints/embed.py
+++ b/backend/app/api/v1/endpoints/embed.py
@@ -87,7 +87,15 @@ def _check_embed_enabled(target: Agent | Workflow) -> None:
 
 def _parse_origin_host(value: str) -> tuple[str, int | None]:
     parsed = urlparse(value if "://" in value else f"//{value}")
-    return (parsed.hostname or "").lower(), parsed.port
+    try:
+        port = parsed.port
+    except ValueError:
+        return "", None
+    if port is None and parsed.scheme == "https":
+        port = 443
+    elif port is None and parsed.scheme == "http":
+        port = 80
+    return (parsed.hostname or "").lower(), port
 
 
 def _domain_matches(

--- a/backend/app/api/v1/endpoints/embed.py
+++ b/backend/app/api/v1/endpoints/embed.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 from typing import Optional
+from urllib.parse import urlparse
 from uuid import UUID
 
 from fastapi import (
@@ -84,6 +85,25 @@ def _check_embed_enabled(target: Agent | Workflow) -> None:
         )
 
 
+def _parse_origin_host(value: str) -> tuple[str, int | None]:
+    parsed = urlparse(value if "://" in value else f"//{value}")
+    return (parsed.hostname or "").lower(), parsed.port
+
+
+def _domain_matches(
+    allowed_host: str,
+    allowed_port: int | None,
+    check_host: str,
+    check_port: int | None,
+) -> bool:
+    if allowed_port is not None and allowed_port != check_port:
+        return False
+    if allowed_host.startswith("*."):
+        base = allowed_host[2:]
+        return check_host == base or check_host.endswith(f".{base}")
+    return check_host == allowed_host
+
+
 def _check_embed_domain(request: Request, target: Agent | Workflow) -> None:
     """Verify request origin is in allowed domains list (if configured)."""
     embed_config = target.embed_config or {}
@@ -91,41 +111,16 @@ def _check_embed_domain(request: Request, target: Agent | Workflow) -> None:
     if not allowed_domains:
         return  # No restriction
 
-    origin = request.headers.get("origin", "")
-    referer = request.headers.get("referer", "")
-
-    # Extract hostname from origin or referer
-    check_host = ""
-    if origin:
-        # origin is like "https://example.com"
-        try:
-            from urllib.parse import urlparse
-
-            check_host = urlparse(origin).hostname or ""
-        except Exception:
-            pass
-    elif referer:
-        try:
-            from urllib.parse import urlparse
-
-            check_host = urlparse(referer).hostname or ""
-        except Exception:
-            pass
-
+    source = request.headers.get("origin") or request.headers.get("referer") or ""
+    check_host, check_port = _parse_origin_host(source)
     if not check_host:
         return  # No origin info, allow (could be direct access for testing)
 
-    # Check if host matches any allowed domain (supports wildcard subdomains)
     for domain in allowed_domains:
-        domain = domain.strip().lower()
-        if not domain:
-            continue
-        if domain.startswith("*."):
-            # Wildcard: *.example.com matches sub.example.com
-            base = domain[2:]
-            if check_host == base or check_host.endswith("." + base):
-                return
-        elif check_host == domain:
+        allowed_host, allowed_port = _parse_origin_host(str(domain).strip().lower())
+        if allowed_host and _domain_matches(
+            allowed_host, allowed_port, check_host, check_port
+        ):
             return
 
     raise BusinessError(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ import traceback
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.api.v1.api import api_router
@@ -507,8 +507,22 @@ class LanguageMiddleware(BaseHTTPMiddleware):
 # Embed security headers middleware - allow iframe embedding for /api/v1/embed/ routes
 class EmbedHeadersMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
+        is_embed_path = request.url.path.startswith(f"{settings.API_V1_STR}/embed/")
+        if is_embed_path and request.method == "OPTIONS":
+            return Response(
+                status_code=204,
+                headers={
+                    "Access-Control-Allow-Origin": "*",
+                    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+                    "Access-Control-Allow-Headers": request.headers.get(
+                        "access-control-request-headers", "*"
+                    ),
+                    "Access-Control-Max-Age": "600",
+                },
+            )
+
         response = await call_next(request)
-        if request.url.path.startswith(f"{settings.API_V1_STR}/embed/"):
+        if is_embed_path:
             # Remove X-Frame-Options to allow iframe embedding
             if "x-frame-options" in response.headers:
                 del response.headers["x-frame-options"]

--- a/backend/tests/api/test_embed_domain.py
+++ b/backend/tests/api/test_embed_domain.py
@@ -43,6 +43,10 @@ def make_target(allowed_domains: list[str] | None) -> SimpleNamespace:
         (["*.example.com"], "https://example.com"),
         (["*.example.com:3000"], "https://foo.example.com:3000"),
         (["https://example.com"], "https://example.com"),
+        (["example.com:443"], "https://example.com"),
+        (["https://example.com:443"], "https://example.com"),
+        (["example.com:80"], "http://example.com"),
+        (["http://example.com:80"], "http://example.com"),
     ],
 )
 def test_check_embed_domain_allows_matching_origins(
@@ -57,6 +61,8 @@ def test_check_embed_domain_allows_matching_origins(
     [
         (["example.com:3000"], "http://example.com:4000"),
         (["*.example.com:3000"], "https://foo.example.com:4000"),
+        (["example.com:443"], "http://example.com"),
+        (["example.com:notaport"], "http://example.com"),
         (["example.com"], "https://evil.example"),
     ],
 )

--- a/backend/tests/api/test_embed_domain.py
+++ b/backend/tests/api/test_embed_domain.py
@@ -1,0 +1,106 @@
+from types import SimpleNamespace
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.api.v1.endpoints.embed import _check_embed_domain
+from app.main import EmbedHeadersMiddleware
+from app.schemas.response import BusinessError
+
+
+def make_request(origin: str | None = None, referer: str | None = None) -> Request:
+    headers = []
+    if origin:
+        headers.append((b"origin", origin.encode()))
+    if referer:
+        headers.append((b"referer", referer.encode()))
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/v1/embed/agents/agent-id/info",
+            "headers": headers,
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "client": ("testclient", 50000),
+        }
+    )
+
+
+def make_target(allowed_domains: list[str] | None) -> SimpleNamespace:
+    return SimpleNamespace(embed_config={"allowed_domains": allowed_domains or []})
+
+
+@pytest.mark.parametrize(
+    ("allowed_domains", "origin"),
+    [
+        ([], "https://evil.example"),
+        (["example.com"], "https://example.com"),
+        (["example.com:3000"], "http://example.com:3000"),
+        (["*.example.com"], "https://foo.example.com"),
+        (["*.example.com"], "https://example.com"),
+        (["*.example.com:3000"], "https://foo.example.com:3000"),
+        (["https://example.com"], "https://example.com"),
+    ],
+)
+def test_check_embed_domain_allows_matching_origins(
+    allowed_domains: list[str],
+    origin: str,
+) -> None:
+    _check_embed_domain(make_request(origin=origin), make_target(allowed_domains))
+
+
+@pytest.mark.parametrize(
+    ("allowed_domains", "origin"),
+    [
+        (["example.com:3000"], "http://example.com:4000"),
+        (["*.example.com:3000"], "https://foo.example.com:4000"),
+        (["example.com"], "https://evil.example"),
+    ],
+)
+def test_check_embed_domain_rejects_non_matching_origins(
+    allowed_domains: list[str],
+    origin: str,
+) -> None:
+    with pytest.raises(BusinessError):
+        _check_embed_domain(make_request(origin=origin), make_target(allowed_domains))
+
+
+def test_check_embed_domain_uses_referer_when_origin_missing() -> None:
+    _check_embed_domain(
+        make_request(referer="https://docs.example.com/page"),
+        make_target(["*.example.com"]),
+    )
+
+
+@pytest.mark.asyncio
+async def test_embed_headers_middleware_handles_preflight() -> None:
+    middleware = EmbedHeadersMiddleware(app=lambda *_args: None)
+    request = Request(
+        {
+            "type": "http",
+            "method": "OPTIONS",
+            "path": "/api/v1/embed/agents/agent-id/info",
+            "headers": [
+                (b"access-control-request-headers", b"authorization,content-type")
+            ],
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "client": ("testclient", 50000),
+        }
+    )
+
+    async def call_next(_request: Request) -> Response:
+        raise AssertionError("preflight should not continue to routing")
+
+    response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 204
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.headers["Access-Control-Allow-Methods"] == "GET, POST, OPTIONS"
+    assert (
+        response.headers["Access-Control-Allow-Headers"] == "authorization,content-type"
+    )

--- a/frontend/app/(platform)/app/apps/[id]/_components/embed-config-dialog.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/_components/embed-config-dialog.tsx
@@ -128,7 +128,7 @@ export function EmbedConfigDialog({
       .map(d => d.trim())
       .filter(Boolean)
 
-    const invalidDomain = domains.find((domain) => !/^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(:\d+)?$/.test(domain))
+    const invalidDomain = domains.find((domain) => !/^(\*\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(:\d+)?$/.test(domain))
     if (invalidDomain) {
       setFieldErrors({ allowed_domains: t('invalidDomain', { value: invalidDomain }) })
       return

--- a/frontend/app/(platform)/app/apps/[id]/_components/embed-config-dialog.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/_components/embed-config-dialog.tsx
@@ -128,7 +128,7 @@ export function EmbedConfigDialog({
       .map(d => d.trim())
       .filter(Boolean)
 
-    const invalidDomain = domains.find((domain) => !/^(\*\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(:\d+)?$/.test(domain))
+    const invalidDomain = domains.find((domain) => !/^(https?:\/\/)?(\*\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(:\d+)?$/i.test(domain))
     if (invalidDomain) {
       setFieldErrors({ allowed_domains: t('invalidDomain', { value: invalidDomain }) })
       return


### PR DESCRIPTION
## Summary
- support wildcard and port-aware allowed domains for embedded agent/workflow origins
- handle embed API CORS preflight requests before routing
- allow wildcard domains in the embed configuration dialog
- add focused backend tests for embed domain matching and preflight headers

## Validation
- PYTHONPATH=. uv run pytest tests/api/test_embed_domain.py
- uv run ruff check app/api/v1/endpoints/embed.py app/main.py tests/api/test_embed_domain.py
- uv run ruff format --check app/api/v1/endpoints/embed.py app/main.py tests/api/test_embed_domain.py
- git diff --check
- cd frontend && bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced embed domain validation to support wildcard subdomains and port-specific allowed domains.
  * Improved embed CORS preflight support by returning a fast `204` with the required cross-origin headers.

* **Bug Fixes**
  * Made embed access checks more reliable by correctly deriving and matching request `Origin`/`Referer`, including port handling.

* **UI Changes**
  * Updated allowed-domain input validation to accept optional `*.` wildcard prefixes.

* **Tests**
  * Added coverage for embed-domain matching and embed header middleware behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->