### PR TITLE
feat: add scoped RBAC workbench permissions

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -285,7 +285,9 @@ async def check_scoped_permission(
 ) -> None:
     if user.is_superuser:
         return
-    if user_has_global_permission(user, required_permission):
+    if required_permission.startswith("admin:") and user_has_global_permission(
+        user, required_permission
+    ):
         return
     if not required_permission.startswith(
         "admin:"

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -9,7 +9,7 @@ from app.core.config import settings
 from app.core.redis import is_token_blacklisted
 from app.core.timezone import now_utc
 from app.core.i18n import set_language
-from app.models.user import User
+from app.models.user import User, ScopedRoleAssignment
 from app.models.api_key import APIKey
 from app.schemas.token import TokenPayload
 from app.schemas.response import ResponseCode, BusinessError
@@ -257,6 +257,50 @@ async def get_current_user_optional(
     return user
 
 
+def user_has_global_permission(user: User, required_permission: str) -> bool:
+    for role in user.roles:
+        for permission in role.permissions:
+            if permission.code == required_permission or permission.code == "*":
+                return True
+    return False
+
+
+async def user_has_scoped_permission(
+    user: User, required_permission: str, scope_type: str, scope_id: UUID
+) -> bool:
+    assignments = await ScopedRoleAssignment.filter(
+        user=user,
+        scope_type=scope_type,
+        scope_id=scope_id,
+    ).prefetch_related("role__permissions")
+    for assignment in assignments:
+        for permission in assignment.role.permissions:
+            if permission.code == required_permission or permission.code == "*":
+                return True
+    return False
+
+
+async def check_scoped_permission(
+    user: User, required_permission: str, scope_type: str, scope_id: UUID
+) -> None:
+    if user.is_superuser:
+        return
+    if user_has_global_permission(user, required_permission):
+        return
+    if not required_permission.startswith(
+        "admin:"
+    ) and await user_has_scoped_permission(
+        user, required_permission, scope_type, scope_id
+    ):
+        return
+    raise BusinessError(
+        code=ResponseCode.PERMISSION_DENIED,
+        msg_key="operation_not_permitted",
+        status_code=status.HTTP_403_FORBIDDEN,
+        permission=required_permission,
+    )
+
+
 class PermissionChecker:
     def __init__(self, required_permission: str):
         self.required_permission = required_permission
@@ -267,23 +311,7 @@ class PermissionChecker:
         if current_user.is_superuser:
             return current_user
 
-        # Check permissions
-        # Since we prefetched roles and permissions, we can check in memory
-        # Note: roles__permissions is a list of Permission objects
-
-        has_permission = False
-        for role in current_user.roles:
-            for permission in role.permissions:
-                if (
-                    permission.code == self.required_permission
-                    or permission.code == "*"
-                ):
-                    has_permission = True
-                    break
-            if has_permission:
-                break
-
-        if not has_permission:
+        if not user_has_global_permission(current_user, self.required_permission):
             raise BusinessError(
                 code=ResponseCode.PERMISSION_DENIED,
                 msg_key="operation_not_permitted",

--- a/backend/app/api/team_access.py
+++ b/backend/app/api/team_access.py
@@ -1,0 +1,39 @@
+"""Shared team access helpers."""
+
+from uuid import UUID
+
+from app.models.user import Team, TeamMember, User
+from app.schemas.response import BusinessError, ResponseCode
+
+
+async def check_team_access(
+    team_id: UUID, user: User, require_admin: bool = False
+) -> Team:
+    """Check whether a user can access a team."""
+    team = await Team.filter(id=team_id).first()
+    if not team:
+        raise BusinessError(
+            code=ResponseCode.TEAM_NOT_FOUND,
+            msg_key="team_not_found",
+            status_code=404,
+        )
+
+    if user.is_superuser:
+        return team
+
+    membership = await TeamMember.filter(team=team, user=user).first()
+    if not membership:
+        raise BusinessError(
+            code=ResponseCode.NOT_TEAM_MEMBER,
+            msg_key="not_team_member",
+            status_code=403,
+        )
+
+    if require_admin and membership.role not in ["owner", "admin"]:
+        raise BusinessError(
+            code=ResponseCode.TEAM_ADMIN_REQUIRED,
+            msg_key="team_admin_required",
+            status_code=403,
+        )
+
+    return team

--- a/backend/app/api/v1/admin/endpoints/conversations.py
+++ b/backend/app/api/v1/admin/endpoints/conversations.py
@@ -110,15 +110,15 @@ async def list_all_conversations(
     List conversations.
 
     - Super Admin: Can see all conversations
-    - Admin (has dashboard:access): Can see all conversations in their teams
+    - Admin (has admin:dashboard:access): Can see all conversations in their teams
     - Member/Viewer: Can only see their own conversations
     """
-    # Check if user has dashboard:access permission (Admin level)
+    # Check if user has admin dashboard access permission (Admin level)
     has_dashboard_access = current_user.is_superuser
     if not has_dashboard_access:
         for role in current_user.roles:
             for perm in role.permissions:
-                if perm.code == "dashboard:access" or perm.code == "*":
+                if perm.code == "admin:dashboard:access" or perm.code == "*":
                     has_dashboard_access = True
                     break
             if has_dashboard_access:
@@ -233,12 +233,12 @@ async def get_conversation_stats(
     - Super Admin/Admin: Stats for all conversations in accessible teams
     - Member/Viewer: Stats for their own conversations only
     """
-    # Check if user has dashboard:access permission (Admin level)
+    # Check if user has admin dashboard access permission (Admin level)
     has_dashboard_access = current_user.is_superuser
     if not has_dashboard_access:
         for role in current_user.roles:
             for perm in role.permissions:
-                if perm.code == "dashboard:access" or perm.code == "*":
+                if perm.code == "admin:dashboard:access" or perm.code == "*":
                     has_dashboard_access = True
                     break
             if has_dashboard_access:
@@ -325,12 +325,12 @@ async def get_conversation_trends(
     - Super Admin/Admin: Trends for all conversations in accessible teams
     - Member/Viewer: Trends for their own conversations only
     """
-    # Check if user has dashboard:access permission (Admin level)
+    # Check if user has admin dashboard access permission (Admin level)
     has_dashboard_access = current_user.is_superuser
     if not has_dashboard_access:
         for role in current_user.roles:
             for perm in role.permissions:
-                if perm.code == "dashboard:access" or perm.code == "*":
+                if perm.code == "admin:dashboard:access" or perm.code == "*":
                     has_dashboard_access = True
                     break
             if has_dashboard_access:
@@ -455,11 +455,11 @@ async def get_conversation_detail(
 
     # Check access permissions
     if not current_user.is_superuser:
-        # Check if user has dashboard:access permission (Admin level)
+        # Check if user has admin:dashboard:access permission (Admin level)
         has_dashboard_access = False
         for role in current_user.roles:
             for perm in role.permissions:
-                if perm.code == "dashboard:access" or perm.code == "*":
+                if perm.code == "admin:dashboard:access" or perm.code == "*":
                     has_dashboard_access = True
                     break
             if has_dashboard_access:
@@ -548,11 +548,11 @@ async def delete_conversation_admin(
 
     # Check access permissions
     if not current_user.is_superuser:
-        # Check if user has dashboard:access permission (Admin level)
+        # Check if user has admin:dashboard:access permission (Admin level)
         has_dashboard_access = False
         for role in current_user.roles:
             for perm in role.permissions:
-                if perm.code == "dashboard:access" or perm.code == "*":
+                if perm.code == "admin:dashboard:access" or perm.code == "*":
                     has_dashboard_access = True
                     break
             if has_dashboard_access:
@@ -612,11 +612,11 @@ async def batch_delete_conversations(
 
     # Check access permissions
     if not current_user.is_superuser:
-        # Check if user has dashboard:access permission (Admin level)
+        # Check if user has admin:dashboard:access permission (Admin level)
         has_dashboard_access = False
         for role in current_user.roles:
             for perm in role.permissions:
-                if perm.code == "dashboard:access" or perm.code == "*":
+                if perm.code == "admin:dashboard:access" or perm.code == "*":
                     has_dashboard_access = True
                     break
             if has_dashboard_access:

--- a/backend/app/api/v1/admin/endpoints/roles.py
+++ b/backend/app/api/v1/admin/endpoints/roles.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from tortoise.expressions import Q
 
 from app.api import deps
-from app.models.user import Role, Permission, User
+from app.models.user import Role, Permission, ScopedRoleAssignment, User
 from app.schemas.user import Role as RoleSchema, RoleCreate
 from app.schemas.response import (
     Response,
@@ -228,6 +228,14 @@ async def delete_role(
             code=ResponseCode.ROLE_IN_USE,
             msg_key="role_in_use",
             count=users_with_role,
+        )
+
+    scoped_assignments = await ScopedRoleAssignment.filter(role=role).count()
+    if scoped_assignments > 0:
+        raise BusinessError(
+            code=ResponseCode.ROLE_IN_USE,
+            msg_key="role_in_use",
+            count=scoped_assignments,
         )
 
     await role.delete()

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -10,6 +10,7 @@ from app.api.v1.endpoints import (
     models,
     knowledge_bases,
     agents,
+    conversations,
     agent_stats,
     chat,
     tools,
@@ -42,6 +43,9 @@ api_router.include_router(
     knowledge_bases.router, prefix="/knowledge-bases", tags=["knowledge-bases"]
 )
 api_router.include_router(agents.router, prefix="/agents", tags=["agents"])
+api_router.include_router(
+    conversations.router, prefix="/conversations", tags=["conversations"]
+)
 api_router.include_router(agent_stats.router, prefix="/agents", tags=["agent-stats"])
 api_router.include_router(chat.router, prefix="/agents", tags=["chat"])
 api_router.include_router(tools.router, prefix="/tools", tags=["tools"])

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -13,7 +13,8 @@ from tortoise.expressions import F, Q
 from tortoise.functions import Count
 
 from app.api import deps
-from app.models.user import User, Team, TeamMember
+from app.api.team_access import check_team_access
+from app.models.user import User, TeamMember
 from app.models.model import TeamModel, Model
 from app.models.knowledge_base import KnowledgeBase
 from app.models.agent import (
@@ -66,39 +67,6 @@ def normalize_agent_visibility(visibility: str) -> str:
     return AgentVisibility.TEAM if visibility == AgentVisibility.PUBLIC else visibility
 
 
-async def check_team_access(
-    team_id: UUID, user: User, require_admin: bool = False
-) -> Team:
-    """Check if user has access to the team."""
-    team = await Team.filter(id=team_id).first()
-    if not team:
-        raise BusinessError(
-            code=ResponseCode.TEAM_NOT_FOUND,
-            msg_key="team_not_found",
-            status_code=404,
-        )
-
-    if user.is_superuser:
-        return team
-
-    membership = await TeamMember.filter(team=team, user=user).first()
-    if not membership:
-        raise BusinessError(
-            code=ResponseCode.NOT_TEAM_MEMBER,
-            msg_key="not_team_member",
-            status_code=403,
-        )
-
-    if require_admin and membership.role not in ["owner", "admin", "member"]:
-        raise BusinessError(
-            code=ResponseCode.TEAM_ADMIN_REQUIRED,
-            msg_key="team_admin_required",
-            status_code=403,
-        )
-
-    return team
-
-
 async def check_agent_access(
     agent_id: UUID, user: User, require_write: bool = False
 ) -> Agent:
@@ -117,21 +85,27 @@ async def check_agent_access(
             status_code=404,
         )
 
+    if user.is_superuser:
+        return agent
+
+    is_owner = agent.created_by and agent.created_by.id == user.id
     if agent.visibility == AgentVisibility.PRIVATE:
-        if (
-            agent.created_by
-            and agent.created_by.id != user.id
-            and not user.is_superuser
-        ):
-            raise BusinessError(
-                code=ResponseCode.AGENT_ACCESS_DENIED,
-                msg_key="agent_access_denied",
-                status_code=403,
-            )
-        if not agent.created_by and not user.is_superuser:
-            await check_team_access(agent.team.id, user, require_admin=require_write)
-    else:
-        await check_team_access(agent.team.id, user, require_admin=require_write)
+        if is_owner:
+            return agent
+        if not agent.created_by:
+            await check_team_access(agent.team.id, user)
+            if require_write:
+                await check_team_access(agent.team.id, user, require_admin=True)
+            return agent
+        raise BusinessError(
+            code=ResponseCode.AGENT_ACCESS_DENIED,
+            msg_key="agent_access_denied",
+            status_code=403,
+        )
+
+    await check_team_access(agent.team.id, user)
+    if require_write and not is_owner:
+        await check_team_access(agent.team.id, user, require_admin=True)
 
     return agent
 
@@ -324,6 +298,7 @@ async def list_agents(
     status: str | None = None,
     visibility: str | None = None,
     keyword: str | None = None,
+    own_only: bool = False,
     page: int = 1,
     page_size: int = 20,
     current_user: User = Depends(deps.PermissionChecker("agent:read")),
@@ -357,6 +332,9 @@ async def list_agents(
             )
             | Q(created_by=current_user, visibility=AgentVisibility.PRIVATE)
         )
+
+    if own_only and not current_user.is_superuser:
+        query = query.filter(created_by=current_user)
 
     if status:
         query = query.filter(status=status)
@@ -409,10 +387,13 @@ async def create_agent(
     *,
     request: Request,
     agent_in: AgentCreate,
-    current_user: User = Depends(deps.PermissionChecker("agent:create")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Create a new agent."""
     # Check team access
+    await deps.check_scoped_permission(
+        current_user, "agent:create", "team", agent_in.team_id
+    )
     team = await check_team_access(agent_in.team_id, current_user)
 
     # Check for duplicate name within the same team
@@ -553,10 +534,13 @@ async def update_agent(
     request: Request,
     agent_id: UUID,
     agent_in: AgentUpdate,
-    current_user: User = Depends(deps.PermissionChecker("agent:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Update an agent."""
     agent = await check_agent_access(agent_id, current_user, require_write=True)
+    await deps.check_scoped_permission(
+        current_user, "agent:update", "team", agent.team.id
+    )
 
     # Check for duplicate name within the same team (exclude self)
     if agent_in.name is not None and agent_in.name != agent.name:
@@ -859,10 +843,13 @@ async def unpublish_agent(
 async def duplicate_agent(
     agent_id: UUID,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("agent:create")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Duplicate an agent."""
     agent = await check_agent_access(agent_id, current_user)
+    await deps.check_scoped_permission(
+        current_user, "agent:create", "team", agent.team.id
+    )
 
     # Create a copy
     new_agent = await Agent.create(

--- a/backend/app/api/v1/endpoints/api_keys.py
+++ b/backend/app/api/v1/endpoints/api_keys.py
@@ -133,7 +133,7 @@ async def list_api_keys(
     ),
     user_id: Optional[list[UUID]] = Query(None, description="Filter by user ID"),
     search: Optional[str] = Query(None, description="Search by name or key prefix"),
-    current_user: User = Depends(deps.get_current_active_user),
+    current_user: User = Depends(deps.PermissionChecker("apikey:read")),
 ) -> Any:
     """
     List all API keys with optional filters.
@@ -198,7 +198,7 @@ async def list_api_keys(
 
 @router.get("/stats", response_model=Response[APIKeyStats])
 async def get_api_key_stats(
-    current_user: User = Depends(deps.get_current_active_user),
+    current_user: User = Depends(deps.PermissionChecker("apikey:read")),
 ) -> Any:
     """
     Get API key statistics.
@@ -235,7 +235,7 @@ async def create_api_key(
     *,
     request: Request,
     data: APIKeyCreate,
-    current_user: User = Depends(deps.get_current_active_user),
+    current_user: User = Depends(deps.PermissionChecker("apikey:create")),
 ) -> Any:
     """
     Create a new API key.
@@ -309,7 +309,7 @@ async def create_api_key(
 @router.get("/{api_key_id}", response_model=Response[APIKeyResponse])
 async def get_api_key(
     api_key_id: UUID,
-    current_user: User = Depends(deps.get_current_active_user),
+    current_user: User = Depends(deps.PermissionChecker("apikey:read")),
 ) -> Any:
     """
     Get a specific API key by ID.
@@ -327,7 +327,7 @@ async def update_api_key(
     request: Request,
     api_key_id: UUID,
     data: APIKeyUpdate,
-    current_user: User = Depends(deps.get_current_active_user),
+    current_user: User = Depends(deps.PermissionChecker("apikey:update")),
 ) -> Any:
     """
     Update an API key.
@@ -335,19 +335,26 @@ async def update_api_key(
     api_key = await get_api_key_or_404(api_key_id)
     await ensure_api_key_owner(api_key, current_user)
 
-    # 处理 Agent 关联更新
-    if data.agent_ids is not None:
-        new_agents = await collect_allowed_agents(data.agent_ids, current_user)
+    new_agents = (
+        await collect_allowed_agents(data.agent_ids, current_user)
+        if data.agent_ids is not None
+        else None
+    )
+    new_workflows = (
+        await collect_allowed_workflows(data.workflow_ids, current_user)
+        if data.workflow_ids is not None
+        else None
+    )
 
+    # 处理 Agent 关联更新
+    if new_agents is not None:
         # 清除现有关联并添加新关联
         await api_key.agents.clear()
         if new_agents:
             await api_key.agents.add(*new_agents)
 
     # 处理 Workflow 关联更新
-    if data.workflow_ids is not None:
-        new_workflows = await collect_allowed_workflows(data.workflow_ids, current_user)
-
+    if new_workflows is not None:
         # 清除现有关联并添加新关联
         await api_key.workflows.clear()
         if new_workflows:
@@ -395,7 +402,7 @@ async def update_api_key(
 async def delete_api_key(
     request: Request,
     api_key_id: UUID,
-    current_user: User = Depends(deps.get_current_active_user),
+    current_user: User = Depends(deps.PermissionChecker("apikey:delete")),
 ) -> Any:
     """
     Delete an API key.
@@ -429,7 +436,7 @@ async def delete_api_key(
 async def activate_api_key(
     request: Request,
     api_key_id: UUID,
-    current_user: User = Depends(deps.get_current_active_user),
+    current_user: User = Depends(deps.PermissionChecker("apikey:update")),
 ) -> Any:
     """
     Activate an API key.
@@ -466,7 +473,7 @@ async def activate_api_key(
 async def deactivate_api_key(
     request: Request,
     api_key_id: UUID,
-    current_user: User = Depends(deps.get_current_active_user),
+    current_user: User = Depends(deps.PermissionChecker("apikey:update")),
 ) -> Any:
     """
     Deactivate an API key.

--- a/backend/app/api/v1/endpoints/api_keys.py
+++ b/backend/app/api/v1/endpoints/api_keys.py
@@ -5,6 +5,8 @@ from fastapi import APIRouter, Depends, Query, Request
 from tortoise.expressions import Q
 
 from app.api import deps
+from app.api.workflow_access import check_workflow_access
+from app.api.v1.endpoints.agents import check_agent_access
 from app.core.timezone import now_utc
 from app.models.user import User
 from app.models.api_key import APIKey
@@ -77,6 +79,51 @@ async def build_api_key_response(
     return response_data
 
 
+async def ensure_api_key_owner(api_key: APIKey, current_user: User) -> None:
+    if current_user.is_superuser or api_key.user_id == current_user.id:
+        return
+    raise BusinessError(
+        code=ResponseCode.PERMISSION_DENIED,
+        msg_key="permission_denied",
+        status_code=403,
+    )
+
+
+async def get_api_key_or_404(api_key_id: UUID) -> APIKey:
+    api_key = (
+        await APIKey.filter(id=api_key_id)
+        .prefetch_related("user", "agents", "workflows")
+        .first()
+    )
+    if not api_key:
+        raise BusinessError(
+            code=ResponseCode.NOT_FOUND,
+            msg_key="api_key_not_found",
+            status_code=404,
+        )
+    return api_key
+
+
+async def collect_allowed_agents(
+    agent_ids: list[UUID] | None, user: User
+) -> list[Agent]:
+    agents = []
+    for agent_id in agent_ids or []:
+        agent = await check_agent_access(agent_id, user)
+        agents.append(agent)
+    return agents
+
+
+async def collect_allowed_workflows(
+    workflow_ids: list[UUID] | None, user: User
+) -> list[Any]:
+    workflows = []
+    for workflow_id in workflow_ids or []:
+        workflow = await check_workflow_access(workflow_id, user)
+        workflows.append(workflow)
+    return workflows
+
+
 @router.get("", response_model=Response[PageData[APIKeyResponse]])
 async def list_api_keys(
     page: int = 1,
@@ -86,7 +133,7 @@ async def list_api_keys(
     ),
     user_id: Optional[list[UUID]] = Query(None, description="Filter by user ID"),
     search: Optional[str] = Query(None, description="Search by name or key prefix"),
-    current_user: User = Depends(deps.PermissionChecker("apikey:read")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     List all API keys with optional filters.
@@ -151,7 +198,7 @@ async def list_api_keys(
 
 @router.get("/stats", response_model=Response[APIKeyStats])
 async def get_api_key_stats(
-    current_user: User = Depends(deps.PermissionChecker("apikey:read")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     Get API key statistics.
@@ -188,41 +235,16 @@ async def create_api_key(
     *,
     request: Request,
     data: APIKeyCreate,
-    current_user: User = Depends(deps.PermissionChecker("apikey:create")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     Create a new API key.
     The full key is only returned once at creation time.
     """
-    # 验证 Agent IDs（检查是否存在且用户有权限访问）
-    agents = []
-    if data.agent_ids:
-        for agent_id in data.agent_ids:
-            agent = await Agent.filter(id=agent_id).first()
-            if not agent:
-                raise BusinessError(
-                    code=ResponseCode.NOT_FOUND,
-                    msg_key="agent_not_found",
-                    status_code=404,
-                )
-            # 检查用户是否有权限访问该 Agent（通过团队成员关系）
-            # 简化：这里假设用户可以访问自己创建的或所在团队的 Agent
-            agents.append(agent)
+    agents = await collect_allowed_agents(data.agent_ids, current_user)
 
     # 验证 Workflow IDs（检查是否存在且用户有权限访问）
-    workflows = []
-    if data.workflow_ids:
-        from app.models.workflow import Workflow
-
-        for workflow_id in data.workflow_ids:
-            workflow = await Workflow.filter(id=workflow_id).first()
-            if not workflow:
-                raise BusinessError(
-                    code=ResponseCode.NOT_FOUND,
-                    msg_key="workflow_not_found",
-                    status_code=404,
-                )
-            workflows.append(workflow)
+    workflows = await collect_allowed_workflows(data.workflow_ids, current_user)
 
     # Generate API key
     full_key, key_prefix, key_hash = APIKey.generate_key()
@@ -287,31 +309,13 @@ async def create_api_key(
 @router.get("/{api_key_id}", response_model=Response[APIKeyResponse])
 async def get_api_key(
     api_key_id: UUID,
-    current_user: User = Depends(deps.PermissionChecker("apikey:read")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     Get a specific API key by ID.
     """
-    api_key = (
-        await APIKey.filter(id=api_key_id)
-        .prefetch_related("user", "agents", "workflows")
-        .first()
-    )
-
-    if not api_key:
-        raise BusinessError(
-            code=ResponseCode.NOT_FOUND,
-            msg_key="api_key_not_found",
-            status_code=404,
-        )
-
-    # Check permission - admin can see all, user can only see their own
-    if not current_user.is_superuser and api_key.user_id != current_user.id:
-        raise BusinessError(
-            code=ResponseCode.PERMISSION_DENIED,
-            msg_key="permission_denied",
-            status_code=403,
-        )
+    api_key = await get_api_key_or_404(api_key_id)
+    await ensure_api_key_owner(api_key, current_user)
 
     response_data = await build_api_key_response(api_key)
     return success(data=response_data)
@@ -323,45 +327,17 @@ async def update_api_key(
     request: Request,
     api_key_id: UUID,
     data: APIKeyUpdate,
-    current_user: User = Depends(deps.PermissionChecker("apikey:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     Update an API key.
     """
-    api_key = (
-        await APIKey.filter(id=api_key_id)
-        .prefetch_related("user", "agents", "workflows")
-        .first()
-    )
-
-    if not api_key:
-        raise BusinessError(
-            code=ResponseCode.NOT_FOUND,
-            msg_key="api_key_not_found",
-            status_code=404,
-        )
-
-    # Check permission
-    if not current_user.is_superuser and api_key.user_id != current_user.id:
-        raise BusinessError(
-            code=ResponseCode.PERMISSION_DENIED,
-            msg_key="permission_denied",
-            status_code=403,
-        )
+    api_key = await get_api_key_or_404(api_key_id)
+    await ensure_api_key_owner(api_key, current_user)
 
     # 处理 Agent 关联更新
     if data.agent_ids is not None:
-        # 验证新的 Agent IDs
-        new_agents = []
-        for agent_id in data.agent_ids:
-            agent = await Agent.filter(id=agent_id).first()
-            if not agent:
-                raise BusinessError(
-                    code=ResponseCode.NOT_FOUND,
-                    msg_key="agent_not_found",
-                    status_code=404,
-                )
-            new_agents.append(agent)
+        new_agents = await collect_allowed_agents(data.agent_ids, current_user)
 
         # 清除现有关联并添加新关联
         await api_key.agents.clear()
@@ -370,19 +346,7 @@ async def update_api_key(
 
     # 处理 Workflow 关联更新
     if data.workflow_ids is not None:
-        # 验证新的 Workflow IDs
-        from app.models.workflow import Workflow
-
-        new_workflows = []
-        for workflow_id in data.workflow_ids:
-            workflow = await Workflow.filter(id=workflow_id).first()
-            if not workflow:
-                raise BusinessError(
-                    code=ResponseCode.NOT_FOUND,
-                    msg_key="workflow_not_found",
-                    status_code=404,
-                )
-            new_workflows.append(workflow)
+        new_workflows = await collect_allowed_workflows(data.workflow_ids, current_user)
 
         # 清除现有关联并添加新关联
         await api_key.workflows.clear()
@@ -431,31 +395,13 @@ async def update_api_key(
 async def delete_api_key(
     request: Request,
     api_key_id: UUID,
-    current_user: User = Depends(deps.PermissionChecker("apikey:delete")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     Delete an API key.
     """
-    api_key = (
-        await APIKey.filter(id=api_key_id)
-        .prefetch_related("user", "agents", "workflows")
-        .first()
-    )
-
-    if not api_key:
-        raise BusinessError(
-            code=ResponseCode.NOT_FOUND,
-            msg_key="api_key_not_found",
-            status_code=404,
-        )
-
-    # Check permission
-    if not current_user.is_superuser and api_key.user_id != current_user.id:
-        raise BusinessError(
-            code=ResponseCode.PERMISSION_DENIED,
-            msg_key="permission_denied",
-            status_code=403,
-        )
+    api_key = await get_api_key_or_404(api_key_id)
+    await ensure_api_key_owner(api_key, current_user)
 
     # Store for response
     response_data = await build_api_key_response(api_key)
@@ -483,31 +429,13 @@ async def delete_api_key(
 async def activate_api_key(
     request: Request,
     api_key_id: UUID,
-    current_user: User = Depends(deps.PermissionChecker("apikey:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     Activate an API key.
     """
-    api_key = (
-        await APIKey.filter(id=api_key_id)
-        .prefetch_related("agents", "workflows", "user")
-        .first()
-    )
-
-    if not api_key:
-        raise BusinessError(
-            code=ResponseCode.NOT_FOUND,
-            msg_key="api_key_not_found",
-            status_code=404,
-        )
-
-    # Check permission
-    if not current_user.is_superuser and api_key.user_id != current_user.id:
-        raise BusinessError(
-            code=ResponseCode.PERMISSION_DENIED,
-            msg_key="permission_denied",
-            status_code=403,
-        )
+    api_key = await get_api_key_or_404(api_key_id)
+    await ensure_api_key_owner(api_key, current_user)
 
     if api_key.is_active:
         raise BusinessError(
@@ -538,31 +466,13 @@ async def activate_api_key(
 async def deactivate_api_key(
     request: Request,
     api_key_id: UUID,
-    current_user: User = Depends(deps.PermissionChecker("apikey:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     Deactivate an API key.
     """
-    api_key = (
-        await APIKey.filter(id=api_key_id)
-        .prefetch_related("agents", "workflows", "user")
-        .first()
-    )
-
-    if not api_key:
-        raise BusinessError(
-            code=ResponseCode.NOT_FOUND,
-            msg_key="api_key_not_found",
-            status_code=404,
-        )
-
-    # Check permission
-    if not current_user.is_superuser and api_key.user_id != current_user.id:
-        raise BusinessError(
-            code=ResponseCode.PERMISSION_DENIED,
-            msg_key="permission_denied",
-            status_code=403,
-        )
+    api_key = await get_api_key_or_404(api_key_id)
+    await ensure_api_key_owner(api_key, current_user)
 
     if not api_key.is_active:
         raise BusinessError(

--- a/backend/app/api/v1/endpoints/conversations.py
+++ b/backend/app/api/v1/endpoints/conversations.py
@@ -65,6 +65,25 @@ async def check_team_access(team_id: UUID, user: User) -> Team:
     return team
 
 
+def _has_global_dashboard_access(user: User) -> bool:
+    if user.is_superuser:
+        return True
+    return any(
+        perm.code in ("admin:dashboard:access", "*")
+        for role in user.roles
+        for perm in role.permissions
+    )
+
+
+async def has_conversation_team_admin_access(user: User, team_id: UUID | None) -> bool:
+    if _has_global_dashboard_access(user):
+        return True
+    if not team_id:
+        return False
+    membership = await TeamMember.filter(team_id=team_id, user=user).first()
+    return bool(membership and membership.role in ["owner", "admin"])
+
+
 async def get_user_team_agent_ids(
     user: User, team_id: UUID | None = None
 ) -> list[UUID]:
@@ -111,19 +130,12 @@ async def list_all_conversations(
     List conversations.
 
     - Super Admin: Can see all conversations
-    - Admin (has dashboard:access): Can see all conversations in their teams
+    - Admin (has admin:dashboard:access): Can see all conversations in their teams
     - Member/Viewer: Can only see their own conversations
     """
-    # Check if user has dashboard:access permission (Admin level)
-    has_dashboard_access = current_user.is_superuser
-    if not has_dashboard_access:
-        for role in current_user.roles:
-            for perm in role.permissions:
-                if perm.code == "dashboard:access" or perm.code == "*":
-                    has_dashboard_access = True
-                    break
-            if has_dashboard_access:
-                break
+    has_dashboard_access = await has_conversation_team_admin_access(
+        current_user, team_id
+    )
 
     # Get agent IDs user has access to (team isolation for non-superusers)
     accessible_agent_ids = await get_user_team_agent_ids(current_user, team_id)
@@ -221,16 +233,9 @@ async def get_conversation_stats(
     - Super Admin/Admin: Stats for all conversations in accessible teams
     - Member/Viewer: Stats for their own conversations only
     """
-    # Check if user has dashboard:access permission (Admin level)
-    has_dashboard_access = current_user.is_superuser
-    if not has_dashboard_access:
-        for role in current_user.roles:
-            for perm in role.permissions:
-                if perm.code == "dashboard:access" or perm.code == "*":
-                    has_dashboard_access = True
-                    break
-            if has_dashboard_access:
-                break
+    has_dashboard_access = await has_conversation_team_admin_access(
+        current_user, team_id
+    )
 
     # Get agent IDs user has access to
     agent_ids = await get_user_team_agent_ids(current_user, team_id)
@@ -313,16 +318,9 @@ async def get_conversation_trends(
     - Super Admin/Admin: Trends for all conversations in accessible teams
     - Member/Viewer: Trends for their own conversations only
     """
-    # Check if user has dashboard:access permission (Admin level)
-    has_dashboard_access = current_user.is_superuser
-    if not has_dashboard_access:
-        for role in current_user.roles:
-            for perm in role.permissions:
-                if perm.code == "dashboard:access" or perm.code == "*":
-                    has_dashboard_access = True
-                    break
-            if has_dashboard_access:
-                break
+    has_dashboard_access = await has_conversation_team_admin_access(
+        current_user, team_id
+    )
 
     now_local = now()
 
@@ -368,6 +366,13 @@ async def get_conversation_trends(
     if not has_dashboard_access:
         conv_query = conv_query.filter(user_id=current_user.id)
 
+    user_map: dict[UUID, str] = {}
+    if has_dashboard_access and team_id:
+        team_user_rows = await TeamMember.filter(team_id=team_id).prefetch_related(
+            "user"
+        )
+        user_map = {member.user.id: member.user.username for member in team_user_rows}
+
     # Use database-level aggregation for conversation counts by day
     # Build time series data grouped by day
     data_points = []
@@ -382,12 +387,22 @@ async def get_conversation_trends(
         point_end_utc = to_utc(point_end)
 
         # Count conversations created in this day using database query
-        conv_count = await conv_query.filter(
+        day_conv_query = conv_query.filter(
             created_at__gte=point_start_utc, created_at__lt=point_end_utc
-        ).count()
+        )
+        conv_count = await day_conv_query.count()
 
         # Count messages for conversations in accessible scope (not just today's conversations)
         all_conv_ids = await conv_query.values_list("id", flat=True)
+        user_usage = {
+            str(user_id): {"name": username, "conversations": 0, "tokens": 0}
+            for user_id, username in user_map.items()
+        }
+        if has_dashboard_access:
+            day_conversations = await day_conv_query.all()
+            for conversation in day_conversations:
+                if conversation.user_id in user_map:
+                    user_usage[str(conversation.user_id)]["conversations"] += 1
         if all_conv_ids:
             msg_count = await Message.filter(
                 conversation_id__in=list(all_conv_ids),
@@ -408,6 +423,20 @@ async def get_conversation_trends(
                 if m["token_usage"]:
                     tokens += m["token_usage"].get("prompt", 0) or 0
                     tokens += m["token_usage"].get("completion", 0) or 0
+
+            if has_dashboard_access:
+                token_rows = await Message.filter(
+                    conversation_id__in=list(all_conv_ids),
+                    created_at__gte=point_start_utc,
+                    created_at__lt=point_end_utc,
+                    token_usage__isnull=False,
+                ).prefetch_related("conversation")
+                for message in token_rows:
+                    user_id = message.conversation.user_id
+                    if user_id in user_map and message.token_usage:
+                        user_usage[str(user_id)]["tokens"] += (
+                            message.token_usage.get("prompt", 0) or 0
+                        ) + (message.token_usage.get("completion", 0) or 0)
         else:
             msg_count = 0
             tokens = 0
@@ -421,6 +450,7 @@ async def get_conversation_trends(
                 "conversations": conv_count,
                 "messages": msg_count,
                 "tokens": tokens,
+                "users": user_usage,
             }
         )
 
@@ -458,11 +488,11 @@ async def get_conversation_detail(
 
     # Check access permissions
     if not current_user.is_superuser:
-        # Check if user has dashboard:access permission (Admin level)
+        # Check if user has admin:dashboard:access permission (Admin level)
         has_dashboard_access = False
         for role in current_user.roles:
             for perm in role.permissions:
-                if perm.code == "dashboard:access" or perm.code == "*":
+                if perm.code == "admin:dashboard:access" or perm.code == "*":
                     has_dashboard_access = True
                     break
             if has_dashboard_access:
@@ -551,11 +581,11 @@ async def delete_conversation_admin(
 
     # Check access permissions
     if not current_user.is_superuser:
-        # Check if user has dashboard:access permission (Admin level)
+        # Check if user has admin:dashboard:access permission (Admin level)
         has_dashboard_access = False
         for role in current_user.roles:
             for perm in role.permissions:
-                if perm.code == "dashboard:access" or perm.code == "*":
+                if perm.code == "admin:dashboard:access" or perm.code == "*":
                     has_dashboard_access = True
                     break
             if has_dashboard_access:
@@ -633,11 +663,11 @@ async def batch_delete_conversations(
 
     # Check access permissions
     if not current_user.is_superuser:
-        # Check if user has dashboard:access permission (Admin level)
+        # Check if user has admin:dashboard:access permission (Admin level)
         has_dashboard_access = False
         for role in current_user.roles:
             for perm in role.permissions:
-                if perm.code == "dashboard:access" or perm.code == "*":
+                if perm.code == "admin:dashboard:access" or perm.code == "*":
                     has_dashboard_access = True
                     break
             if has_dashboard_access:

--- a/backend/app/api/v1/endpoints/knowledge_bases.py
+++ b/backend/app/api/v1/endpoints/knowledge_bases.py
@@ -178,7 +178,8 @@ async def require_kb_read(
     current_user: User = Depends(deps.get_current_active_user),
 ) -> User:
     user = await require_kb_permission(request, current_user)
-    _require_kb_action(user, "read")
+    if _kb_access_mode.get() == "admin":
+        _require_kb_action(user, "read")
     return user
 
 
@@ -187,7 +188,8 @@ async def require_kb_create(
     current_user: User = Depends(deps.get_current_active_user),
 ) -> User:
     user = await require_kb_permission(request, current_user)
-    _require_kb_action(user, "create")
+    if _kb_access_mode.get() == "admin":
+        _require_kb_action(user, "create")
     return user
 
 
@@ -196,7 +198,8 @@ async def require_kb_update(
     current_user: User = Depends(deps.get_current_active_user),
 ) -> User:
     user = await require_kb_permission(request, current_user)
-    _require_kb_action(user, "update")
+    if _kb_access_mode.get() == "admin":
+        _require_kb_action(user, "update")
     return user
 
 
@@ -205,7 +208,8 @@ async def require_kb_delete(
     current_user: User = Depends(deps.get_current_active_user),
 ) -> User:
     user = await require_kb_permission(request, current_user)
-    _require_kb_action(user, "delete")
+    if _kb_access_mode.get() == "admin":
+        _require_kb_action(user, "delete")
     return user
 
 
@@ -335,7 +339,10 @@ async def ensure_team_authorized_model(
 
 
 async def check_kb_access(
-    kb_id: UUID, user: User, require_write: bool = False
+    kb_id: UUID,
+    user: User,
+    require_write: bool = False,
+    allow_owner_write: bool = True,
 ) -> KnowledgeBase:
     """
     Check if user has access to the knowledge base.
@@ -353,8 +360,13 @@ async def check_kb_access(
             status_code=404,
         )
 
-    # Check team access
-    await check_team_access(kb.team.id, user, require_admin=require_write)
+    if user.is_superuser or _kb_access_mode.get() == "admin":
+        return kb
+
+    is_owner = kb.created_by and kb.created_by.id == user.id
+    await check_team_access(kb.team.id, user)
+    if require_write and (not allow_owner_write or not is_owner):
+        await check_team_access(kb.team.id, user, require_admin=True)
     return kb
 
 
@@ -366,6 +378,7 @@ async def list_knowledge_bases(
     team_id: UUID | None = None,
     search: str | None = None,
     status: list[str] | None = None,
+    own_only: bool = False,
     page: int = 1,
     page_size: int = 20,
     current_user: User = Depends(require_kb_read),
@@ -387,6 +400,9 @@ async def list_knowledge_bases(
             "team_id", flat=True
         )
         query = query.filter(team_id__in=memberships)
+
+    if own_only and not current_user.is_superuser:
+        query = query.filter(created_by=current_user)
 
     if search:
         query = query.filter(name__icontains=search)
@@ -593,7 +609,9 @@ async def delete_knowledge_base(
     Delete knowledge base and all its documents.
     Requires admin permission in the team.
     """
-    kb = await check_kb_access(kb_id, current_user, require_write=True)
+    kb = await check_kb_access(
+        kb_id, current_user, require_write=True, allow_owner_write=False
+    )
     kb_name = kb.name
 
     # Delete all documents and chunks (cascades)

--- a/backend/app/api/v1/endpoints/teams.py
+++ b/backend/app/api/v1/endpoints/teams.py
@@ -37,7 +37,7 @@ router = APIRouter()
 
 @router.get("/my", response_model=Response[List[UserTeamInfo]])
 async def get_my_teams(
-    current_user: User = Depends(deps.PermissionChecker("team:read")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Get all teams the current user belongs to with their role."""
     memberships = await TeamMember.filter(user=current_user).prefetch_related("team")
@@ -61,9 +61,10 @@ async def get_my_teams(
 @router.get("/{team_id}", response_model=Response[TeamWithMembers])
 async def get_team(
     team_id: UUID,
-    current_user: User = Depends(deps.PermissionChecker("team:read")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Get team by ID with members list."""
+    await deps.check_scoped_permission(current_user, "team:read", "team", team_id)
     team = await Team.filter(id=team_id).prefetch_related("owner").first()
     if not team:
         raise BusinessError(
@@ -117,9 +118,10 @@ async def update_team(
     request: Request,
     team_id: UUID,
     team_in: TeamUpdate,
-    current_user: User = Depends(deps.PermissionChecker("team:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Update team info. Only owner or admin can update."""
+    await deps.check_scoped_permission(current_user, "team:update", "team", team_id)
     team = await Team.filter(id=team_id).first()
     if not team:
         raise BusinessError(
@@ -183,9 +185,10 @@ async def add_team_member(
     request: Request,
     team_id: UUID,
     member_in: TeamMemberAdd,
-    current_user: User = Depends(deps.PermissionChecker("team:manage")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Add a member to the team. Only owner or admin can add members."""
+    await deps.check_scoped_permission(current_user, "team:manage", "team", team_id)
     team = await Team.filter(id=team_id).first()
     if not team:
         raise BusinessError(
@@ -297,9 +300,10 @@ async def update_team_member(
     team_id: UUID,
     user_id: UUID,
     member_in: TeamMemberUpdate,
-    current_user: User = Depends(deps.PermissionChecker("team:manage")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Update member role. Only owner can change roles."""
+    await deps.check_scoped_permission(current_user, "team:manage", "team", team_id)
     team = await Team.filter(id=team_id).first()
     if not team:
         raise BusinessError(
@@ -385,9 +389,10 @@ async def remove_team_member(
     request: Request,
     team_id: UUID,
     user_id: UUID,
-    current_user: User = Depends(deps.PermissionChecker("team:manage")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Remove a member from the team."""
+    await deps.check_scoped_permission(current_user, "team:manage", "team", team_id)
     team = await Team.filter(id=team_id).first()
     if not team:
         raise BusinessError(
@@ -481,9 +486,10 @@ async def remove_team_member(
 @router.post("/{team_id}/leave", response_model=Response[dict])
 async def leave_team(
     team_id: UUID,
-    current_user: User = Depends(deps.PermissionChecker("team:read")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Leave a team. Owner cannot leave without transferring ownership first."""
+    await deps.check_scoped_permission(current_user, "team:read", "team", team_id)
     team = await Team.filter(id=team_id).first()
     if not team:
         raise BusinessError(
@@ -517,13 +523,14 @@ async def transfer_ownership(
     *,
     team_id: UUID,
     new_owner_id: UUID,
-    current_user: User = Depends(deps.PermissionChecker("team:manage")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     Transfer team ownership to another member.
 
     Only current owner or superuser can do this.
     """
+    await deps.check_scoped_permission(current_user, "team:manage", "team", team_id)
     team = await Team.filter(id=team_id).first()
     if not team:
         raise BusinessError(

--- a/backend/app/api/v1/endpoints/teams.py
+++ b/backend/app/api/v1/endpoints/teams.py
@@ -392,7 +392,9 @@ async def remove_team_member(
     current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Remove a member from the team."""
-    await deps.check_scoped_permission(current_user, "team:manage", "team", team_id)
+    is_self = str(user_id) == str(current_user.id)
+    if not is_self:
+        await deps.check_scoped_permission(current_user, "team:manage", "team", team_id)
     team = await Team.filter(id=team_id).first()
     if not team:
         raise BusinessError(
@@ -423,7 +425,6 @@ async def remove_team_member(
             msg_key="cannot_remove_owner",
         )
 
-    is_self = str(target_user.id) == str(current_user.id)
     if not is_self and not current_user.is_superuser:
         current_membership = await TeamMember.filter(
             team=team, user=current_user

--- a/backend/app/api/v1/endpoints/tools.py
+++ b/backend/app/api/v1/endpoints/tools.py
@@ -15,6 +15,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Query, Request
 
 from app.api import deps
+from app.api.team_access import check_team_access
 from app.core.i18n import has_translation, t
 from app.models.user import User, Team, TeamMember
 from app.models.tool import (
@@ -97,37 +98,14 @@ def _runtime_duration_ms(runtime_result: Any) -> int | None:
 # ============ Helper Functions ============
 
 
-async def check_team_access(
-    team_id: UUID, user: User, require_admin: bool = False
-) -> Team:
-    """检查用户是否有团队访问权限"""
-    team = await Team.filter(id=team_id).first()
-    if not team:
-        raise BusinessError(
-            code=ResponseCode.TEAM_NOT_FOUND,
-            msg_key="team_not_found",
-            status_code=404,
-        )
-
+async def check_tool_write_access(tool: Tool, user: User) -> None:
+    """Allow creators to edit their tools; team owner/admin can edit all team tools."""
     if user.is_superuser:
-        return team
+        return
 
-    membership = await TeamMember.filter(team=team, user=user).first()
-    if not membership:
-        raise BusinessError(
-            code=ResponseCode.NOT_TEAM_MEMBER,
-            msg_key="not_team_member",
-            status_code=403,
-        )
-
-    if require_admin and membership.role not in ["owner", "admin"]:
-        raise BusinessError(
-            code=ResponseCode.TEAM_ADMIN_REQUIRED,
-            msg_key="team_admin_required",
-            status_code=403,
-        )
-
-    return team
+    await check_team_access(tool.team_id, user)
+    if tool.created_by_id != user.id:
+        await check_team_access(tool.team_id, user, require_admin=True)
 
 
 def _get_builtin_tool_description(
@@ -230,6 +208,7 @@ def db_tool_to_out(tool: Tool, creator_name: str | None = None) -> ToolOut:
         code_config=CodeConfigSchema(**tool.code_config) if tool.code_config else None,
         mcp_config=McpConfigSchema(**tool.mcp_config) if tool.mcp_config else None,
         team_id=tool.team_id,
+        created_by_id=tool.created_by_id,
         created_by_name=creator_name,
     )
 
@@ -654,12 +633,11 @@ async def create_tool(
     team_id: UUID,
     tool_in: ToolCreateInput,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("tool:create")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """创建自定义工具"""
-    await check_team_access(team_id, current_user, require_admin=True)
-
-    # 检查名称是否已存在
+    await check_team_access(team_id, current_user)
+    await deps.check_scoped_permission(current_user, "tool:create", "team", team_id)
     existing = await Tool.filter(team_id=team_id, name=tool_in.name).first()
     if existing:
         raise BusinessError(
@@ -781,7 +759,7 @@ async def update_tool(
             status_code=404,
         )
 
-    await check_team_access(tool.team_id, current_user, require_admin=True)
+    await check_tool_write_access(tool, current_user)
 
     # 如果修改名称，检查是否冲突
     if tool_in.name and tool_in.name != tool.name:
@@ -1176,7 +1154,7 @@ async def toggle_tool(
             status_code=404,
         )
 
-    await check_team_access(tool.team_id, current_user, require_admin=True)
+    await check_tool_write_access(tool, current_user)
 
     tool.is_enabled = not tool.is_enabled
     await tool.save()
@@ -1369,7 +1347,7 @@ async def create_tool_config(
     config_data = ToolConfigCreate(**data)
 
     if team_id:
-        await check_team_access(team_id, current_user)
+        await check_team_access(team_id, current_user, require_admin=True)
     else:
         if not current_user.is_superuser:
             raise BusinessError(
@@ -1432,7 +1410,7 @@ async def update_tool_config(
     config_data = ToolConfigUpdate(**data)
 
     if team_id:
-        await check_team_access(team_id, current_user)
+        await check_team_access(team_id, current_user, require_admin=True)
         config = await ToolConfig.filter(tool_name=tool_name, team_id=team_id).first()
     else:
         if not current_user.is_superuser:
@@ -1485,7 +1463,7 @@ async def delete_tool_config(
     from app.models.tool_config import ToolConfig
 
     if team_id:
-        await check_team_access(team_id, current_user)
+        await check_team_access(team_id, current_user, require_admin=True)
         config = await ToolConfig.filter(tool_name=tool_name, team_id=team_id).first()
     else:
         if not current_user.is_superuser:

--- a/backend/app/api/v1/endpoints/tools.py
+++ b/backend/app/api/v1/endpoints/tools.py
@@ -760,6 +760,9 @@ async def update_tool(
         )
 
     await check_tool_write_access(tool, current_user)
+    await deps.check_scoped_permission(
+        current_user, "tool:update", "team", tool.team_id
+    )
 
     # 如果修改名称，检查是否冲突
     if tool_in.name and tool_in.name != tool.name:
@@ -1155,6 +1158,9 @@ async def toggle_tool(
         )
 
     await check_tool_write_access(tool, current_user)
+    await deps.check_scoped_permission(
+        current_user, "tool:update", "team", tool.team_id
+    )
 
     tool.is_enabled = not tool.is_enabled
     await tool.save()

--- a/backend/app/api/v1/endpoints/tools.py
+++ b/backend/app/api/v1/endpoints/tools.py
@@ -748,7 +748,7 @@ async def update_tool(
     tool_id: UUID,
     tool_in: ToolUpdateInput,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("tool:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """更新工具"""
     tool = await Tool.filter(id=tool_id).prefetch_related("created_by").first()
@@ -821,7 +821,7 @@ async def update_tool(
 async def delete_tool(
     tool_id: UUID,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("tool:delete")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """删除工具"""
     tool = await Tool.filter(id=tool_id).first()
@@ -1143,7 +1143,7 @@ async def execute_code_directly(
 async def toggle_tool(
     tool_id: UUID,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("tool:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """切换工具启用状态"""
     tool = await Tool.filter(id=tool_id).prefetch_related("created_by").first()
@@ -1336,7 +1336,7 @@ async def create_tool_config(
     data: dict,
     request: Request,
     team_id: UUID | None = None,
-    current_user: User = Depends(deps.PermissionChecker("tool:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     创建工具配置
@@ -1399,7 +1399,7 @@ async def update_tool_config(
     data: dict,
     request: Request,
     team_id: UUID | None = None,
-    current_user: User = Depends(deps.PermissionChecker("tool:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     更新工具配置
@@ -1455,7 +1455,7 @@ async def delete_tool_config(
     tool_name: str,
     request: Request,
     team_id: UUID | None = None,
-    current_user: User = Depends(deps.PermissionChecker("tool:delete")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     删除工具配置
@@ -1510,7 +1510,7 @@ async def share_tool(
     tool_id: UUID,
     share_data: ToolShareInput,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("tool:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     共享工具给其他团队
@@ -1660,7 +1660,7 @@ async def unshare_tool(
     tool_id: UUID,
     team_id: UUID,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("tool:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
     取消工具共享

--- a/backend/app/api/v1/endpoints/workflows.py
+++ b/backend/app/api/v1/endpoints/workflows.py
@@ -14,9 +14,11 @@ from fastapi.responses import StreamingResponse
 from tortoise.expressions import Q
 
 from app.api import deps
+from app.api.team_access import check_team_access
+from app.api.workflow_access import check_workflow_access
 from app.core.i18n import t
 from app.core.timezone import now, to_local, to_utc
-from app.models.user import User, Team, TeamMember
+from app.models.user import User, TeamMember
 from app.models.workflow import (
     Workflow,
     WorkflowRun,
@@ -67,79 +69,6 @@ def normalize_webhook_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
     if len(inputs) == 1 and isinstance(nested_inputs, dict):
         return nested_inputs
     return inputs
-
-
-async def check_team_access(
-    team_id: UUID, user: User, require_admin: bool = False
-) -> Team:
-    """Check if user has access to the team."""
-    team = await Team.filter(id=team_id).first()
-    if not team:
-        raise BusinessError(
-            code=ResponseCode.TEAM_NOT_FOUND,
-            msg_key="team_not_found",
-            status_code=404,
-        )
-
-    if user.is_superuser:
-        return team
-
-    membership = await TeamMember.filter(team=team, user=user).first()
-    if not membership:
-        raise BusinessError(
-            code=ResponseCode.NOT_TEAM_MEMBER,
-            msg_key="not_team_member",
-            status_code=403,
-        )
-
-    if require_admin and membership.role not in ["owner", "admin", "member"]:
-        raise BusinessError(
-            code=ResponseCode.TEAM_ADMIN_REQUIRED,
-            msg_key="team_admin_required",
-            status_code=403,
-        )
-
-    return team
-
-
-async def check_workflow_access(
-    workflow_id: UUID, user: User, require_write: bool = False
-) -> Workflow:
-    """Check if user has access to the workflow."""
-    workflow = (
-        await Workflow.filter(id=workflow_id)
-        .prefetch_related("team", "created_by")
-        .first()
-    )
-    if not workflow:
-        raise BusinessError(
-            code=ResponseCode.NOT_FOUND,
-            msg_key="workflow_not_found",
-            status_code=404,
-        )
-
-    # Check visibility and team access
-    if workflow.visibility == WorkflowVisibility.PRIVATE:
-        # Only creator (or superuser) can access private workflows
-        # If creator is deleted, fall back to team-level access
-        if (
-            workflow.created_by
-            and workflow.created_by.id != user.id
-            and not user.is_superuser
-        ):
-            raise BusinessError(
-                code=ResponseCode.FORBIDDEN,
-                msg_key="workflow_access_denied",
-                status_code=403,
-            )
-        elif not workflow.created_by and not user.is_superuser:
-            # Creator deleted, check team access
-            await check_team_access(workflow.team.id, user, require_admin=require_write)
-    else:
-        # Team/public visibility - check team membership
-        await check_team_access(workflow.team.id, user, require_admin=require_write)
-
-    return workflow
 
 
 # ============ Global Workflow Runs (must be before /{workflow_id} routes) ============
@@ -384,6 +313,7 @@ async def list_workflows(
     trigger_type: TriggerType | None = None,
     visibility: str | None = None,
     keyword: str | None = None,
+    own_only: bool = False,
     page: int = 1,
     page_size: int = 20,
     current_user: User = Depends(deps.PermissionChecker("workflow:read")),
@@ -432,6 +362,9 @@ async def list_workflows(
             )
         )
 
+    if own_only and not current_user.is_superuser:
+        query = query.filter(created_by=current_user)
+
     if status:
         query = query.filter(status=status)
 
@@ -448,13 +381,24 @@ async def list_workflows(
 
     total = await query.count()
     skip = (page - 1) * page_size
-    workflows = await query.offset(skip).limit(page_size).order_by("-updated_at")
+    workflows = (
+        await query.prefetch_related("created_by")
+        .offset(skip)
+        .limit(page_size)
+        .order_by("-updated_at")
+    )
 
-    workflow_list = [WorkflowListItem.model_validate(w) for w in workflows]
+    workflow_list = []
+    for workflow in workflows:
+        item = WorkflowListItem.model_validate(workflow).model_dump()
+        item["created_by_name"] = (
+            workflow.created_by.username if workflow.created_by else None
+        )
+        workflow_list.append(item)
 
     return success(
         data={
-            "items": [w.model_dump() for w in workflow_list],
+            "items": workflow_list,
             "total": total,
             "page": page,
             "page_size": page_size,
@@ -467,10 +411,13 @@ async def create_workflow(
     *,
     workflow_in: WorkflowCreate,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("workflow:create")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Create a new workflow."""
     # Check team access
+    await deps.check_scoped_permission(
+        current_user, "workflow:create", "team", workflow_in.team_id
+    )
     team = await check_team_access(workflow_in.team_id, current_user)
 
     # Check for duplicate name within the same team
@@ -708,11 +655,14 @@ async def update_workflow(
     workflow_id: UUID,
     workflow_in: WorkflowUpdate,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("workflow:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Update a workflow."""
     workflow = await check_workflow_access(
         workflow_id, current_user, require_write=True
+    )
+    await deps.check_scoped_permission(
+        current_user, "workflow:update", "team", workflow.team_id
     )
 
     # Check for duplicate name within the same team (exclude self)
@@ -889,10 +839,13 @@ async def unpublish_workflow(
 async def duplicate_workflow(
     workflow_id: UUID,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("workflow:create")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Duplicate a workflow."""
     workflow = await check_workflow_access(workflow_id, current_user)
+    await deps.check_scoped_permission(
+        current_user, "workflow:create", "team", workflow.team_id
+    )
 
     # Create a copy
     new_workflow = await Workflow.create(
@@ -939,11 +892,14 @@ async def duplicate_workflow(
 async def regenerate_webhook_token(
     workflow_id: UUID,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("workflow:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Regenerate webhook token for a workflow."""
     workflow = await check_workflow_access(
         workflow_id, current_user, require_write=True
+    )
+    await deps.check_scoped_permission(
+        current_user, "workflow:update", "team", workflow.team_id
     )
 
     workflow.webhook_token = secrets.token_urlsafe(32)
@@ -1606,11 +1562,12 @@ async def create_workflow_version(
     workflow_id: UUID,
     version_in: WorkflowVersionCreate,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("workflow:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Manually create a version snapshot of the current workflow state."""
-    workflow = await check_workflow_access(
-        workflow_id, current_user, require_write=True
+    workflow = await check_workflow_access(workflow_id, current_user)
+    await deps.check_scoped_permission(
+        current_user, "workflow:update", "team", workflow.team_id
     )
 
     # Create version snapshot
@@ -1651,11 +1608,12 @@ async def restore_workflow_version(
     version: int,
     restore_in: WorkflowVersionRestore,
     request: Request,
-    current_user: User = Depends(deps.PermissionChecker("workflow:update")),
+    current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Restore a workflow to a specific version."""
-    workflow = await check_workflow_access(
-        workflow_id, current_user, require_write=True
+    workflow = await check_workflow_access(workflow_id, current_user)
+    await deps.check_scoped_permission(
+        current_user, "workflow:update", "team", workflow.team_id
     )
 
     # Get the version to restore

--- a/backend/app/api/v1/endpoints/workflows.py
+++ b/backend/app/api/v1/endpoints/workflows.py
@@ -842,7 +842,9 @@ async def duplicate_workflow(
     current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Duplicate a workflow."""
-    workflow = await check_workflow_access(workflow_id, current_user)
+    workflow = await check_workflow_access(
+        workflow_id, current_user, require_write=True
+    )
     await deps.check_scoped_permission(
         current_user, "workflow:create", "team", workflow.team_id
     )
@@ -1565,7 +1567,9 @@ async def create_workflow_version(
     current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Manually create a version snapshot of the current workflow state."""
-    workflow = await check_workflow_access(workflow_id, current_user)
+    workflow = await check_workflow_access(
+        workflow_id, current_user, require_write=True
+    )
     await deps.check_scoped_permission(
         current_user, "workflow:update", "team", workflow.team_id
     )
@@ -1611,7 +1615,9 @@ async def restore_workflow_version(
     current_user: User = Depends(deps.get_current_active_user),
 ) -> Any:
     """Restore a workflow to a specific version."""
-    workflow = await check_workflow_access(workflow_id, current_user)
+    workflow = await check_workflow_access(
+        workflow_id, current_user, require_write=True
+    )
     await deps.check_scoped_permission(
         current_user, "workflow:update", "team", workflow.team_id
     )

--- a/backend/app/api/v1/workflow_metrics.py
+++ b/backend/app/api/v1/workflow_metrics.py
@@ -13,7 +13,8 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
-from app.api.deps import get_current_user
+from app.api import deps
+from app.api.workflow_access import check_workflow_access
 from app.core.i18n import t
 from app.models.user import User
 from app.services.workflow import (
@@ -100,7 +101,7 @@ class CacheStatsResponse(BaseModel):
 
 @router.get("/dashboard", response_model=DashboardSummaryResponse)
 async def get_dashboard_summary(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(deps.PermissionChecker("admin:dashboard:access")),
 ):
     """
     Get dashboard summary with overall workflow metrics.
@@ -129,7 +130,7 @@ async def get_dashboard_summary(
 async def get_workflow_metrics(
     workflow_id: UUID,
     time_range_minutes: int = Query(default=60, ge=1, le=1440),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(deps.PermissionChecker("workflow:read")),
 ):
     """
     Get detailed metrics for a specific workflow.
@@ -141,6 +142,7 @@ async def get_workflow_metrics(
     Returns:
         Detailed workflow execution metrics
     """
+    await check_workflow_access(workflow_id, current_user)
     metrics_collector = get_metrics_collector()
     metrics = await metrics_collector.get_workflow_metrics(
         str(workflow_id),
@@ -171,7 +173,7 @@ async def get_workflow_metrics(
 
 @router.get("/nodes", response_model=dict[str, NodeMetricsResponse])
 async def get_all_node_metrics(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(deps.PermissionChecker("admin:dashboard:access")),
 ):
     """
     Get metrics for all node types.
@@ -205,7 +207,7 @@ async def get_all_node_metrics(
 @router.get("/nodes/{node_type}", response_model=NodeMetricsResponse)
 async def get_node_type_metrics(
     node_type: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(deps.PermissionChecker("admin:dashboard:access")),
 ):
     """
     Get metrics for a specific node type.
@@ -238,7 +240,7 @@ async def get_node_type_metrics(
 
 @router.get("/running", response_model=list[RunningWorkflowResponse])
 async def get_running_workflows(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(deps.PermissionChecker("admin:dashboard:access")),
 ):
     """
     Get list of currently running workflows.
@@ -254,7 +256,7 @@ async def get_running_workflows(
 
 @router.get("/cache", response_model=CacheStatsResponse)
 async def get_cache_stats(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(deps.PermissionChecker("admin:dashboard:access")),
 ):
     """
     Get workflow cache statistics.
@@ -281,7 +283,7 @@ async def get_cache_stats(
 
 @router.delete("/cache")
 async def clear_cache(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(deps.PermissionChecker("admin:settings:update")),
 ):
     """
     Clear all workflow cache entries.
@@ -293,7 +295,6 @@ async def clear_cache(
     - LLM response cache
     - Tool result cache
     """
-    # TODO: Add admin check
     cache = get_workflow_cache()
     count = await cache.clear_all()
 

--- a/backend/app/api/v1/workflow_metrics.py
+++ b/backend/app/api/v1/workflow_metrics.py
@@ -130,7 +130,7 @@ async def get_dashboard_summary(
 async def get_workflow_metrics(
     workflow_id: UUID,
     time_range_minutes: int = Query(default=60, ge=1, le=1440),
-    current_user: User = Depends(deps.PermissionChecker("workflow:read")),
+    current_user: User = Depends(deps.get_current_active_user),
 ):
     """
     Get detailed metrics for a specific workflow.

--- a/backend/app/api/v1/workflow_versions.py
+++ b/backend/app/api/v1/workflow_versions.py
@@ -33,11 +33,21 @@ from app.services.workflow.templates import (
 
 
 async def check_version_workflow_access(
-    workflow_id: str, version_id: str, current_user: User, require_write: bool = False
+    workflow_id: str,
+    version_id: str,
+    current_user: User,
+    require_write: bool = False,
+    required_permission: str | None = None,
 ) -> None:
     workflow = await check_workflow_access(
-        UUID(workflow_id), current_user, require_write=require_write
+        UUID(workflow_id),
+        current_user,
+        require_write=require_write or required_permission is not None,
     )
+    if required_permission:
+        await deps.check_scoped_permission(
+            current_user, required_permission, "team", workflow.team.id
+        )
     version = await get_version_manager().get_version(version_id)
     if not version:
         raise BusinessError(
@@ -212,7 +222,7 @@ async def publish_version(
     manager = get_version_manager()
 
     await check_version_workflow_access(
-        workflow_id, version_id, current_user, require_write=True
+        workflow_id, version_id, current_user, required_permission="workflow:publish"
     )
     try:
         version = await manager.publish_version(version_id, current_user.id)

--- a/backend/app/api/v1/workflow_versions.py
+++ b/backend/app/api/v1/workflow_versions.py
@@ -129,7 +129,7 @@ class ForkResponse(BaseModel):
 @router.post("", response_model=CreateVersionResponse)
 async def create_version(
     request: CreateVersionRequest,
-    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:update"))],
+    current_user: Annotated[User, Depends(deps.get_current_active_user)],
 ):
     """Create a new workflow version."""
     manager = get_version_manager()
@@ -159,7 +159,7 @@ async def create_version(
 @router.get("/{workflow_id}/history", response_model=VersionListResponse)
 async def get_version_history(
     workflow_id: str,
-    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:read"))],
+    current_user: Annotated[User, Depends(deps.get_current_active_user)],
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
     status: VersionStatus | None = None,
@@ -185,7 +185,7 @@ async def get_version_history(
 async def get_version(
     workflow_id: str,
     version_id: str,
-    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:read"))],
+    current_user: Annotated[User, Depends(deps.get_current_active_user)],
 ):
     """Get a specific version."""
     manager = get_version_manager()
@@ -206,7 +206,7 @@ async def get_version(
 async def publish_version(
     workflow_id: str,
     version_id: str,
-    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:publish"))],
+    current_user: Annotated[User, Depends(deps.get_current_active_user)],
 ):
     """Publish a version."""
     manager = get_version_manager()
@@ -237,7 +237,7 @@ async def publish_version(
 async def archive_version(
     workflow_id: str,
     version_id: str,
-    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:update"))],
+    current_user: Annotated[User, Depends(deps.get_current_active_user)],
 ):
     """Archive a version."""
     manager = get_version_manager()
@@ -267,7 +267,7 @@ async def archive_version(
 @router.get("/{workflow_id}/diff", response_model=VersionDiffResponse)
 async def get_version_diff(
     workflow_id: str,
-    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:read"))],
+    current_user: Annotated[User, Depends(deps.get_current_active_user)],
     from_version: str = Query(..., description="Source version ID"),
     to_version: str = Query(..., description="Target version ID"),
 ):
@@ -303,7 +303,7 @@ async def get_version_diff(
 async def rollback_version(
     workflow_id: str,
     request: RollbackRequest,
-    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:update"))],
+    current_user: Annotated[User, Depends(deps.get_current_active_user)],
 ):
     """Rollback to a previous version."""
     manager = get_version_manager()
@@ -335,7 +335,7 @@ async def rollback_version(
 async def fork_workflow(
     workflow_id: str,
     request: ForkRequest,
-    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:update"))],
+    current_user: Annotated[User, Depends(deps.get_current_active_user)],
 ):
     """Fork a workflow to create a new one."""
     manager = get_version_manager()
@@ -366,7 +366,7 @@ async def fork_workflow(
 @router.get("/{workflow_id}/stats")
 async def get_version_stats(
     workflow_id: str,
-    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:read"))],
+    current_user: Annotated[User, Depends(deps.get_current_active_user)],
 ):
     """Get version statistics for a workflow."""
     manager = get_version_manager()

--- a/backend/app/api/v1/workflow_versions.py
+++ b/backend/app/api/v1/workflow_versions.py
@@ -14,7 +14,9 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 
+from app.api import deps
 from app.api.deps import get_current_user
+from app.api.workflow_access import check_workflow_access
 from app.models.user import User
 from app.schemas.response import BusinessError, ResponseCode
 from app.services.workflow.errors import translate_public_workflow_error
@@ -28,6 +30,27 @@ from app.services.workflow.templates import (
     TemplateVisibility,
     TemplateVariable,
 )
+
+
+async def check_version_workflow_access(
+    workflow_id: str, version_id: str, current_user: User, require_write: bool = False
+) -> None:
+    workflow = await check_workflow_access(
+        UUID(workflow_id), current_user, require_write=require_write
+    )
+    version = await get_version_manager().get_version(version_id)
+    if not version:
+        raise BusinessError(
+            code=ResponseCode.NOT_FOUND,
+            msg_key="workflow_version_not_found",
+            status_code=404,
+        )
+    if version.workflow_id != str(workflow.id):
+        raise BusinessError(
+            code=ResponseCode.NOT_FOUND,
+            msg_key="workflow_version_not_found",
+            status_code=404,
+        )
 
 
 router = APIRouter(prefix="/workflow-versions", tags=["workflow-versions"])
@@ -106,10 +129,13 @@ class ForkResponse(BaseModel):
 @router.post("", response_model=CreateVersionResponse)
 async def create_version(
     request: CreateVersionRequest,
-    current_user: Annotated[User, Depends(get_current_user)],
+    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:update"))],
 ):
     """Create a new workflow version."""
     manager = get_version_manager()
+    await check_workflow_access(
+        UUID(request.workflow_id), current_user, require_write=True
+    )
 
     version = await manager.create_version(
         workflow_id=UUID(request.workflow_id),
@@ -133,13 +159,14 @@ async def create_version(
 @router.get("/{workflow_id}/history", response_model=VersionListResponse)
 async def get_version_history(
     workflow_id: str,
-    current_user: Annotated[User, Depends(get_current_user)],
+    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:read"))],
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
     status: VersionStatus | None = None,
 ):
     """Get version history for a workflow."""
     manager = get_version_manager()
+    await check_workflow_access(UUID(workflow_id), current_user)
 
     versions = await manager.get_history(
         workflow_id=UUID(workflow_id),
@@ -158,12 +185,12 @@ async def get_version_history(
 async def get_version(
     workflow_id: str,
     version_id: str,
-    current_user: Annotated[User, Depends(get_current_user)],
+    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:read"))],
 ):
     """Get a specific version."""
     manager = get_version_manager()
 
-    _ = workflow_id
+    await check_version_workflow_access(workflow_id, version_id, current_user)
     version = await manager.get_version(version_id)
     if not version:
         raise BusinessError(
@@ -179,12 +206,14 @@ async def get_version(
 async def publish_version(
     workflow_id: str,
     version_id: str,
-    current_user: Annotated[User, Depends(get_current_user)],
+    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:publish"))],
 ):
     """Publish a version."""
     manager = get_version_manager()
 
-    _ = workflow_id
+    await check_version_workflow_access(
+        workflow_id, version_id, current_user, require_write=True
+    )
     try:
         version = await manager.publish_version(version_id, current_user.id)
         if not version:
@@ -208,12 +237,14 @@ async def publish_version(
 async def archive_version(
     workflow_id: str,
     version_id: str,
-    current_user: Annotated[User, Depends(get_current_user)],
+    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:update"))],
 ):
     """Archive a version."""
     manager = get_version_manager()
 
-    _ = workflow_id
+    await check_version_workflow_access(
+        workflow_id, version_id, current_user, require_write=True
+    )
     try:
         version = await manager.archive_version(version_id)
         if not version:
@@ -236,14 +267,15 @@ async def archive_version(
 @router.get("/{workflow_id}/diff", response_model=VersionDiffResponse)
 async def get_version_diff(
     workflow_id: str,
-    current_user: Annotated[User, Depends(get_current_user)],
+    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:read"))],
     from_version: str = Query(..., description="Source version ID"),
     to_version: str = Query(..., description="Target version ID"),
 ):
     """Get diff between two versions."""
     manager = get_version_manager()
 
-    _ = workflow_id
+    await check_version_workflow_access(workflow_id, from_version, current_user)
+    await check_version_workflow_access(workflow_id, to_version, current_user)
     try:
         diff = await manager.diff(from_version, to_version)
         if not diff:
@@ -271,11 +303,14 @@ async def get_version_diff(
 async def rollback_version(
     workflow_id: str,
     request: RollbackRequest,
-    current_user: Annotated[User, Depends(get_current_user)],
+    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:update"))],
 ):
     """Rollback to a previous version."""
     manager = get_version_manager()
 
+    await check_version_workflow_access(
+        workflow_id, request.version_id, current_user, require_write=True
+    )
     try:
         result = await manager.rollback(
             workflow_id=UUID(workflow_id),
@@ -300,11 +335,15 @@ async def rollback_version(
 async def fork_workflow(
     workflow_id: str,
     request: ForkRequest,
-    current_user: Annotated[User, Depends(get_current_user)],
+    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:update"))],
 ):
     """Fork a workflow to create a new one."""
     manager = get_version_manager()
 
+    await check_version_workflow_access(workflow_id, request.version_id, current_user)
+    await check_workflow_access(
+        UUID(request.new_workflow_id), current_user, require_write=True
+    )
     try:
         new_version = await manager.fork(
             workflow_id=UUID(workflow_id),
@@ -327,11 +366,12 @@ async def fork_workflow(
 @router.get("/{workflow_id}/stats")
 async def get_version_stats(
     workflow_id: str,
-    current_user: Annotated[User, Depends(get_current_user)],
+    current_user: Annotated[User, Depends(deps.PermissionChecker("workflow:read"))],
 ):
     """Get version statistics for a workflow."""
     manager = get_version_manager()
 
+    await check_workflow_access(UUID(workflow_id), current_user)
     stats = await manager.get_stats(UUID(workflow_id))
     return stats
 

--- a/backend/app/api/workflow_access.py
+++ b/backend/app/api/workflow_access.py
@@ -1,0 +1,49 @@
+"""Shared workflow access helpers."""
+
+from uuid import UUID
+
+from app.api.team_access import check_team_access
+from app.models.user import User
+from app.models.workflow import Workflow, WorkflowVisibility
+from app.schemas.response import BusinessError, ResponseCode
+
+
+async def check_workflow_access(
+    workflow_id: UUID, user: User, require_write: bool = False
+) -> Workflow:
+    """Check whether a user can access a workflow."""
+    workflow = (
+        await Workflow.filter(id=workflow_id)
+        .prefetch_related("team", "created_by")
+        .first()
+    )
+    if not workflow:
+        raise BusinessError(
+            code=ResponseCode.NOT_FOUND,
+            msg_key="workflow_not_found",
+            status_code=404,
+        )
+
+    if user.is_superuser:
+        return workflow
+
+    is_owner = workflow.created_by and workflow.created_by.id == user.id
+    if workflow.visibility == WorkflowVisibility.PRIVATE:
+        if is_owner:
+            return workflow
+        if not workflow.created_by:
+            await check_team_access(workflow.team.id, user)
+            if require_write:
+                await check_team_access(workflow.team.id, user, require_admin=True)
+            return workflow
+        raise BusinessError(
+            code=ResponseCode.FORBIDDEN,
+            msg_key="workflow_access_denied",
+            status_code=403,
+        )
+
+    await check_team_access(workflow.team.id, user)
+    if require_write and not is_owner:
+        await check_team_access(workflow.team.id, user, require_admin=True)
+
+    return workflow

--- a/backend/app/api/workflow_access.py
+++ b/backend/app/api/workflow_access.py
@@ -31,10 +31,11 @@ async def check_workflow_access(
     if workflow.visibility == WorkflowVisibility.PRIVATE:
         if is_owner:
             return workflow
+        if require_write:
+            await check_team_access(workflow.team.id, user, require_admin=True)
+            return workflow
         if not workflow.created_by:
             await check_team_access(workflow.team.id, user)
-            if require_write:
-                await check_team_access(workflow.team.id, user, require_admin=True)
             return workflow
         raise BusinessError(
             code=ResponseCode.FORBIDDEN,

--- a/backend/app/core/init_data.py
+++ b/backend/app/core/init_data.py
@@ -2468,10 +2468,9 @@ async def init_db():
 
     try:
         await init_scoped_role_assignments_table()
-    except Exception as e:
-        logger.warning(
-            f"Scoped role assignment migration failed (may be first run): {e}"
-        )
+    except Exception:
+        logger.exception("Scoped role assignment migration failed")
+        raise
 
     # 3. Initialize Site Settings
     logger.info("Initializing site settings...")

--- a/backend/app/core/init_data.py
+++ b/backend/app/core/init_data.py
@@ -3,7 +3,7 @@ import logging
 
 from tortoise import Tortoise
 
-from app.models.user import Role, Permission
+from app.models.user import Role, Permission, TeamMember
 from app.models.site_setting import init_default_settings
 from app.core.permissions import SystemPermissions
 
@@ -174,6 +174,73 @@ async def init_workflow_tables():
     logger.info("Created workflow indexes")
 
     logger.info("Workflow tables initialization complete")
+
+
+async def init_scoped_role_assignments_table():
+    """Create and backfill team-scoped role assignments."""
+    logger.info("Initializing scoped role assignments table...")
+    conn = Tortoise.get_connection("default")
+
+    await execute_startup_migration_query(
+        conn,
+        """
+        CREATE TABLE IF NOT EXISTS scoped_role_assignments (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            role_id UUID NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+            scope_type VARCHAR(20) NOT NULL,
+            scope_id UUID NOT NULL,
+            source VARCHAR(20) NOT NULL DEFAULT 'manual',
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT scoped_role_assignments_unique UNIQUE (user_id, role_id, scope_type, scope_id)
+        )
+        """,
+    )
+    await execute_startup_migration_query(
+        conn,
+        """
+        CREATE INDEX IF NOT EXISTS idx_scoped_role_assignments_user_scope
+        ON scoped_role_assignments(user_id, scope_type, scope_id)
+        """,
+    )
+    await execute_startup_migration_query(
+        conn,
+        """
+        CREATE INDEX IF NOT EXISTS idx_scoped_role_assignments_role_scope
+        ON scoped_role_assignments(role_id, scope_type, scope_id)
+        """,
+    )
+
+    role_by_team_role = {
+        "owner": await Role.filter(name="Admin").first(),
+        "admin": await Role.filter(name="Admin").first(),
+        "member": await Role.filter(name="Member").first(),
+        "viewer": await Role.filter(name="Viewer").first(),
+    }
+    created = 0
+    skipped = 0
+    memberships = await TeamMember.all().prefetch_related("team", "user")
+    for membership in memberships:
+        role = role_by_team_role.get(membership.role)
+        if not role:
+            skipped += 1
+            continue
+        await execute_startup_migration_query(
+            conn,
+            f"""
+            INSERT INTO scoped_role_assignments (user_id, role_id, scope_type, scope_id, source)
+            VALUES ('{membership.user.id}', '{role.id}', 'team', '{membership.team.id}', 'migration')
+            ON CONFLICT (user_id, role_id, scope_type, scope_id) DO NOTHING
+            """,
+        )
+        created += 1
+
+    logger.info(
+        "Scoped role assignments initialized: %s attempted, %s skipped",
+        created,
+        skipped,
+    )
 
 
 async def init_user_locale_field():
@@ -2332,12 +2399,10 @@ async def init_db():
         "agent:read",
         "agent:create",
         "agent:update",
-        "agent:delete",
         "agent:chat",
         "workflow:read",
         "workflow:create",
         "workflow:update",
-        "workflow:delete",
         "workflow:run",
         "kb:read",
         "kb:create",
@@ -2400,6 +2465,13 @@ async def init_db():
         logger.info("Created system role: Viewer")
 
     await sync_role_permissions(viewer_role, viewer_permissions, "Viewer")
+
+    try:
+        await init_scoped_role_assignments_table()
+    except Exception as e:
+        logger.warning(
+            f"Scoped role assignment migration failed (may be first run): {e}"
+        )
 
     # 3. Initialize Site Settings
     logger.info("Initializing site settings...")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,4 @@
-from .user import Permission, Role, Team, TeamMember, User
+from .user import Permission, Role, ScopedRoleAssignment, Team, TeamMember, User
 from .site_setting import (
     SiteSetting,
     init_default_settings,
@@ -84,6 +84,7 @@ __all__ = [
     "Permission",
     "Team",
     "TeamMember",
+    "ScopedRoleAssignment",
     "SiteSetting",
     "init_default_settings",
     "DEFAULT_SETTINGS",

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -113,6 +113,34 @@ class TeamMember(models.Model):
         return f"{self.user} in {self.team} ({self.role})"
 
 
+class ScopedRoleAssignment(models.Model):
+    """Role assignment scoped to a team or future resource scope."""
+
+    id = fields.UUIDField(pk=True)
+    user: fields.ForeignKeyRelation["User"] = fields.ForeignKeyField(
+        "models.User", related_name="scoped_role_assignments", on_delete=fields.CASCADE
+    )
+    role: fields.ForeignKeyRelation[Role] = fields.ForeignKeyField(
+        "models.Role", related_name="scoped_assignments", on_delete=fields.CASCADE
+    )
+    scope_type = fields.CharField(max_length=20, description="Scope type, e.g. team")
+    scope_id = fields.UUIDField(description="Scoped resource ID")
+    source = fields.CharField(
+        max_length=20,
+        default="manual",
+        description="Assignment source: manual, default, migration, system",
+    )
+    created_at = fields.DatetimeField(auto_now_add=True)
+    updated_at = fields.DatetimeField(auto_now=True)
+
+    class Meta:
+        table = "scoped_role_assignments"
+        unique_together = (("user", "role", "scope_type", "scope_id"),)
+
+    def __str__(self):
+        return f"{self.user} -> {self.role} ({self.scope_type}:{self.scope_id})"
+
+
 class User(models.Model):
     id = fields.UUIDField(pk=True)
     username = fields.CharField(max_length=50, unique=True)

--- a/backend/app/schemas/tool.py
+++ b/backend/app/schemas/tool.py
@@ -222,6 +222,9 @@ class ToolOut(BaseModel):
 
     # 用于后台管理的额外字段
     team_id: UUID | None = Field(default=None, description="所属团队")
+    created_by_id: UUID | None = Field(
+        default=None, description="创建者 ID (可能已删除)"
+    )
     created_by_name: str | None = Field(default=None, description="创建者名称")
 
     # 工具共享相关字段
@@ -273,9 +276,6 @@ class ToolDetailOut(ToolOut):
     team_id: UUID | None = Field(default=None, description="所属团队")
     created_at: str | None = Field(default=None, description="创建时间")
     updated_at: str | None = Field(default=None, description="更新时间")
-    created_by_id: UUID | None = Field(
-        default=None, description="创建者 ID (可能已删除)"
-    )
     created_by_name: str | None = Field(default=None, description="创建者名称")
 
 

--- a/backend/app/schemas/workflow.py
+++ b/backend/app/schemas/workflow.py
@@ -96,6 +96,8 @@ class WorkflowListItem(BaseModel):
     run_count: int
     success_count: int
     fail_count: int
+    created_by_id: UUID | None
+    created_by_name: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/services/clouisle_package_resources.py
+++ b/backend/app/services/clouisle_package_resources.py
@@ -773,6 +773,13 @@ class KnowledgeBasePackageAdapter(ResourcePackageAdapter):
                     msg_key="kb_not_found",
                     status_code=404,
                 )
+        if kb.created_by_id != user.id:
+            raise BusinessError(
+                code=ResponseCode.PERMISSION_DENIED,
+                msg_key="operation_not_permitted",
+                status_code=403,
+                permission=self.read_permission,
+            )
         dependencies: list[dict[str, Any]] = []
         if kb.embedding_model_id:
             model = await Model.filter(id=kb.embedding_model_id).first()

--- a/backend/app/services/clouisle_package_resources.py
+++ b/backend/app/services/clouisle_package_resources.py
@@ -773,13 +773,13 @@ class KnowledgeBasePackageAdapter(ResourcePackageAdapter):
                     msg_key="kb_not_found",
                     status_code=404,
                 )
-        if kb.created_by_id != user.id:
-            raise BusinessError(
-                code=ResponseCode.PERMISSION_DENIED,
-                msg_key="operation_not_permitted",
-                status_code=403,
-                permission=self.read_permission,
-            )
+            if kb.created_by_id != user.id:
+                raise BusinessError(
+                    code=ResponseCode.PERMISSION_DENIED,
+                    msg_key="operation_not_permitted",
+                    status_code=403,
+                    permission=self.read_permission,
+                )
         dependencies: list[dict[str, Any]] = []
         if kb.embedding_model_id:
             model = await Model.filter(id=kb.embedding_model_id).first()

--- a/backend/app/services/team_role_sync.py
+++ b/backend/app/services/team_role_sync.py
@@ -34,6 +34,7 @@ async def sync_scoped_role_assignment(membership: TeamMember) -> None:
         user=membership.user,
         scope_type="team",
         scope_id=membership.team.id,
+        source="system",
     ).delete()
     await ScopedRoleAssignment.get_or_create(
         user=membership.user,
@@ -120,6 +121,7 @@ async def sync_user_role_from_teams(user: User) -> None:
         ScopedRoleAssignment.filter(
             user=user,
             scope_type="team",
+            source="system",
         )
         .exclude(scope_id__in=active_team_ids)
         .delete()

--- a/backend/app/services/team_role_sync.py
+++ b/backend/app/services/team_role_sync.py
@@ -2,19 +2,55 @@ import logging
 from uuid import UUID
 
 from app.models.site_setting import SiteSetting
-from app.models.user import Role, Team, TeamMember, User
+from app.models.user import Role, ScopedRoleAssignment, Team, TeamMember, User
 
 logger = logging.getLogger(__name__)
 
-# Team role to global role mapping
-# owner/admin -> Admin, member -> Member, viewer -> no extra role
-TEAM_ROLE_TO_GLOBAL = {
+# Team role to scoped role mapping. Team roles no longer grant global roles.
+TEAM_ROLE_TO_GLOBAL: dict[str, tuple[str, ...]] = {}
+TEAM_ROLE_TO_SCOPED_ROLE = {
     "owner": "Admin",
     "admin": "Admin",
     "member": "Member",
+    "viewer": "Viewer",
 }
 
 DEFAULT_TEAM_ROLES = {"viewer", "member", "admin"}
+
+
+async def sync_scoped_role_assignment(membership: TeamMember) -> None:
+    """Mirror a team membership role into a team-scoped role assignment."""
+    role_name = TEAM_ROLE_TO_SCOPED_ROLE.get(membership.role)
+    if not role_name:
+        logger.warning("Unknown team role %r for scoped sync", membership.role)
+        return
+
+    role = await Role.filter(name=role_name).first()
+    if not role:
+        logger.warning("Scoped sync role %s not found", role_name)
+        return
+
+    await ScopedRoleAssignment.filter(
+        user=membership.user,
+        scope_type="team",
+        scope_id=membership.team.id,
+    ).delete()
+    await ScopedRoleAssignment.get_or_create(
+        user=membership.user,
+        role=role,
+        scope_type="team",
+        scope_id=membership.team.id,
+        defaults={"source": "system"},
+    )
+
+
+async def remove_scoped_role_assignment(user: User, team_id: UUID) -> None:
+    """Remove team-scoped role assignments for a user in one team."""
+    await ScopedRoleAssignment.filter(
+        user=user,
+        scope_type="team",
+        scope_id=team_id,
+    ).delete()
 
 
 async def assign_default_role(user: User) -> None:
@@ -58,37 +94,33 @@ async def assign_default_team(user: User) -> bool:
         )
         return False
 
-    _, created = await TeamMember.get_or_create(
+    membership, created = await TeamMember.get_or_create(
         team=team,
         user=user,
         defaults={"role": default_team_role},
     )
+    if created:
+        await sync_scoped_role_assignment(membership)
     return created
 
 
 async def sync_user_role_from_teams(user: User) -> None:
+    """Sync team memberships into scoped role assignments.
+
+    Legacy behavior granted/removing global Admin/Member from team roles. Do not do
+    that anymore: existing global roles may be manual, and source was not tracked.
     """
-    Sync global roles based on the user's highest team role across all teams.
+    memberships = await TeamMember.filter(user=user).prefetch_related("team", "user")
+    active_team_ids = set()
+    for membership in memberships:
+        active_team_ids.add(membership.team.id)
+        await sync_scoped_role_assignment(membership)
 
-    - Any team with owner/admin -> ensure user has Admin + Member global roles
-    - Highest team role is member -> remove Admin, ensure Member
-    - Highest is viewer or no teams -> remove Admin and Member (keep others like Viewer)
-    """
-    memberships = await TeamMember.filter(user=user).all()
-
-    roles = {m.role for m in memberships}
-    has_admin = "owner" in roles or "admin" in roles
-    has_member = has_admin or "member" in roles
-
-    admin_role = await Role.filter(name="Admin").first()
-    member_role = await Role.filter(name="Member").first()
-
-    if has_admin and admin_role:
-        await user.roles.add(admin_role)
-    elif admin_role:
-        await user.roles.remove(admin_role)
-
-    if has_member and member_role:
-        await user.roles.add(member_role)
-    elif member_role:
-        await user.roles.remove(member_role)
+    await (
+        ScopedRoleAssignment.filter(
+            user=user,
+            scope_type="team",
+        )
+        .exclude(scope_id__in=active_team_ids)
+        .delete()
+    )

--- a/backend/tests/api/test_knowledge_base_permissions.py
+++ b/backend/tests/api/test_knowledge_base_permissions.py
@@ -69,11 +69,14 @@ def test_admin_kb_route_requires_admin_permission(kb_permission_client):
     assert response.json()["code"] == 3000
 
 
-def test_platform_kb_route_requires_platform_permission(kb_permission_client):
-    client, user = kb_permission_client
+@pytest.mark.anyio
+async def test_platform_kb_route_uses_team_membership_not_global_permission(
+    kb_permission_client,
+):
+    _, user = kb_permission_client
     user.roles = [_Role("admin:knowledge-base:read")]
+    request = SimpleNamespace(url=SimpleNamespace(path="/api/v1/knowledge-bases"))
 
-    response = client.get("/api/v1/knowledge-bases")
+    result = await knowledge_bases.require_kb_read(request, user)
 
-    assert response.status_code == 403
-    assert response.json()["code"] == 3000
+    assert result is user

--- a/backend/tests/api/test_scoped_rbac_access.py
+++ b/backend/tests/api/test_scoped_rbac_access.py
@@ -1,0 +1,189 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.api.deps import check_scoped_permission
+from app.api.team_access import check_team_access
+from app.api.workflow_access import check_workflow_access
+from app.models.workflow import WorkflowVisibility
+from app.schemas.response import BusinessError
+
+
+class _Permission:
+    def __init__(self, code: str):
+        self.code = code
+
+
+class _Role:
+    def __init__(self, *codes: str):
+        self.permissions = [_Permission(code) for code in codes]
+
+
+class _Query:
+    def __init__(self, value):
+        self.value = value
+
+    def prefetch_related(self, *_args):
+        return self
+
+    async def first(self):
+        return self.value
+
+    def __await__(self):
+        async def resolve():
+            return self.value
+
+        return resolve().__await__()
+
+
+class _TeamModel:
+    team = None
+
+    @classmethod
+    def filter(cls, **_kwargs):
+        return _Query(cls.team)
+
+
+class _TeamMemberModel:
+    membership = None
+
+    @classmethod
+    def filter(cls, **_kwargs):
+        return _Query(cls.membership)
+
+
+@pytest.mark.anyio
+async def test_team_member_cannot_use_team_admin_action(monkeypatch):
+    team = SimpleNamespace(id=uuid4())
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+    _TeamModel.team = team
+    _TeamMemberModel.membership = SimpleNamespace(role="member")
+    monkeypatch.setattr("app.api.team_access.Team", _TeamModel)
+    monkeypatch.setattr("app.api.team_access.TeamMember", _TeamMemberModel)
+
+    with pytest.raises(BusinessError) as error:
+        await check_team_access(team.id, user, require_admin=True)
+
+    assert error.value.msg_key == "team_admin_required"
+
+
+@pytest.mark.anyio
+async def test_team_admin_can_use_team_admin_action(monkeypatch):
+    team = SimpleNamespace(id=uuid4())
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+    _TeamModel.team = team
+    _TeamMemberModel.membership = SimpleNamespace(role="admin")
+    monkeypatch.setattr("app.api.team_access.Team", _TeamModel)
+    monkeypatch.setattr("app.api.team_access.TeamMember", _TeamMemberModel)
+
+    assert await check_team_access(team.id, user, require_admin=True) is team
+
+
+class _WorkflowModel:
+    workflow = None
+
+    @classmethod
+    def filter(cls, **_kwargs):
+        return _Query(cls.workflow)
+
+
+@pytest.mark.anyio
+async def test_private_workflow_rejects_unrelated_user(monkeypatch):
+    owner = SimpleNamespace(id=uuid4())
+    other_user = SimpleNamespace(id=uuid4(), is_superuser=False)
+    _WorkflowModel.workflow = SimpleNamespace(
+        id=uuid4(),
+        visibility=WorkflowVisibility.PRIVATE,
+        created_by=owner,
+        team=SimpleNamespace(id=uuid4()),
+    )
+    monkeypatch.setattr("app.api.workflow_access.Workflow", _WorkflowModel)
+
+    with pytest.raises(BusinessError) as error:
+        await check_workflow_access(_WorkflowModel.workflow.id, other_user)
+
+    assert error.value.msg_key == "workflow_access_denied"
+
+
+@pytest.mark.anyio
+async def test_team_workflow_write_delegates_to_team_admin_check(monkeypatch):
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+    team = SimpleNamespace(id=uuid4())
+    workflow = SimpleNamespace(
+        id=uuid4(),
+        visibility=WorkflowVisibility.TEAM,
+        created_by=None,
+        team=team,
+    )
+    _WorkflowModel.workflow = workflow
+    check_team = AsyncMock()
+    monkeypatch.setattr("app.api.workflow_access.Workflow", _WorkflowModel)
+    monkeypatch.setattr("app.api.workflow_access.check_team_access", check_team)
+
+    assert (
+        await check_workflow_access(workflow.id, user, require_write=True) is workflow
+    )
+    check_team.assert_any_await(team.id, user)
+    check_team.assert_any_await(team.id, user, require_admin=True)
+
+
+class _ScopedAssignmentModel:
+    assignments = []
+
+    @classmethod
+    def filter(cls, **_kwargs):
+        return _Query(cls.assignments)
+
+
+@pytest.mark.anyio
+async def test_team_scoped_role_cannot_satisfy_admin_permission(monkeypatch):
+    user = SimpleNamespace(
+        id=uuid4(),
+        is_superuser=False,
+        roles=[],
+    )
+    _ScopedAssignmentModel.assignments = [SimpleNamespace(role=_Role("admin:*", "*"))]
+    monkeypatch.setattr("app.api.deps.ScopedRoleAssignment", _ScopedAssignmentModel)
+
+    with pytest.raises(BusinessError) as error:
+        await check_scoped_permission(user, "admin:dashboard:access", "team", uuid4())
+
+    assert error.value.msg_key == "operation_not_permitted"
+
+
+@pytest.mark.anyio
+async def test_team_scoped_role_satisfies_non_admin_permission(monkeypatch):
+    user = SimpleNamespace(
+        id=uuid4(),
+        is_superuser=False,
+        roles=[],
+    )
+    _ScopedAssignmentModel.assignments = [
+        SimpleNamespace(role=_Role("workflow:update"))
+    ]
+    monkeypatch.setattr("app.api.deps.ScopedRoleAssignment", _ScopedAssignmentModel)
+
+    await check_scoped_permission(user, "workflow:update", "team", uuid4())
+
+
+@pytest.mark.anyio
+async def test_team_workflow_owner_can_write_without_team_admin(monkeypatch):
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+    team = SimpleNamespace(id=uuid4())
+    workflow = SimpleNamespace(
+        id=uuid4(),
+        visibility=WorkflowVisibility.TEAM,
+        created_by=user,
+        team=team,
+    )
+    _WorkflowModel.workflow = workflow
+    check_team = AsyncMock()
+    monkeypatch.setattr("app.api.workflow_access.Workflow", _WorkflowModel)
+    monkeypatch.setattr("app.api.workflow_access.check_team_access", check_team)
+
+    assert (
+        await check_workflow_access(workflow.id, user, require_write=True) is workflow
+    )
+    check_team.assert_awaited_once_with(team.id, user)

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -2,6 +2,13 @@
 
 ## Active
 
+- **scoped-rbac-landing** — Complete. Decouple team authorization from global RBAC by first closing authorization gaps, then adding team-scoped role assignments. See `docs/plan/scoped-rbac.md`
+  - [x] 1. Planning docs
+  - [x] 2. Shared team access and immediate workflow authorization fixes
+  - [x] 3. Scoped role assignment model and migration
+  - [x] 4. Scoped permission helper and core endpoint migration
+  - [x] 5. Frontend compatibility and documentation
+
 - **yun-105-click-captcha-hardening** — In progress. Harden click captcha with a Cloudflare-like single click check, pointer trajectory validation, and backend-only proof minting. See `docs/plan/yun-105-click-captcha-hardening.md`
   - [x] 1. Design docs and implementation index
   - [x] 2. Backend pointer payload and trajectory scoring

--- a/docs/dev/design/access-control/PERMISSION_AUDIT_REPORT.md
+++ b/docs/dev/design/access-control/PERMISSION_AUDIT_REPORT.md
@@ -1,0 +1,289 @@
+# Permission System Audit Report
+
+## Scope
+
+This report summarizes the current permission-system verification and follow-up audit across:
+
+- Built-in global roles and default assignment
+- Team member roles and team-role synchronization
+- Effective permission checks
+- Agent / Workflow / Viewer / Member boundaries
+- Admin / platform route isolation
+- Completeness, consistency, compliance, and maintainability risks
+
+Primary implementation references:
+
+- `backend/app/core/permissions.py`
+- `backend/app/core/init_data.py`
+- `backend/app/api/deps.py`
+- `backend/app/services/team_role_sync.py`
+- `backend/app/api/v1/endpoints/teams.py`
+- `frontend/lib/route-permissions.ts`
+
+## Verification Summary
+
+### Confirmed Behavior
+
+- `User.is_superuser` bypasses normal `PermissionChecker` checks.
+- `PermissionChecker` checks global `User -> Role -> Permission` codes only.
+- A literal `*` permission satisfies any `PermissionChecker` requirement.
+- Team membership and resource visibility checks are implemented separately from global permission checks.
+- Built-in global roles are `Super Admin`, `Admin`, `Member`, and `Viewer`.
+- Team roles are currently intended as `owner`, `admin`, `member`, and `viewer`.
+- `default_team_role` allows `viewer`, `member`, and `admin`; `owner` is not automatically assigned.
+- Global `Viewer` is not true read-only: it can read/use resources through `chat`, `run`, and `execute` permissions.
+- Team `viewer` does not automatically grant global `Viewer`.
+
+### Fixes Already Applied in This Branch
+
+- Removed `agent:delete` and `workflow:delete` from default global `Member` role initialization.
+- Changed workbench home to use the platform conversation trends API instead of the admin conversation trends API.
+- Replaced stale `dashboard:access` checks in conversation stats/trends with `admin:dashboard:access`.
+- Updated permission docs to clarify:
+  - `*` vs `is_superuser`
+  - global roles vs team roles
+  - default role/default team behavior
+  - Viewer as view/use-only, not strict read-only
+  - `team_role_sync` now mirrors team roles into `ScopedRoleAssignment` and no longer grants/removes global `Admin` / `Member`
+  - default team registration creates `TeamMember` and immediately mirrors it into `ScopedRoleAssignment`
+  - resource helpers have inconsistent team-role thresholds today
+
+## Key Findings
+
+### Fixed: Team Roles No Longer Grant Global Admin Powers
+
+Team `owner` / `admin` now syncs to a team-scoped `Admin` assignment through `ScopedRoleAssignment`, not to the user's global roles. Scoped assignments are evaluated only for the requested scope, and `admin:*` remains global-only.
+
+**Impact**: Team-local administration no longer creates a platform-wide global admin capability path.
+
+**Follow-up**: Historical global `Admin` / `Member` assignments are not automatically removed because old data did not track whether they were manual or sync-derived.
+
+---
+
+### Fixed: Team Role Sync No Longer Removes Manual Global Roles
+
+`sync_user_role_from_teams()` now maintains team-scoped assignments for the user's active teams and removes stale team-scoped assignments only. It no longer removes global roles named `Admin` or `Member`.
+
+**Impact**: Manual global role assignments are preserved when team membership changes.
+
+**Follow-up**: Operators may still need a one-time review of legacy global `Admin` / `Member` grants created before this change.
+
+---
+
+### Fixed: Default Team Assignment Creates Scoped Permissions
+
+Default team registration now creates the `TeamMember` and immediately mirrors the membership into `ScopedRoleAssignment`. A user assigned to the default team receives effective team-scoped permissions without waiting for a later sync path.
+
+**Impact**: The displayed default team role and the user's scoped team permissions are aligned at registration time.
+
+---
+
+### Fixed: Workflow Metrics Are Permission-Gated
+
+Workflow metrics endpoints now enforce explicit permissions. Per-workflow reads require workflow access plus `workflow:read`; dashboard/global runtime reads require `admin:dashboard:access`; cache deletion requires `admin:settings:update`.
+
+**Impact**: Authenticated users without the relevant team-scoped or global admin permission can no longer view runtime metrics or clear workflow cache.
+
+---
+
+### Fixed: Workflow Version Endpoints Enforce RBAC and Resource Access
+
+Workflow version create, publish, archive, rollback, and read paths now validate workflow access and enforce the expected permission code for the action.
+
+**Impact**: Authenticated users can no longer mutate or read workflow versions unless they can access the workflow and satisfy the relevant workflow permission.
+
+---
+
+### High: Default Admin Role Is Overbroad
+
+Global `Admin` combines dashboard access, user management, audit export, admin resource management, and platform resource capabilities.
+
+**Impact**: It is hard to assign a limited operational admin role without granting unrelated sensitive access.
+
+**Recommendation**: Split global admin capabilities into narrower roles, for example:
+
+- Dashboard Admin
+- User Admin
+- Audit Viewer
+- Audit Exporter
+- Platform Operator
+- Content Admin
+
+---
+
+### High: Wildcard Permission Is Dangerous Outside Superuser
+
+A role containing `*` satisfies all `PermissionChecker` checks. The code does not fully guarantee that only actual superusers can ever receive a role with `*`.
+
+**Impact**: If `*` is assigned to a custom role, that role becomes effectively all-powerful for global permission checks.
+
+**Recommendation**: Treat `*` as internal-only:
+
+- prevent custom assignment of `*`
+- or make `PermissionChecker` honor `*` only when `current_user.is_superuser` is true
+
+---
+
+### Medium: Team Member Role Values Are Not Strictly Validated
+
+Team member role schemas accept strings. Add/update member logic blocks `owner` in some paths but does not consistently reject unknown values.
+
+**Impact**: Invalid roles such as `admin ` or `superadmin` can be stored, producing undefined behavior.
+
+**Recommendation**: Use a strict enum / `Literal["viewer", "member", "admin"]` at schema boundaries, and add a DB constraint if supported.
+
+---
+
+### Fixed: Team Access Helpers Are Centralized for Core Resources
+
+Core Team, Agent, and Workflow paths now share explicit team/workflow access helpers, and the `require_admin=True` path consistently means team `owner` or `admin`.
+
+**Impact**: Team `member` no longer passes owner/admin-only checks through divergent Agent/Workflow helper behavior.
+
+**Follow-up**: Continue migrating Knowledge Base, Tool, Skill, and Notification helpers to the shared helper as those files are touched.
+
+---
+
+### Medium: Permission Registry Is Not a True Single Source of Truth
+
+Permission codes are hardcoded across:
+
+- `SystemPermissions`
+- role initialization lists
+- backend `PermissionChecker("...")` calls
+- frontend route permissions
+- docs tables
+
+**Impact**: Drift is expected. A typo or missing role preset entry may become a runtime authorization bug.
+
+**Recommendation**:
+
+- derive role presets from `SystemPermissions` constants/groups
+- replace backend permission string literals with constants as files are touched
+- add a CI test that verifies every role preset and route permission exists in the backend permission catalog
+
+---
+
+### Medium: Admin / Platform Split Is Conceptually Mixed
+
+Routes distinguish admin permissions from platform permissions in several places, but the default global `Admin` role intentionally bundles both.
+
+**Impact**: The route model says “separate,” while the preset role model says “combined.” This is workable but must be explicit.
+
+**Recommendation**: Document default `Admin` as “dashboard + platform operator,” or split it into separate global roles.
+
+---
+
+### Medium: Notification Delete Permission Is Defined but Not Enforced
+
+`admin:notification:delete` exists and is assigned to Admin, but the delete endpoint uses active-user authentication plus ad hoc scope checks rather than `PermissionChecker("admin:notification:delete")`.
+
+**Impact**: Custom roles granted that permission do not reliably get the capability; other users may pass through team-scope checks without that explicit permission.
+
+**Recommendation**: Add `PermissionChecker("admin:notification:delete")`, then keep scope checks for data isolation only.
+
+---
+
+### Medium: Memory Permissions Are Inconsistent
+
+Platform memory permissions are defined, but preset roles do not initialize them consistently, memory endpoints are mostly ownership/auth based, and frontend UI checks some memory permission codes.
+
+**Impact**: Memory behavior is neither clearly RBAC-managed nor clearly ownership-only.
+
+**Recommendation**: Pick one model:
+
+- RBAC-managed: enforce/grant memory permissions consistently.
+- Ownership-only: remove unused permission gates and document ownership-only semantics.
+
+---
+
+### Medium: RBAC Changes Need Better Audit Logging
+
+Role and permission create/update/delete flows do not consistently log before/after permission sets. User role assignment audit details are limited.
+
+**Impact**: Privilege changes may be hard to reconstruct during incident review.
+
+**Recommendation**: Audit all role/permission/user-role changes with actor, target, before/after role and permission IDs, request metadata, and failure events.
+
+---
+
+### Medium: SSO Default Team Documentation Is Incomplete
+
+Local registration assigns the default team. SSO user creation assigns provider/global default role but does not assign default team in the same way.
+
+**Impact**: Operator/user docs can overpromise SSO provisioning behavior.
+
+**Recommendation**: Either call default-team assignment during SSO user creation, or update SSO docs to say default team assignment currently applies to local registration only.
+
+---
+
+### Low: Frontend Permission Guards Are Duplicated
+
+Two frontend `PermissionGuard` implementations exist with different behavior.
+
+**Impact**: UI authorization fixes can land in one guard but not the other.
+
+**Recommendation**: Keep one guard and one hook, then migrate callers.
+
+---
+
+### Low: Unknown Frontend Routes Default to Allowed
+
+`canAccessRoute()` allows routes with no config.
+
+**Impact**: New dashboard/admin pages can be exposed in the frontend until backend rejects them.
+
+**Recommendation**: Fail closed for dashboard/admin route groups unless explicitly public.
+
+---
+
+### Low: Permission Docs Are Still Summary-Level
+
+The admin guide intentionally summarizes permissions, but it omits some categories such as `admin:app:*`, `admin:capability:*`, `admin:knowledge-base:*`, `admin:team:*`, and `skill:*`.
+
+**Impact**: Operators cannot fully design custom roles from the summary table alone.
+
+**Recommendation**: Generate permission tables from `SystemPermissions.get_all_definitions()` or add a doc check that fails when a permission code is undocumented.
+
+## Recommended Roadmap
+
+### Phase 1: Close Immediate Authorization Holes
+
+1. Enforce `admin:notification:delete` on notification deletion.
+2. Strictly validate team member role values.
+3. Prevent custom roles from using `*`, or make `*` effective only for `is_superuser`.
+
+### Phase 2: Finish Scoped RBAC Migration
+
+1. Continue migrating Knowledge Base, Tool, Skill, and Notification team checks to shared access helpers as those files are touched.
+2. Review historical global `Admin` / `Member` grants that may have been created by legacy team-role sync.
+3. Rename docs/UI labels where useful to distinguish:
+   - Global Admin / Global Member / Global Viewer
+   - Team Owner / Team Admin / Team Member / Team Viewer
+
+### Phase 3: Reduce Drift
+
+1. Continue migrating Knowledge Base, Tool, Skill, and Notification team checks to shared access helpers as those files are touched.
+2. Replace backend raw permission strings with `SystemPermissions` constants as files are touched.
+3. Add CI checks for:
+   - role preset permissions exist in `SystemPermissions`
+   - frontend route permission strings exist in backend catalog
+   - docs permission tables mention all system permissions or intentionally exclude them
+
+### Phase 4: Clarify Role Model
+
+1. Split broad `Admin` into narrower roles if least privilege matters for production tenants.
+2. Decide whether `Viewer` should remain view/use-only or become strict read-only.
+3. Decide whether `Member` should retain destructive permissions for KB, Tool, Skill, API Keys, and conversations.
+4. Decide whether Memory is RBAC-managed or ownership-only.
+
+## Overall Assessment
+
+The current permission system has a workable foundation: global permission codes, team-scoped role assignments, team membership checks, resource visibility checks, and frontend route gates all exist. The main remaining risk is semantic breadth and drift:
+
+- team roles are mirrored into scoped RBAC assignments, not global roles
+- global `Admin` bundles multiple administrative domains
+- some non-core resource helpers still have local team-role thresholds
+- permission codes are duplicated across backend, frontend, initialization, and docs
+
+The highest-value fix has landed: team roles are decoupled from global roles. Next, continue closing the remaining workflow-adjacent/notification gaps and add small drift tests so future permission changes fail fast in CI.

--- a/docs/dev/design/access-control/RBAC_SPEC.md
+++ b/docs/dev/design/access-control/RBAC_SPEC.md
@@ -2,6 +2,14 @@
 
 本文档基于当前代码实现整理权限设计，不以历史设计稿或分析文档为准。
 
+权威实现入口：
+
+- `backend/app/core/permissions.py`：系统权限定义
+- `backend/app/core/init_data.py`：内置角色与默认角色初始化
+- `backend/app/services/team_role_sync.py`：团队角色到团队作用域角色授权的同步
+- `backend/app/api/deps.py`：认证与 `PermissionChecker`
+- `backend/app/api/v1/endpoints/teams.py`：团队成员角色边界
+
 适用范围：
 
 - 后端认证与授权
@@ -182,10 +190,10 @@
 
 主要权限：
 
-- 所有 `admin:*` 系统级权限
-- 所有平台业务权限：`agent:*`、`workflow:*`、`kb:*`、`tool:*`、`skill:*` 等
+- 后台管理能力：包含 `admin:dashboard:access`、用户/角色/权限读取、模型管理、设置读取、SSO 读取、审计读取/导出等；部分高危后台变更能力仅 Super Admin 拥有
+- 平台业务能力：包含团队范围的 Agent、Workflow、KB、Tool、Skill 等管理与使用权限
 
-注意：当前代码中 `Admin` 角色既承担后台能力，也会被团队角色同步逻辑自动授予，见下文。
+注意：当前代码中 `Admin` 角色既承担后台能力，也可作为团队作用域角色复用；但团队作用域 `Admin` 不能满足 `admin:*` 后台权限。
 
 ### 4.3 Member
 
@@ -194,13 +202,15 @@
 当前意图包括：
 
 - 访问团队内常用业务资源
-- 对 Agent、Workflow、KB、Tool、Skill 拥有完整 CRUD 权限
+- 对 Agent、Workflow、KB、Tool、Skill 拥有创建和更新权限
+- 可以使用 Agent、运行 Workflow、执行 Tool/Skill
 - 不具备后台访问能力（无 `admin:*` 权限）
+- 不具备 Agent / Workflow 的删除或发布权限
 
 主要权限：
 
-- `agent:read/create/update/delete/chat`
-- `workflow:read/create/update/delete/run`
+- `agent:read/create/update/chat`
+- `workflow:read/create/update/run`
 - `kb:read/create/update/delete`
 - `tool:read/create/update/delete/execute`
 - `skill:read/create/update/delete/execute`
@@ -219,14 +229,17 @@
 - `skill:read/execute`
 - `team:read`、`conversation:read`
 
-### 4.5 现状说明
+### 4.5 默认角色与默认团队
 
-虽然存在内置全局角色，但当前实现中：
+默认分配逻辑位于 `backend/app/services/team_role_sync.py`，初始化逻辑位于 `backend/app/core/init_data.py`。
 
-- `Admin` / `Member` 会被团队成员角色自动同步
-- `Viewer` 不会由团队 `viewer` 自动同步得到
+- `default_role_id`：新用户默认全局角色；系统初始化时如果为空，会写入 `Viewer` 角色 ID。
+- `default_team_id`：配置后，新注册用户会自动加入该团队。
+- `default_team_role`：自动加入默认团队时使用的团队角色，默认 `member`。
+- 自动团队角色只允许 `viewer`、`member`、`admin`；配置异常时回退到 `member`。
+- `owner` 不会作为自动默认团队角色分配。
 
-因此，全局角色并非完全独立于团队体系。
+注意：默认全局角色和默认团队角色是两套概念。全局角色提供 permission code，团队角色只决定用户在某个 team 内的管理级别。
 
 ---
 
@@ -303,47 +316,65 @@
 
 ---
 
-## 6. 团队成员角色与全局角色的关系
+## 6. 团队成员角色与作用域 RBAC 的关系
 
-当前代码存在一个重要同步机制：
+当前代码通过 `backend/app/services/team_role_sync.py` 将 `TeamMember.role` 维护为团队作用域角色授权，而不是再授予或移除全局 `Admin` / `Member`。
 
-- `backend/app/services/team_role_sync.py`
+### 6.1 ScopedRoleAssignment
 
-其逻辑是根据用户在所有团队中的最高角色，同步用户的全局角色。
+团队作用域授权存储在 `ScopedRoleAssignment`：
 
-### 6.1 映射规则
+- `user`：授权用户
+- `role`：复用现有 `Role`
+- `scope_type`：当前为 `team`
+- `scope_id`：团队 ID
+- `source`：`manual`、`migration`、`system` 等来源标记
+- `(user, role, scope_type, scope_id)` 唯一
+
+启动初始化会幂等创建表和索引，并从现有 `TeamMember` 回填团队作用域授权。
+
+### 6.2 映射规则
 
 当前规则：
 
-- 只要用户在任意团队中是 `owner` 或 `admin`
-  - 确保用户拥有全局 `Admin`
-  - 同时确保用户拥有全局 `Member`
-- 如果用户最高团队角色是 `member`
-  - 移除全局 `Admin`
-  - 确保拥有全局 `Member`
-- 如果用户只有 `viewer` 或已不在任何团队中
-  - 移除全局 `Admin`
-  - 移除全局 `Member`
-  - 保留其他角色（例如默认 `Viewer`）
+- 团队 `owner` / `admin` -> 该 team 下的作用域 `Admin`
+- 团队 `member` -> 该 team 下的作用域 `Member`
+- 团队 `viewer` -> 该 team 下的作用域 `Viewer`
 
-### 6.2 触发时机
+该同步不会删除或授予用户的全局角色。历史上由团队角色同步出来的全局 `Admin` / `Member` 因无法区分来源，不会自动批量清理。
 
-以下团队操作会触发同步：
+### 6.3 权限解析规则
+
+作用域权限检查使用 `check_scoped_permission(user, code, scope_type, scope_id)`：
+
+1. `is_superuser` 直接通过
+2. 全局角色命中目标 permission 或 `*` 时通过
+3. 对非 `admin:*` 权限，团队作用域角色命中目标 permission 或 `*` 时通过
+4. 其他情况拒绝
+
+`admin:*` 始终只允许全局角色或超级管理员满足，团队作用域角色不能授予后台管理权限。
+
+### 6.4 触发时机
+
+以下团队操作会维护团队作用域授权：
 
 - 添加成员
 - 修改成员角色
 - 移除成员
 - 主动离开团队
+- 转移所有权
 
-### 6.3 影响
+默认团队注册流程会创建 `TeamMember`，并立即同步为团队作用域授权。
 
-这意味着当前实现里：
+### 6.5 团队 Viewer 与只可浏览权限
 
-- 全局 `Admin` / `Member` 不是纯粹静态角色
-- 它们会被团队角色反向驱动
-- 团队角色与全局角色在语义上已经耦合
+团队 `viewer` 和全局 `Viewer` 不是同一个角色：
 
-这是当前权限体系最核心的实现特征之一。
+- 团队 `viewer` 只表示用户在某个团队内处于最低管理级别。
+- 团队 `viewer` 不会自动授予全局 `Viewer` 角色。
+- 全局 `Viewer` 才提供 `team:read`、`agent:read/chat`、`workflow:read/run`、`kb:read`、`tool:read/execute`、`skill:read/execute` 等 permission code。
+
+因此，“只可浏览”在当前实现中更准确地表示：不能 create / update / delete / publish，但可以在已有资源上执行安全使用类动作，例如 chat、run、execute。
 
 ---
 
@@ -359,7 +390,8 @@
 2. 超级管理员直接放行
 3. 检查用户是否为该 team 成员
 4. 如果是写操作或管理操作，且 `require_admin=True`
-   - 要求团队角色必须是 `owner` 或 `admin`
+   - 常见要求是团队角色必须是 `owner` 或 `admin`
+   - 但各资源 helper 仍有差异，KB 的后台路径可绕过普通团队成员校验
 
 ### 7.1 资源模块中的统一模式
 
@@ -391,7 +423,7 @@
 例如：
 
 - 必须是该 team 成员
-- 某些操作必须是 `owner/admin`
+- 某些操作必须是 `owner/admin`；具体以对应 endpoint/helper 为准
 
 因此，拥有某个 permission code 并不代表可以操作任意团队的数据。
 
@@ -586,12 +618,12 @@ Workflow 采用与 Agent 类似的模式：
 
 当前权限体系并非“只有内置角色 + 权限表”，而是：
 
-- **全局角色体系** 与 **团队成员体系** 同时存在
-- 且两者通过 `team_role_sync` 存在反向同步
+- **全局角色体系** 与 **团队作用域授权体系** 同时存在
+- `team_role_sync` 只维护团队作用域授权，不再把团队角色同步为全局 `Admin` / `Member`
 
 因此，当前系统更准确的描述应为：
 
-> 一个以全局 RBAC 为能力层、以 TeamMember 为作用域层、以资源可见性为对象层的复合权限系统。
+> 一个以全局 RBAC 为全局能力层、以团队作用域 RBAC 为 team 内能力层、以资源可见性为对象层的复合权限系统。
 
 ### 12.3 当前主要问题
 

--- a/docs/dev/design/access-control/README.md
+++ b/docs/dev/design/access-control/README.md
@@ -16,5 +16,6 @@ Use this area for:
 
 ## Notes
 
-- `RBAC_SPEC.md` describes the current implementation in code, including global RBAC, team member roles, and resource visibility.
-- `TEAM_MODEL_AUTH_SPEC.md` focuses on model authorization and team-scoped isolation.
+- `RBAC_SPEC.md` is the canonical current implementation reference for global roles, team roles, default assignment, effective permissions, and Viewer view/use-only semantics.
+- `TEAM_MODEL_AUTH_SPEC.md` focuses on model authorization and team-scoped model/quota isolation.
+- Older guide or analysis documents may be higher-level or historical; when exact permission behavior matters, link back to `RBAC_SPEC.md` rather than duplicating matrices.

--- a/docs/guide/admin-guide/permissions/PERMISSIONS.md
+++ b/docs/guide/admin-guide/permissions/PERMISSIONS.md
@@ -2,13 +2,15 @@
 
 This document describes the permission system design of the Clouisle platform, including special permissions, permission combinations, and data visibility rules.
 
+For exact implementation semantics, use `docs/dev/design/access-control/RBAC_SPEC.md` as the source of truth. This guide is operator-facing and intentionally summarizes the current model.
+
 ## 1. Permission Categories
 
 ### 1.1 Special Permissions
 
 | Permission | Description | Purpose |
 |------------|-------------|---------|
-| `*` | Super permission | Only Super Admin role has this, bypasses all permission checks |
+| `*` | Wildcard permission code | Satisfies permission-code checks; `User.is_superuser` is the runtime bypass used by backend checks |
 | `admin:dashboard:access` | Dashboard access | Controls access to admin dashboard, key permission distinguishing "admin" from "regular user" |
 
 ### 1.2 Dashboard Management Permissions (requires `admin:dashboard:access`)
@@ -56,7 +58,7 @@ These permissions are for managing business resources. All users may have them, 
 | **Super Admin** | Super administrator | `*` (all permissions) |
 | **Admin** | Dashboard administrator | `admin:dashboard:access` + system read visibility + team-scoped resource management |
 | **Member** | Collaborative member | Daily resource creation and editing without dashboard access |
-| **Viewer** | Default read-only user | Read/chat/run/execute permissions without dashboard access |
+| **Viewer** | Default read/use-only user | Read/chat/run/execute permissions without dashboard access |
 
 ### 2.2 Role Permission Comparison
 
@@ -98,9 +100,30 @@ These permissions are for managing business resources. All users may have them, 
 | `conversation:read` | ✓ | ✓ | ✓ | ✓ |
 | `conversation:delete` | ✓ | ✓ | ✓ | |
 
+### 2.3 Default Assignment
+
+New users receive the configured default global role. During system initialization, `default_role_id` is set to the global **Viewer** role when no default exists.
+
+If `default_team_id` is configured, new users also join that team with `default_team_role`. The default team role is `member`; valid automatic team roles are `viewer`, `member`, and `admin`. `owner` is never assigned automatically.
+
+Global roles and team roles are separate: global roles provide permission codes, while team roles are mirrored into team-scoped role assignments. Team-scoped permissions apply only inside the target team and cannot satisfy `admin:*` dashboard permissions.
+
+### 2.4 Scoped Team Role Assignments
+
+Team membership is mirrored into team-scoped role assignments:
+
+| Team role | Scoped role in that team |
+|-----------|--------------------------|
+| Owner | Admin |
+| Admin | Admin |
+| Member | Member |
+| Viewer | Viewer |
+
+This does not grant or remove global roles. Legacy global `Admin` / `Member` assignments from earlier behavior are not automatically cleaned up because their source cannot be distinguished from manual assignments.
+
 ---
 
-## 3. Data Isolation Rules
+## 3. Data Visibility and Isolation
 
 ### 3.1 Core Concepts
 
@@ -150,7 +173,7 @@ For resources other than conversations (Agent, Workflow, Knowledge Base, etc.):
 | Super Admin | All resources |
 | Admin | All resources in their teams |
 | Member | All resources in their teams |
-| Viewer | All resources in their teams (read-only) |
+| Viewer | All resources in their teams (view/use-only) |
 
 ---
 
@@ -176,7 +199,7 @@ For resources other than conversations (Agent, Workflow, Knowledge Base, etc.):
 - ✓ Dashboard management menu
 - ✗ Other teams' conversations
 
-### 4.3 Scenario: Read-Only User
+### 4.3 Scenario: View/Use-Only User
 
 **User Role**: Viewer (default role)
 
@@ -185,7 +208,7 @@ For resources other than conversations (Agent, Workflow, Knowledge Base, etc.):
 - ✓ Chat with Agent (`agent:chat`)
 - ✓ Run workflows (`workflow:run`)
 - ✓ Execute tools (`tool:execute`)
-- ✗ Create/modify/delete any resources
+- ✗ Create/modify/delete/publish resources
 - ✗ Access dashboard management
 
 ### 4.4 Scenario: Site Settings Management
@@ -285,7 +308,7 @@ else:
 | System Administrator | Super Admin | Responsible for system configuration, user management |
 | Department Manager | Admin | View dashboard data and manage team resources without changing the permission system |
 | Developer | Member | Create and edit day-to-day resources without dashboard access |
-| Business User | Viewer | Default read-only access for using agents and workflows |
+| Business User | Viewer | Default view/use-only access for using agents and workflows |
 
 ### 7.2 Custom Roles
 
@@ -306,3 +329,4 @@ You can create custom roles based on business needs, for example:
 - Only grant users the minimum permissions needed to complete their work
 - Avoid assigning `admin:dashboard:access` permission to regular users
 - `admin:settings:update` permission should be limited to system administrators only
+- Review legacy global `Admin` / `Member` grants after enabling scoped RBAC; team roles no longer maintain those global roles

--- a/docs/guide/user-guide/teams/team-roles.md
+++ b/docs/guide/user-guide/teams/team-roles.md
@@ -4,7 +4,9 @@ This guide explains the different roles and permissions in Clouisle teams.
 
 ## Overview
 
-Team roles control what members can do within a team. Understanding roles helps you:
+Team roles control what members can do within a team. They are separate from global system roles. Global roles provide system-wide capabilities; team roles are mirrored into team-scoped role assignments that apply only inside that team. Team roles do not grant admin dashboard (`admin:*`) permissions.
+
+Understanding roles helps you:
 
 - **Manage access**: Control who can do what
 - **Delegate responsibilities**: Assign appropriate permissions
@@ -37,16 +39,16 @@ Viewer (lowest permissions)
 | **Member Management** |
 | Invite members | ✅ | ✅ | ❌ | ❌ |
 | Remove members | ✅ | ✅ | ❌ | ❌ |
-| Change member roles | ✅ | ✅ | ❌ | ❌ |
+| Change member roles | ✅ | ❌ | ❌ | ❌ |
 | **Agents** |
 | Create agents | ✅ | ✅ | ✅ | ❌ |
 | Save team agents | ✅ | ✅ | ✅ | ❌ |
-| Delete agents | ✅ | ✅ | ✅ | ❌ |
+| Delete agents | ✅ | ✅ | ❌ | ❌ |
 | Chat with agents | ✅ | ✅ | ✅ | ✅ |
 | **Workflows** |
 | Create workflows | ✅ | ✅ | ✅ | ❌ |
 | Save team workflows | ✅ | ✅ | ✅ | ❌ |
-| Delete workflows | ✅ | ✅ | ✅ | ❌ |
+| Delete workflows | ✅ | ✅ | ❌ | ❌ |
 | Run workflows | ✅ | ✅ | ✅ | ✅ |
 | **Tools & Skills** |
 | Create/edit/delete tools | ✅ | ✅ | ❌ | ❌ |
@@ -72,6 +74,10 @@ Viewer (lowest permissions)
 | View audit logs | ✅ | ✅ | ❌ | ❌ |
 | Export data | ✅ | ✅ | ❌ | ❌ |
 
+## Scope Boundary
+
+Team roles only apply inside the team where they are assigned. A team Admin can manage resources in that team, but does not gain admin dashboard permissions unless a global role separately grants `admin:*` permissions.
+
 ## Owner Role
 
 ### Responsibilities
@@ -94,9 +100,7 @@ Viewer (lowest permissions)
 - Manage subscription
 
 **Shared with Admin:**
-- All admin permissions
 - Invite/remove members
-- Change member roles
 - Update team settings
 - View audit logs
 
@@ -160,12 +164,11 @@ Viewer (lowest permissions)
 **Member management:**
 - Invite new members
 - Remove members (except Owner)
-- Change member roles (except Owner)
 - Approve join requests
 - View member activity
 
 **Resource management:**
-- Create/update/delete all team resources
+- Create/update/delete team resources allowed by team-scoped RBAC
 - Manage agents, workflows, knowledge bases
 - Configure resource settings
 - Monitor resource usage
@@ -214,7 +217,7 @@ Viewer (lowest permissions)
 **App collaboration:**
 - Save team agents
 - Save team workflows
-- Delete team agents and workflows when permitted by global RBAC
+- Use team agents and workflows
 
 **Resource usage:**
 - Chat with all team agents
@@ -236,6 +239,7 @@ Viewer (lowest permissions)
 - Manage team settings
 - Invite or remove members
 - Change member roles
+- Delete or publish agents and workflows
 - Update others' resources
 - Delete others' resources
 - View audit logs
@@ -245,7 +249,7 @@ Viewer (lowest permissions)
 
 ### Responsibilities
 
-**Viewers have read-only access:**
+**Viewers have view/use-only access:**
 
 - View team resources
 - Use agents and workflows
@@ -282,6 +286,10 @@ Viewer (lowest permissions)
 - Temporary access
 - Read-only auditors
 - Stakeholders
+
+## Default Team Role
+
+When a default team is configured, new users can be added automatically as `viewer`, `member`, or `admin`. If no role is configured, the default is `member`. `owner` is never assigned automatically.
 
 ## Custom Roles (If Available)
 
@@ -322,7 +330,7 @@ Viewer (lowest permissions)
 
 ### Assigning Roles
 
-**Steps (Owner/Admin only):**
+**Steps (Owner only):**
 
 1. Go to **Team Settings** → **Members**
 2. Find member
@@ -445,7 +453,7 @@ You now have additional permissions:
 
 **✅ Do:**
 - Limit Owner and Admin roles
-- Use Viewer role for read-only access
+- Use Viewer role for view/use-only access
 - Review audit logs regularly
 - Monitor role changes
 - Require approval for role changes

--- a/docs/guide/user-guide/teams/team-roles.md
+++ b/docs/guide/user-guide/teams/team-roles.md
@@ -30,32 +30,53 @@ Viewer (lowest permissions)
 
 ### Role Comparison
 
+### Team Management
+
 | Permission | Owner | Admin | Member | Viewer |
 |------------|-------|-------|--------|--------|
-| **Team Management** |
 | Delete team | ✅ | ❌ | ❌ | ❌ |
 | Update team settings | ✅ | ✅ | ❌ | ❌ |
 | Transfer ownership | ✅ | ❌ | ❌ | ❌ |
-| **Member Management** |
+
+### Member Management
+
+| Permission | Owner | Admin | Member | Viewer |
+|------------|-------|-------|--------|--------|
 | Invite members | ✅ | ✅ | ❌ | ❌ |
 | Remove members | ✅ | ✅ | ❌ | ❌ |
 | Change member roles | ✅ | ❌ | ❌ | ❌ |
-| **Agents** |
+
+### Agents
+
+| Permission | Owner | Admin | Member | Viewer |
+|------------|-------|-------|--------|--------|
 | Create agents | ✅ | ✅ | ✅ | ❌ |
 | Save team agents | ✅ | ✅ | ✅ | ❌ |
 | Delete agents | ✅ | ✅ | ❌ | ❌ |
 | Chat with agents | ✅ | ✅ | ✅ | ✅ |
-| **Workflows** |
+
+### Workflows
+
+| Permission | Owner | Admin | Member | Viewer |
+|------------|-------|-------|--------|--------|
 | Create workflows | ✅ | ✅ | ✅ | ❌ |
 | Save team workflows | ✅ | ✅ | ✅ | ❌ |
 | Delete workflows | ✅ | ✅ | ❌ | ❌ |
 | Run workflows | ✅ | ✅ | ✅ | ✅ |
-| **Tools & Skills** |
+
+### Tools & Skills
+
+| Permission | Owner | Admin | Member | Viewer |
+|------------|-------|-------|--------|--------|
 | Create/edit/delete tools | ✅ | ✅ | ❌ | ❌ |
 | Create/edit/delete skills | ✅ | ✅ | ❌ | ❌ |
 | Execute approved tools | ✅ | ✅ | ✅ | ✅ |
 | Execute approved skills | ✅ | ✅ | ✅ | ✅ |
-| **Knowledge Bases** |
+
+### Knowledge Bases
+
+| Permission | Owner | Admin | Member | Viewer |
+|------------|-------|-------|--------|--------|
 | Create knowledge bases | ✅ | ✅ | ✅ | ❌ |
 | Upload documents | ✅ | ✅ | ✅ | ❌ |
 | Update own documents | ✅ | ✅ | ✅ | ❌ |
@@ -63,13 +84,21 @@ Viewer (lowest permissions)
 | Delete own documents | ✅ | ✅ | ✅ | ❌ |
 | Delete others' documents | ✅ | ✅ | ❌ | ❌ |
 | Search documents | ✅ | ✅ | ✅ | ✅ |
-| **API Keys** |
+
+### API Keys
+
+| Permission | Owner | Admin | Member | Viewer |
+|------------|-------|-------|--------|--------|
 | Create API keys | ✅ | ✅ | ✅ | ❌ |
 | View own API keys | ✅ | ✅ | ✅ | ❌ |
 | View all API keys | ✅ | ✅ | ❌ | ❌ |
 | Revoke own API keys | ✅ | ✅ | ✅ | ❌ |
 | Revoke others' API keys | ✅ | ✅ | ❌ | ❌ |
-| **Audit & Analytics** |
+
+### Audit & Analytics
+
+| Permission | Owner | Admin | Member | Viewer |
+|------------|-------|-------|--------|--------|
 | View team analytics | ✅ | ✅ | ❌ | ❌ |
 | View audit logs | ✅ | ✅ | ❌ | ❌ |
 | Export data | ✅ | ✅ | ❌ | ❌ |

--- a/docs/plan/scoped-rbac.md
+++ b/docs/plan/scoped-rbac.md
@@ -1,0 +1,154 @@
+# Scoped RBAC Design Document
+
+## Background & Goals
+
+The current permission system combines global RBAC with team-local roles and then syncs team roles back into global roles. This creates two problems:
+
+- a team-local `admin` can receive global `Admin` permissions;
+- removing team membership can remove global `Admin` / `Member` roles even when they were assigned manually.
+
+Goals:
+
+- close known authorization gaps before changing schema;
+- centralize team access checks;
+- add team-scoped role assignments without removing existing global roles;
+- keep `admin:*` permissions global-only;
+- keep resource visibility and creator ownership checks separate from RBAC.
+
+## High-Level Design
+
+The landing is staged.
+
+1. Add one shared team-access helper and patch high-risk Workflow endpoints.
+2. Add an additive scoped role assignment table and backfill it from `TeamMember.role`.
+3. Add scoped permission helpers and migrate Team, Agent, and Workflow checks first.
+4. Frontend compatibility was not needed for this landing because the backend did not expose scoped permission data in `/users/me`.
+
+Existing global `PermissionChecker` remains the global/admin-route gate. Scoped checks are added beside it; they do not replace the whole authorization stack in one pass.
+
+## Implementation Plan
+
+### Stage 1: Shared team access and immediate workflow authorization fixes
+
+- **Status**: Completed.
+
+- **Files modified**:
+  - `backend/app/api/team_access.py`
+  - `backend/app/api/v1/endpoints/agents.py`
+  - `backend/app/api/v1/endpoints/workflows.py`
+  - `backend/app/api/v1/workflow_versions.py`
+  - `backend/app/api/v1/workflow_metrics.py`
+  - representative team helper call sites as needed
+
+- **Specific logic**:
+  - Add shared `check_team_access(team_id, user, require_admin=False)`.
+  - Use `owner/admin` only for `require_admin=True`.
+  - Reuse or extract workflow resource access checks for version and metrics endpoints.
+  - Add permission checks for workflow version read/update/publish actions.
+  - Require admin permission for global workflow metrics/cache endpoints.
+
+- **Validation**:
+  - Non-member gets 403 for team resources.
+  - Team member cannot pass owner/admin-only checks.
+  - Workflow version and metrics endpoints reject unrelated users.
+
+### Stage 2: Scoped role assignment model and migration
+
+- **Status**: Completed.
+
+- **Files modified**:
+  - `backend/app/models/user.py`
+  - `backend/app/core/init_data.py`
+  - `backend/app/services/team_role_sync.py`
+  - `backend/app/api/v1/admin/endpoints/roles.py`
+
+- **Specific logic**:
+  - Add `ScopedRoleAssignment` with `user`, `role`, `scope_type`, `scope_id`, `source`, timestamps, and unique `(user, role, scope_type, scope_id)`.
+  - Add idempotent startup migration and indexes.
+  - Backfill team memberships into scoped assignments.
+  - Update role deletion guard to reject roles used by scoped assignments.
+  - Stop new team-role changes from granting global `Admin`.
+  - Do not bulk-remove existing global `Admin` / `Member` roles.
+
+- **Validation**:
+  - Migration is idempotent.
+  - Scoped assignments are created for existing team members.
+  - Existing global permission checks still pass.
+
+### Stage 3: Scoped permission helper and first endpoint migration
+
+- **Status**: Completed.
+
+- **Files modified**:
+  - `backend/app/api/scoped_permissions.py` or `backend/app/api/deps.py`
+  - `backend/app/api/v1/endpoints/teams.py`
+  - `backend/app/api/v1/endpoints/agents.py`
+  - `backend/app/api/v1/endpoints/workflows.py`
+
+- **Specific logic**:
+  - Add `user_has_global_permission`, `user_has_scoped_permission`, and `check_scoped_permission` in `deps.py`.
+  - Resolution order: superuser, global permission, scoped permission, deny.
+  - Ensure scoped team roles do not satisfy `admin:*`.
+  - Apply scoped checks first to Team, Agent, and Workflow paths.
+
+- **Validation**:
+  - Team-scoped Admin works only in its team.
+  - Team-scoped Admin cannot access dashboard/admin routes.
+  - Scoped permission tests cover global-only `admin:*` denial and non-admin scoped permission allow.
+  - Superuser bypass remains intact.
+
+### Stage 4: Frontend compatibility if needed
+
+- **Status**: Completed.
+
+- **Files modified**:
+  - `frontend/lib/api/auth.ts`
+  - `frontend/hooks/use-permissions.ts`
+  - `frontend/components/permission-guard.tsx`
+
+- **Specific logic**:
+  - Keep flat role permissions working.
+  - Add optional scoped permission shape only if `/users/me` exposes it.
+  - Extend `hasPermission(permission, teamId?)` without changing old callers.
+  - Do not add `X-Team-ID`.
+
+- **Validation**:
+  - Existing guards still work.
+  - Frontend lint passes if frontend files change.
+
+### Stage 5: Documentation and cleanup
+
+- **Status**: Completed.
+
+- **Files modified**:
+  - `docs/dev/design/access-control/RBAC_SPEC.md`
+  - `docs/dev/design/access-control/PERMISSION_AUDIT_REPORT.md`
+  - relevant user/admin permission guides
+
+- **Specific logic**:
+  - Document scoped RBAC as the target model.
+  - Mark team-to-global sync as legacy or removed depending on final code.
+  - Document that legacy global roles are not automatically removed.
+
+- **Validation**:
+  - Docs match implementation behavior.
+
+## Testing Strategy
+
+- Backend targeted tests for team access, workflow versions, workflow metrics, scoped assignment migration, scoped permission checks, and role deletion guard.
+- `uv run ruff check` and `uv run ruff format --check` for changed backend files.
+- `uv run mypy app/` if feasible.
+- `bun run lint` only if frontend files change.
+
+## Risks & Mitigation
+
+- **Risk**: removing global `Admin` / `Member` breaks users because current data lacks source tracking.  
+  **Mitigation**: do not bulk-remove existing global roles.
+
+- **Risk**: member edit behavior changes for Agent/Workflow.  
+  **Mitigation**: first enforce explicit owner/admin semantics where helper says admin; scoped roles can later grant finer write permissions intentionally.
+
+- **Risk**: large migration surface.  
+  **Mitigation**: additive table, idempotent migration, and staged endpoint rollout.
+
+- **Rollback**: previous code can ignore the additive scoped assignment table. Stage 1 changes are file-local and reversible.

--- a/frontend/app/(dashboard)/apps/_components/admin-agent-edit-client.tsx
+++ b/frontend/app/(dashboard)/apps/_components/admin-agent-edit-client.tsx
@@ -15,7 +15,7 @@ export function AdminAgentEditClient({ agentId }: { agentId: string }) {
         unpublishAgent: adminAgentsApi.unpublish,
       }}
       backHref="/apps"
-      updatePermission="admin:app:update"
+      allowPermissionUpdate
       baseUrl={`/apps/agents/${agentId}/edit`}
     />
   )

--- a/frontend/app/(dashboard)/apps/_components/admin-workflow-edit-client.tsx
+++ b/frontend/app/(dashboard)/apps/_components/admin-workflow-edit-client.tsx
@@ -18,6 +18,7 @@ export function AdminWorkflowEditClient({ workflowId }: { workflowId: string }) 
         }}
         backHref="/apps?tab=workflows"
         updatePermission="admin:app:update"
+        allowPermissionUpdate
         baseUrl={`/apps/workflows/${workflowId}/edit`}
       />
     </ReactFlowProvider>

--- a/frontend/app/(platform)/app/apps/[id]/_components/agent-toolbar.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/_components/agent-toolbar.tsx
@@ -35,7 +35,7 @@ interface AgentToolbarProps {
   isSaving: boolean
   onSettingsClick: () => void
   onEmbedClick: () => void
-  sidebarCollapsed: boolean
+  onToggleSidebar: () => void
   canUpdate?: boolean
   canPublish?: boolean
 }

--- a/frontend/app/(platform)/app/apps/[id]/_components/agent-toolbar.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/_components/agent-toolbar.tsx
@@ -27,7 +27,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { PermissionGuard } from '@/components/permission-guard'
 
 interface AgentToolbarProps {
   agent: Agent
@@ -37,8 +36,8 @@ interface AgentToolbarProps {
   onSettingsClick: () => void
   onEmbedClick: () => void
   sidebarCollapsed: boolean
-  onToggleSidebar: () => void
-  updatePermission?: string
+  canUpdate?: boolean
+  canPublish?: boolean
 }
 
 export function AgentToolbar({
@@ -50,7 +49,8 @@ export function AgentToolbar({
   onEmbedClick,
   sidebarCollapsed,
   onToggleSidebar,
-  updatePermission = 'agent:update',
+  canUpdate = false,
+  canPublish = false,
 }: AgentToolbarProps) {
   const t = useTranslations('agents.orchestration')
 
@@ -98,30 +98,33 @@ export function AgentToolbar({
           </Button>
         </Link>
 
-        <PermissionGuard permission={updatePermission}>
-          {/* Embed Button */}
-          <Button data-testid="agent-embed-button" variant="outline" size="sm" onClick={onEmbedClick} className="cursor-pointer">
-            <Code className="mr-1.5 h-3.5 w-3.5" />
-            {t('toolbar.embed')}
-          </Button>
+        {canUpdate && (
+          <>
+            {/* Embed Button */}
+            <Button data-testid="agent-embed-button" variant="outline" size="sm" onClick={onEmbedClick} className="cursor-pointer">
+              <Code className="mr-1.5 h-3.5 w-3.5" />
+              {t('toolbar.embed')}
+            </Button>
 
-          {/* Settings Button */}
-          <Button data-testid="agent-settings-button" variant="outline" size="sm" onClick={onSettingsClick} className="cursor-pointer">
-            <Settings className="mr-1.5 h-3.5 w-3.5" />
-            {t('toolbar.settings')}
-          </Button>
+            {/* Settings Button */}
+            <Button data-testid="agent-settings-button" variant="outline" size="sm" onClick={onSettingsClick} className="cursor-pointer">
+              <Settings className="mr-1.5 h-3.5 w-3.5" />
+              {t('toolbar.settings')}
+            </Button>
 
-          {/* Save Button */}
-          <Button data-testid="agent-save-button" variant="outline" size="sm" onClick={onSave} disabled={isSaving} className="cursor-pointer">
-            {isSaving ? (
-              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Save className="mr-1.5 h-3.5 w-3.5" />
-            )}
-            {isSaving ? t('toolbar.saving') : t('toolbar.save')}
-          </Button>
+            {/* Save Button */}
+            <Button data-testid="agent-save-button" variant="outline" size="sm" onClick={onSave} disabled={isSaving} className="cursor-pointer">
+              {isSaving ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Save className="mr-1.5 h-3.5 w-3.5" />
+              )}
+              {isSaving ? t('toolbar.saving') : t('toolbar.save')}
+            </Button>
+          </>
+        )}
 
-          {/* Publish Button */}
+        {canPublish && (
           <DropdownMenu>
             <DropdownMenuTrigger data-testid="agent-publish-button" className="cursor-pointer inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 h-8 px-3">
               {agent.status === 'published' ? t('toolbar.published') : t('toolbar.publish')}
@@ -133,7 +136,7 @@ export function AgentToolbar({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-        </PermissionGuard>
+        )}
       </div>
     </div>
   )

--- a/frontend/app/(platform)/app/apps/[id]/_components/agent-toolbar.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/_components/agent-toolbar.tsx
@@ -35,6 +35,7 @@ interface AgentToolbarProps {
   isSaving: boolean
   onSettingsClick: () => void
   onEmbedClick: () => void
+  sidebarCollapsed: boolean
   onToggleSidebar: () => void
   canUpdate?: boolean
   canPublish?: boolean

--- a/frontend/app/(platform)/app/apps/[id]/page.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/page.tsx
@@ -2,6 +2,8 @@
 
 import * as React from 'react'
 import { useRouter } from 'next/navigation'
+import { useTeam } from '@/contexts/team-context'
+import { usePermissions } from '@/hooks/use-permissions'
 import { useTranslations } from 'next-intl'
 import { toast } from 'sonner'
 import {
@@ -27,6 +29,7 @@ import { AgentOrchestrationForm } from './_components/agent-orchestration-form'
 import { AgentPreviewPanel } from './_components/agent-preview-panel'
 import { AgentSettingsDrawer } from './_components/agent-settings-drawer'
 import { EmbedConfigDialog } from './_components/embed-config-dialog'
+import { useCanPerform } from '@/components/permission-guard'
 
 interface AgentConfigPageProps {
   params: Promise<{ id: string }>
@@ -43,19 +46,22 @@ interface AgentEditorProps {
   agentId: string
   api?: AgentEditorApi
   backHref?: string
-  updatePermission?: string
   baseUrl?: string
+  allowPermissionUpdate?: boolean
 }
 
 export function AgentEditor({
   agentId,
   api = agentsApi,
   backHref = '/app/apps',
-  updatePermission = 'agent:update',
   baseUrl = `/app/apps/${agentId}`,
+  allowPermissionUpdate = false,
 }: AgentEditorProps) {
   const t = useTranslations('agents')
   const router = useRouter()
+  const { currentTeam } = useTeam()
+  const { user } = usePermissions()
+  const { canPerform } = useCanPerform()
 
   const [agent, setAgent] = React.useState<Agent | null>(null)
   const [isLoading, setIsLoading] = React.useState(true)
@@ -283,6 +289,10 @@ export function AgentEditor({
 
   // Check if tools are enabled
   const hasToolsEnabled = toolsConfig.length > 0
+  const canUpdateAgent = Boolean(
+    agent && (user?.is_superuser || (allowPermissionUpdate && canPerform('agent:update')) || currentTeam?.role === 'owner' || currentTeam?.role === 'admin' || agent.created_by?.id === user?.id)
+  )
+  const canPublishAgent = canPerform('agent:publish')
 
   if (isLoading || !agent) {
     return (
@@ -317,7 +327,8 @@ export function AgentEditor({
           onEmbedClick={() => setShowEmbed(true)}
           sidebarCollapsed={sidebarCollapsed}
           onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)}
-          updatePermission={updatePermission}
+          canUpdate={canUpdateAgent}
+          canPublish={canPublishAgent}
         />
 
         {/* Content */}

--- a/frontend/app/(platform)/app/apps/page.tsx
+++ b/frontend/app/(platform)/app/apps/page.tsx
@@ -286,12 +286,14 @@ export default function AppsPage() {
   }
 
   const expectedImportType: ClouisleResourceType | undefined = activeTab === 'agent' || activeTab === 'workflow' ? activeTab : undefined
-  const isTeamAdmin = user?.is_superuser || currentTeam?.role === 'owner' || currentTeam?.role === 'admin'
-  const canCreateApp = canPerform(['agent:create', 'workflow:create'])
-  const canEditApp = (app: AppItem) => isTeamAdmin || app.created_by_id === user?.id
-  const canDuplicateApp = (app: AppItem) =>
-    app.type === 'agent' ? canPerform('agent:create') : canPerform('workflow:create')
-  const canExportApp = (app: AppItem) => app.created_by_id === user?.id
+  const isTeamAdmin = Boolean(user?.is_superuser || currentTeam?.role === 'owner' || currentTeam?.role === 'admin')
+  const canCreateAgent = isTeamAdmin || canPerform('agent:create')
+  const canCreateWorkflow = isTeamAdmin || canPerform('workflow:create')
+  const canCreateApp = canCreateAgent || canCreateWorkflow
+  const isAppOwner = (app: AppItem) => Boolean(user?.id && app.created_by_id === user.id)
+  const canEditApp = (app: AppItem) => isTeamAdmin || isAppOwner(app)
+  const canDuplicateApp = (app: AppItem) => app.type === 'agent' ? canCreateAgent : canCreateWorkflow
+  const canExportApp = (app: AppItem) => isTeamAdmin || isAppOwner(app)
   const canPublishApp = () => isTeamAdmin
   const canDeleteApp = () => isTeamAdmin
 

--- a/frontend/app/(platform)/app/apps/page.tsx
+++ b/frontend/app/(platform)/app/apps/page.tsx
@@ -52,8 +52,9 @@ import { agentsApi, type AgentListItem } from '@/lib/api/agents'
 import { workflowsApi, type WorkflowListItem } from '@/lib/api/workflows'
 import { useTeam } from '@/contexts/team-context'
 import { useRequireTeam } from '@/hooks/use-require-team'
+import { usePermissions } from '@/hooks/use-permissions'
 import { AppCreateDialog } from './_components/app-create-dialog'
-import { PermissionGuard, useCanPerform } from '@/components/permission-guard'
+import { useCanPerform } from '@/components/permission-guard'
 import { ImportPackageDialog } from '@/components/packages/import-package-dialog'
 import { downloadBlob, packagesApi, type ClouisleResourceType } from '@/lib/api/packages'
 
@@ -76,6 +77,8 @@ interface AppItem {
   fail_count?: number
   created_at: string
   updated_at: string
+  created_by_id?: string | null
+  created_by_name?: string | null
 }
 
 export default function AppsPage() {
@@ -83,6 +86,7 @@ export default function AppsPage() {
   const packageT = useTranslations('packages')
   const tCommon = useTranslations('common')
   const { currentTeam } = useTeam()
+  const { user } = usePermissions()
   const router = useRouter()
   const searchParams = useSearchParams()
   const { canPerform } = useCanPerform()
@@ -153,6 +157,8 @@ export default function AppsPage() {
         message_count: agent.message_count,
         created_at: agent.created_at,
         updated_at: agent.updated_at,
+        created_by_id: agent.created_by?.id ?? null,
+        created_by_name: agent.created_by?.username ?? null,
       }))
       
       // Transform workflows to unified format
@@ -168,6 +174,8 @@ export default function AppsPage() {
         fail_count: workflow.fail_count,
         created_at: workflow.created_at,
         updated_at: workflow.updated_at,
+        created_by_id: workflow.created_by_id ?? null,
+        created_by_name: workflow.created_by_name ?? null,
       }))
       
       // Combine and sort by updated_at
@@ -278,6 +286,14 @@ export default function AppsPage() {
   }
 
   const expectedImportType: ClouisleResourceType | undefined = activeTab === 'agent' || activeTab === 'workflow' ? activeTab : undefined
+  const isTeamAdmin = user?.is_superuser || currentTeam?.role === 'owner' || currentTeam?.role === 'admin'
+  const canCreateApp = canPerform(['agent:create', 'workflow:create'])
+  const canEditApp = (app: AppItem) => isTeamAdmin || app.created_by_id === user?.id
+  const canDuplicateApp = (app: AppItem) =>
+    app.type === 'agent' ? canPerform('agent:create') : canPerform('workflow:create')
+  const canExportApp = (app: AppItem) => app.created_by_id === user?.id
+  const canPublishApp = () => isTeamAdmin
+  const canDeleteApp = () => isTeamAdmin
 
   return (
     <div className="py-6 px-8 h-full overflow-y-auto">
@@ -288,18 +304,18 @@ export default function AppsPage() {
           <p className="text-muted-foreground mt-1">{t('description')}</p>
         </div>
         <div className="flex items-center gap-2">
-          {currentTeam && canPerform(['agent:create', 'workflow:create']) && (
+          {currentTeam && canCreateApp && (
             <Button variant="outline" onClick={() => setImportDialogOpen(true)}>
               <Upload className="mr-2 h-4 w-4" />
               {packageT('import')}
             </Button>
           )}
-          <PermissionGuard permission={['agent:create', 'workflow:create']}>
+          {canCreateApp && (
             <Button data-testid="apps-create-button" onClick={() => setCreateDialogOpen(true)}>
               <Plus className="mr-2 h-4 w-4" />
               {t('createApp')}
             </Button>
-          </PermissionGuard>
+          )}
         </div>
       </div>
 
@@ -338,12 +354,12 @@ export default function AppsPage() {
             <AppWindow className="h-12 w-12 text-muted-foreground mb-4" />
             <CardTitle className="mb-2">{t('noApps')}</CardTitle>
             <CardDescription className="mb-4">{t('noAppsHint')}</CardDescription>
-            <PermissionGuard permission={['agent:create', 'workflow:create']}>
+            {canCreateApp && (
               <Button onClick={() => setCreateDialogOpen(true)}>
                 <Plus className="mr-2 h-4 w-4" />
                 {t('createFirstApp')}
               </Button>
-            </PermissionGuard>
+            )}
           </CardContent>
         </Card>
       ) : (
@@ -378,6 +394,11 @@ export default function AppsPage() {
                       <h3 className="text-sm font-medium truncate">
                         {app.name}
                       </h3>
+                      {app.created_by_name && (
+                        <p className="text-xs text-muted-foreground truncate">
+                          {tCommon('createdBy')}：{app.created_by_name}
+                        </p>
+                      )}
                       <div className="flex items-center gap-1.5 mt-0.5">
                         <Badge
                           variant={app.status === 'published' ? 'default' : 'secondary'}
@@ -437,12 +458,14 @@ export default function AppsPage() {
                       )}
                     />
                     <DropdownMenuContent align="end">
-                      <Link href={getAppLink(app)}>
-                        <DropdownMenuItem>
-                          <FileEdit className="mr-2 h-4 w-4" />
-                          {t('configure')}
-                        </DropdownMenuItem>
-                      </Link>
+                      {canEditApp(app) && (
+                        <Link href={getAppLink(app)}>
+                          <DropdownMenuItem>
+                            <FileEdit className="mr-2 h-4 w-4" />
+                            {t('configure')}
+                          </DropdownMenuItem>
+                        </Link>
+                      )}
                       {app.type === 'agent' && (
                         <Link href={`/chat/${app.id}`} target="_blank">
                           <DropdownMenuItem data-testid={`app-chat-button-${app.id}`}>
@@ -459,8 +482,7 @@ export default function AppsPage() {
                           </DropdownMenuItem>
                         </Link>
                       )}
-                      {((app.type === 'agent' && canPerform('agent:publish')) ||
-                        (app.type === 'workflow' && canPerform('workflow:publish'))) && (
+                      {canPublishApp() && (
                         <>
                           <DropdownMenuSeparator />
                           <DropdownMenuItem onClick={(e) => {
@@ -472,8 +494,7 @@ export default function AppsPage() {
                           </DropdownMenuItem>
                         </>
                       )}
-                      {((app.type === 'agent' && canPerform('agent:create')) ||
-                        (app.type === 'workflow' && canPerform('workflow:create'))) && (
+                      {canDuplicateApp(app) && (
                         <DropdownMenuItem onClick={(e) => {
                           e.preventDefault()
                           handleDuplicate(app)
@@ -482,8 +503,7 @@ export default function AppsPage() {
                           {t('duplicate')}
                         </DropdownMenuItem>
                       )}
-                      {((app.type === 'agent' && canPerform('agent:read')) ||
-                        (app.type === 'workflow' && canPerform('workflow:read'))) && (
+                      {canExportApp(app) && (
                         <DropdownMenuItem onClick={(e) => {
                           e.preventDefault()
                           handleExport(app)
@@ -492,8 +512,7 @@ export default function AppsPage() {
                           {packageT('export')}
                         </DropdownMenuItem>
                       )}
-                      {((app.type === 'agent' && canPerform('agent:delete')) ||
-                        (app.type === 'workflow' && canPerform('workflow:delete'))) && (
+                      {canDeleteApp() && (
                         <>
                           <DropdownMenuSeparator />
                           <DropdownMenuItem

--- a/frontend/app/(platform)/app/apps/workflow/[id]/page.tsx
+++ b/frontend/app/(platform)/app/apps/workflow/[id]/page.tsx
@@ -70,6 +70,7 @@ import {
 import { workflowsApi, Workflow, WorkflowUpdateInput, VariableDefinition } from '@/lib/api/workflows'
 import { authApi, User } from '@/lib/api/auth'
 import { useCanPerform } from '@/components/permission-guard'
+import { useTeam } from '@/contexts/team-context'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 
 // Custom Node Types
@@ -247,6 +248,7 @@ export function WorkflowEditorContent({
   const t = useTranslations('workflow')
   const tCommon = useTranslations('common')
   const { canPerform } = useCanPerform()
+  const { currentTeam } = useTeam()
 
   // Workflow definitions earlier than schema_version 2 predate the typed-
   // variable refactor (see docs/dev/design/app-platform/WORKFLOW_TYPE_SYSTEM.md).
@@ -278,10 +280,16 @@ export function WorkflowEditorContent({
   const [validationIssues, setValidationIssues] = React.useState<ValidationIssue[]>([])
   const [showEmbed, setShowEmbed] = React.useState(false)
 
-  const canUpdateWorkflow = Boolean(
-    workflow && (currentUser?.is_superuser || canPerform(updatePermission) || workflow.created_by_id === currentUser?.id)
+  const isWorkflowOwner = Boolean(currentUser?.id && workflow?.created_by_id === currentUser.id)
+  const isWorkflowTeamAdmin = Boolean(
+    workflow && currentTeam?.id === workflow.team_id && (currentTeam.role === 'owner' || currentTeam.role === 'admin')
   )
-  const canPublishWorkflow = canPerform('workflow:publish')
+  const canUpdateWorkflow = Boolean(
+    workflow && (currentUser?.is_superuser || canPerform(updatePermission) || isWorkflowTeamAdmin || isWorkflowOwner)
+  )
+  const canPublishWorkflow = Boolean(
+    workflow && (currentUser?.is_superuser || canPerform('workflow:publish') || isWorkflowTeamAdmin || isWorkflowOwner)
+  )
 
   // ReactFlow instance
   const reactFlowInstance = useReactFlow()
@@ -1507,7 +1515,7 @@ export function WorkflowEditorContent({
                   {tCommon('save')}
                 </Button>
               )}
-              {canPublishWorkflow && (
+              {canPublishWorkflow && (!hasChanges || canUpdateWorkflow) && (
                 <Button
                   variant={workflow?.status === 'published' ? 'default' : 'outline'}
                   size="sm"

--- a/frontend/app/(platform)/app/apps/workflow/[id]/page.tsx
+++ b/frontend/app/(platform)/app/apps/workflow/[id]/page.tsx
@@ -234,6 +234,7 @@ interface WorkflowEditorContentProps {
   api?: WorkflowEditorApi
   backHref?: string
   updatePermission?: string
+  allowPermissionUpdate?: boolean
   baseUrl?: string
 }
 
@@ -242,6 +243,7 @@ export function WorkflowEditorContent({
   api = workflowsApi,
   backHref = '/app/apps',
   updatePermission = 'workflow:update',
+  allowPermissionUpdate = false,
   baseUrl = `/app/apps/workflow/${workflowId}`,
 }: WorkflowEditorContentProps) {
   const router = useRouter()
@@ -285,11 +287,9 @@ export function WorkflowEditorContent({
     workflow && currentTeam?.id === workflow.team_id && (currentTeam.role === 'owner' || currentTeam.role === 'admin')
   )
   const canUpdateWorkflow = Boolean(
-    workflow && (currentUser?.is_superuser || canPerform(updatePermission) || isWorkflowTeamAdmin || isWorkflowOwner)
+    workflow && (currentUser?.is_superuser || (allowPermissionUpdate && canPerform(updatePermission)) || isWorkflowTeamAdmin || isWorkflowOwner)
   )
-  const canPublishWorkflow = Boolean(
-    workflow && (currentUser?.is_superuser || canPerform('workflow:publish') || isWorkflowTeamAdmin || isWorkflowOwner)
-  )
+  const canPublishWorkflow = canUpdateWorkflow
 
   // ReactFlow instance
   const reactFlowInstance = useReactFlow()

--- a/frontend/app/(platform)/app/apps/workflow/[id]/page.tsx
+++ b/frontend/app/(platform)/app/apps/workflow/[id]/page.tsx
@@ -247,7 +247,6 @@ export function WorkflowEditorContent({
   const t = useTranslations('workflow')
   const tCommon = useTranslations('common')
   const { canPerform } = useCanPerform()
-  const canUpdateWorkflow = canPerform(updatePermission)
 
   // Workflow definitions earlier than schema_version 2 predate the typed-
   // variable refactor (see docs/dev/design/app-platform/WORKFLOW_TYPE_SYSTEM.md).
@@ -278,6 +277,11 @@ export function WorkflowEditorContent({
   const [showValidationChecklist, setShowValidationChecklist] = React.useState(false)
   const [validationIssues, setValidationIssues] = React.useState<ValidationIssue[]>([])
   const [showEmbed, setShowEmbed] = React.useState(false)
+
+  const canUpdateWorkflow = Boolean(
+    workflow && (currentUser?.is_superuser || canPerform(updatePermission) || workflow.created_by_id === currentUser?.id)
+  )
+  const canPublishWorkflow = canPerform('workflow:publish')
 
   // ReactFlow instance
   const reactFlowInstance = useReactFlow()
@@ -1503,7 +1507,7 @@ export function WorkflowEditorContent({
                   {tCommon('save')}
                 </Button>
               )}
-              {canUpdateWorkflow && (
+              {canPublishWorkflow && (
                 <Button
                   variant={workflow?.status === 'published' ? 'default' : 'outline'}
                   size="sm"

--- a/frontend/app/(platform)/app/capabilities/_components/tool-card.tsx
+++ b/frontend/app/(platform)/app/capabilities/_components/tool-card.tsx
@@ -21,7 +21,6 @@ import {
   Play,
   Settings,
   Share2,
-  Download,
   Users,
   Clock3,
   Calculator,
@@ -42,7 +41,10 @@ interface ToolCardProps {
   onDelete?: (tool: Tool) => void
   onConfigure?: (tool: Tool) => void
   onShare?: (tool: Tool) => void
-  onExport?: (tool: Tool) => void
+  canConfigure?: boolean
+  canEdit?: boolean
+  canShare?: boolean
+  canDelete?: boolean
 }
 
 // 分类图标和颜色映射
@@ -104,12 +106,13 @@ export function ToolCard({
   onEdit,
   onDelete,
   onConfigure,
-  onShare,
-  onExport,
+  canConfigure = false,
+  canEdit = false,
+  canShare = false,
+  canDelete = false,
 }: ToolCardProps) {
   const t = useTranslations('platform.tools')
   const tCommon = useTranslations('common')
-  const packagesT = useTranslations('packages')
   const category = isPresetToolCategory(tool.category) ? categoryConfig[tool.category] : categoryConfig.other
   const categoryLabel = isPresetToolCategory(tool.category) ? t(`categories.${tool.category}`) : tool.category
   const typeColor = typeColorConfig[tool.type]
@@ -117,6 +120,8 @@ export function ToolCard({
   const needsConfig = tool.type === 'builtin' && tool.requires_config
   const isOwned = tool.is_owned !== false // 默认为 true
   const isShared = !isOwned // 共享给当前团队的工具
+  const showConfig = needsConfig && canConfigure
+  const showMenu = isEditable && (canEdit || canShare || canDelete)
 
   // 类型标签映射（使用 i18n）
   const typeLabels: Record<ToolType, string> = {
@@ -187,6 +192,11 @@ export function ToolCard({
 
             <CardDescription className="text-xs line-clamp-2 mt-0.5">
               {tool.description}
+              {tool.created_by_name && (
+                <span className="block text-muted-foreground mt-0.5 truncate">
+                  {tCommon('createdBy')}：{tool.created_by_name}
+                </span>
+              )}
               {/* 显示所有者信息（如果是共享工具） */}
               {isShared && tool.owner_team_name && (
                 <span className="block text-muted-foreground mt-0.5">
@@ -229,7 +239,7 @@ export function ToolCard({
               <Play className="h-3.5 w-3.5" />
             </Button>
 
-            {needsConfig && (
+            {showConfig && (
               <Button
                 variant="ghost"
                 size="sm"
@@ -244,7 +254,7 @@ export function ToolCard({
               </Button>
             )}
 
-            {isEditable && (
+            {showMenu && (
               <DropdownMenu>
                 <DropdownMenuTrigger
                   render={
@@ -259,52 +269,43 @@ export function ToolCard({
                   }
                 />
                 <DropdownMenuContent align="end">
-                  {/* 只有拥有的工具才能编辑和共享 */}
-                  {isOwned && (
-                    <>
-                      <DropdownMenuItem
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          onEdit?.(tool)
-                        }}
-                      >
-                        <Pencil className="h-4 w-4 mr-2" />
-                        {tCommon('edit')}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          onShare?.(tool)
-                        }}
-                      >
-                        <Share2 className="h-4 w-4 mr-2" />
-                        {t('share.title')}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          onExport?.(tool)
-                        }}
-                      >
-                        <Download className="h-4 w-4 mr-2" />
-                        {packagesT('export')}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        variant="destructive"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          onDelete?.(tool)
-                        }}
-                      >
-                        <Trash2 className="h-4 w-4 mr-2" />
-                        {tCommon('delete')}
-                      </DropdownMenuItem>
-                    </>
-                  )}
-                  {/* 共享的工具只能查看，不能编辑或删除 */}
                   {isShared && (
                     <DropdownMenuItem disabled className="text-muted-foreground">
                       {t('share.sharedFrom', { teamName: tool.owner_team_name || '' })}
+                    </DropdownMenuItem>
+                  )}
+                  {isOwned && canEdit && (
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onEdit?.(tool)
+                      }}
+                    >
+                      <Pencil className="h-4 w-4 mr-2" />
+                      {tCommon('edit')}
+                    </DropdownMenuItem>
+                  )}
+                  {isOwned && canShare && (
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onShare?.(tool)
+                      }}
+                    >
+                      <Share2 className="h-4 w-4 mr-2" />
+                      {t('share.title')}
+                    </DropdownMenuItem>
+                  )}
+                  {isOwned && canDelete && (
+                    <DropdownMenuItem
+                      variant="destructive"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onDelete?.(tool)
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      {tCommon('delete')}
                     </DropdownMenuItem>
                   )}
                 </DropdownMenuContent>

--- a/frontend/app/(platform)/app/capabilities/_components/tool-card.tsx
+++ b/frontend/app/(platform)/app/capabilities/_components/tool-card.tsx
@@ -106,6 +106,7 @@ export function ToolCard({
   onEdit,
   onDelete,
   onConfigure,
+  onShare,
   canConfigure = false,
   canEdit = false,
   canShare = false,

--- a/frontend/app/(platform)/app/capabilities/_components/tool-list.tsx
+++ b/frontend/app/(platform)/app/capabilities/_components/tool-list.tsx
@@ -16,12 +16,27 @@ interface ToolListProps {
   onDelete?: (tool: Tool) => void
   onConfigure?: (tool: Tool) => void
   onShare?: (tool: Tool) => void
-  onExport?: (tool: Tool) => void
+  canConfigure?: (tool: Tool) => boolean
+  canEdit?: (tool: Tool) => boolean
+  canShare?: (tool: Tool) => boolean
+  canDelete?: (tool: Tool) => boolean
 }
 
 type FilterType = 'all' | ToolType
 
-export function ToolList({ tools, onSelect, onTest, onEdit, onDelete, onConfigure, onShare, onExport }: ToolListProps) {
+export function ToolList({
+  tools,
+  onSelect,
+  onTest,
+  onEdit,
+  onDelete,
+  onConfigure,
+  onShare,
+  canConfigure,
+  canEdit,
+  canShare,
+  canDelete,
+}: ToolListProps) {
   const t = useTranslations('platform.tools')
   const [search, setSearch] = useState('')
   const [filter, setFilter] = useState<FilterType>('all')
@@ -128,7 +143,10 @@ export function ToolList({ tools, onSelect, onTest, onEdit, onDelete, onConfigur
                     onDelete={onDelete}
                     onConfigure={onConfigure}
                     onShare={onShare}
-                    onExport={onExport}
+                    canConfigure={canConfigure?.(tool) ?? false}
+                    canEdit={canEdit?.(tool) ?? false}
+                    canShare={canShare?.(tool) ?? false}
+                    canDelete={canDelete?.(tool) ?? false}
                   />
                 ))}
               </div>

--- a/frontend/app/(platform)/app/capabilities/page.tsx
+++ b/frontend/app/(platform)/app/capabilities/page.tsx
@@ -27,8 +27,6 @@ import {
 import {
   toolsApi,
   teamsApi,
-  packagesApi,
-  downloadBlob,
   Tool,
   ToolDetail,
   ToolCreateInput,
@@ -43,7 +41,8 @@ import { HttpToolDialog } from './_components/http-tool-dialog'
 import { McpToolDialog } from './_components/mcp-tool-dialog'
 import { ToolShareDialog } from './_components/tool-share-dialog'
 import { ImportPackageDialog } from '@/components/packages/import-package-dialog'
-import { PermissionGuard, useCanPerform } from '@/components/permission-guard'
+import { useCanPerform } from '@/components/permission-guard'
+import { usePermissions } from '@/hooks/use-permissions'
 
 type CapabilityTab = 'tools' | 'skills'
 
@@ -52,11 +51,19 @@ export default function CapabilitiesPage() {
   const tCommon = useTranslations('common')
   const packagesT = useTranslations('packages')
   const { currentTeam } = useTeam()
+  const { user } = usePermissions()
   const router = useRouter()
   const searchParams = useSearchParams()
   const { canPerform } = useCanPerform()
   const canReadTools = canPerform('tool:read')
   const canReadSkills = canPerform('skill:read')
+  const isTeamAdmin = Boolean(user?.is_superuser || currentTeam?.role === 'owner' || currentTeam?.role === 'admin')
+  const canCreateTool = canPerform('tool:create')
+  const canEditTool = (tool: Tool) =>
+    Boolean(tool.is_owned !== false && (isTeamAdmin || tool.created_by_id === user?.id))
+  const canConfigureTool = () => isTeamAdmin
+  const canShareTool = () => isTeamAdmin
+  const canDeleteTool = () => isTeamAdmin
 
   // 没有团队时重定向到首页
   useRequireTeam()
@@ -343,12 +350,6 @@ export default function CapabilitiesPage() {
     loadTools() // 重新加载工具列表以更新共享计数
   }
 
-  const handleExportTool = async (tool: Tool) => {
-    if (!tool.id) return
-    const { blob, filename } = await packagesApi.export('tool', tool.id)
-    downloadBlob(blob, filename)
-  }
-
   return (
     <div className="py-6 px-8 h-full overflow-y-auto">
       <div className="mb-6">
@@ -385,14 +386,14 @@ export default function CapabilitiesPage() {
                 {t('tools.refresh')}
               </Button>
 
-              <PermissionGuard permission="tool:create">
+              {canCreateTool && (
                 <Button variant="outline" onClick={() => setImportDialogOpen(true)} data-testid="capabilities-import-button">
                   <Upload className="mr-2 h-4 w-4" />
                   {packagesT('import')}
                 </Button>
-              </PermissionGuard>
+              )}
 
-              <PermissionGuard permission="tool:create">
+              {canCreateTool && (
                 <DropdownMenu>
                   <DropdownMenuTrigger
                     render={
@@ -433,7 +434,7 @@ export default function CapabilitiesPage() {
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
-              </PermissionGuard>
+              )}
             </div>
           </div>
 
@@ -449,7 +450,7 @@ export default function CapabilitiesPage() {
                 <CardDescription className="mb-4">
                   {t('tools.createToolHint')}
                 </CardDescription>
-                <PermissionGuard permission="tool:create">
+                {canCreateTool && (
                   <DropdownMenu>
                     <DropdownMenuTrigger
                       render={
@@ -474,7 +475,7 @@ export default function CapabilitiesPage() {
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
-                </PermissionGuard>
+                )}
               </CardContent>
             </Card>
           ) : (
@@ -482,11 +483,14 @@ export default function CapabilitiesPage() {
               tools={tools}
               onSelect={canPerform('tool:execute') ? handleSelectTool : undefined}
               onTest={canPerform('tool:execute') ? handleSelectTool : undefined}
-              onEdit={canPerform('tool:update') ? handleEditTool : undefined}
-              onDelete={canPerform('tool:delete') ? handleDeleteClick : undefined}
-              onConfigure={canPerform('tool:update') ? handleConfigureTool : undefined}
-              onShare={canPerform('tool:update') ? handleShareTool : undefined}
-              onExport={canPerform('tool:read') ? handleExportTool : undefined}
+              onEdit={handleEditTool}
+              onDelete={handleDeleteClick}
+              onConfigure={handleConfigureTool}
+              onShare={handleShareTool}
+              canConfigure={canConfigureTool}
+              canEdit={canEditTool}
+              canShare={canShareTool}
+              canDelete={canDeleteTool}
             />
           )}
         </TabsContent>

--- a/frontend/app/(platform)/app/kb/[id]/page.tsx
+++ b/frontend/app/(platform)/app/kb/[id]/page.tsx
@@ -93,9 +93,9 @@ export default function KnowledgeBaseDetailPage({
     loadKnowledgeBase(false)
   }
   
-  const canUpdateKb = Boolean(
-    knowledgeBase && (user?.is_superuser || currentTeam?.role === 'owner' || currentTeam?.role === 'admin' || knowledgeBase.created_by?.id === user?.id)
-  )
+  const isTeamAdmin = Boolean(user?.is_superuser || currentTeam?.role === 'owner' || currentTeam?.role === 'admin')
+  const isKbOwner = Boolean(user?.id && knowledgeBase?.created_by?.id === user.id)
+  const canUpdateKb = Boolean(knowledgeBase && (isTeamAdmin || isKbOwner))
 
   if (isLoading || !knowledgeBase) {
     return (

--- a/frontend/app/(platform)/app/kb/[id]/page.tsx
+++ b/frontend/app/(platform)/app/kb/[id]/page.tsx
@@ -21,13 +21,13 @@ import {
   ArrowUpDown,
 } from 'lucide-react'
 import { useTeam } from '@/contexts/team-context'
+import { usePermissions } from '@/hooks/use-permissions'
 import { knowledgeBasesApi, type KnowledgeBase, type KnowledgeBaseStats } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { DocumentsTable, UploadDocumentDialog, ImportUrlDialog } from './_components'
 import { KnowledgeBaseDialog } from '../_components/kb-dialog'
-import { PermissionGuard } from '@/components/permission-guard'
 
 export default function KnowledgeBaseDetailPage({
   params,
@@ -38,6 +38,7 @@ export default function KnowledgeBaseDetailPage({
   const t = useTranslations('knowledgeBases')
   const router = useRouter()
   const { currentTeam } = useTeam()
+  const { user } = usePermissions()
   
   // 数据状态
   const [knowledgeBase, setKnowledgeBase] = React.useState<KnowledgeBase | null>(null)
@@ -92,6 +93,10 @@ export default function KnowledgeBaseDetailPage({
     loadKnowledgeBase(false)
   }
   
+  const canUpdateKb = Boolean(
+    knowledgeBase && (user?.is_superuser || currentTeam?.role === 'owner' || currentTeam?.role === 'admin' || knowledgeBase.created_by?.id === user?.id)
+  )
+
   if (isLoading || !knowledgeBase) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -133,19 +138,21 @@ export default function KnowledgeBaseDetailPage({
             <Search className="mr-2 h-4 w-4" />
             {t('searchTest')}
           </Button>
-          <PermissionGuard permission="kb:update">
-            <Button variant="outline" onClick={() => setImportUrlDialogOpen(true)}>
-              <LinkIcon className="mr-2 h-4 w-4" />
-              {t('importUrl')}
-            </Button>
-            <Button onClick={() => setUploadDialogOpen(true)}>
-              <Upload className="mr-2 h-4 w-4" />
-              {t('uploadDocument')}
-            </Button>
-            <Button variant="ghost" size="icon" onClick={() => setSettingsDialogOpen(true)}>
-              <Settings className="h-4 w-4" />
-            </Button>
-          </PermissionGuard>
+          {canUpdateKb && (
+            <>
+              <Button variant="outline" onClick={() => setImportUrlDialogOpen(true)}>
+                <LinkIcon className="mr-2 h-4 w-4" />
+                {t('importUrl')}
+              </Button>
+              <Button onClick={() => setUploadDialogOpen(true)}>
+                <Upload className="mr-2 h-4 w-4" />
+                {t('uploadDocument')}
+              </Button>
+              <Button variant="ghost" size="icon" onClick={() => setSettingsDialogOpen(true)}>
+                <Settings className="h-4 w-4" />
+              </Button>
+            </>
+          )}
         </div>
       </div>
       

--- a/frontend/app/(platform)/app/kb/page.tsx
+++ b/frontend/app/(platform)/app/kb/page.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react'
 import { useTeam } from '@/contexts/team-context'
 import { useRequireTeam } from '@/hooks/use-require-team'
+import { usePermissions } from '@/hooks/use-permissions'
 import { knowledgeBasesApi, type KnowledgeBase } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -63,6 +64,7 @@ export default function KnowledgeBasePage() {
   const packageT = useTranslations('packages')
   const commonT = useTranslations('common')
   const { currentTeam } = useTeam()
+  const { user } = usePermissions()
   const { canPerform } = useCanPerform()
   const searchParams = useSearchParams()
   const router = useRouter()
@@ -157,6 +159,11 @@ export default function KnowledgeBasePage() {
   const handleSuccess = () => {
     fetchKnowledgeBases()
   }
+
+  const isTeamAdmin = user?.is_superuser || currentTeam?.role === 'owner' || currentTeam?.role === 'admin'
+  const canEditKb = (kb: KnowledgeBase) => isTeamAdmin || kb.created_by?.id === user?.id
+  const canExportKb = (kb: KnowledgeBase) => kb.created_by?.id === user?.id
+  const canDeleteKb = () => isTeamAdmin
 
   // 过滤知识库
   const filteredKnowledgeBases = React.useMemo(() => {
@@ -285,7 +292,7 @@ export default function KnowledgeBasePage() {
                   )}
                 />
                 <DropdownMenuContent align="end">
-                  {canPerform('kb:update') && (
+                  {canEditKb(kb) && (
                     <DropdownMenuItem onClick={(e) => { e.preventDefault(); handleEdit(kb) }}>
                       <Pencil className="mr-2 h-4 w-4" />
                       {commonT('edit')}
@@ -297,13 +304,13 @@ export default function KnowledgeBasePage() {
                       {kbT('searchTest')}
                     </DropdownMenuItem>
                   </Link>
-                  {canPerform('kb:read') && (
+                  {canExportKb(kb) && (
                     <DropdownMenuItem onClick={(e) => { e.preventDefault(); handleExport(kb) }}>
                       <Download className="mr-2 h-4 w-4" />
                       {packageT('export')}
                     </DropdownMenuItem>
                   )}
-                  {canPerform('kb:delete') && (
+                  {canDeleteKb() && (
                     <>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem

--- a/frontend/app/(platform)/app/kb/page.tsx
+++ b/frontend/app/(platform)/app/kb/page.tsx
@@ -160,9 +160,10 @@ export default function KnowledgeBasePage() {
     fetchKnowledgeBases()
   }
 
-  const isTeamAdmin = user?.is_superuser || currentTeam?.role === 'owner' || currentTeam?.role === 'admin'
-  const canEditKb = (kb: KnowledgeBase) => isTeamAdmin || kb.created_by?.id === user?.id
-  const canExportKb = (kb: KnowledgeBase) => kb.created_by?.id === user?.id
+  const isTeamAdmin = Boolean(user?.is_superuser || currentTeam?.role === 'owner' || currentTeam?.role === 'admin')
+  const isKbOwner = (kb: KnowledgeBase) => Boolean(user?.id && kb.created_by?.id === user.id)
+  const canEditKb = (kb: KnowledgeBase) => isTeamAdmin || isKbOwner(kb)
+  const canExportKb = (kb: KnowledgeBase) => isTeamAdmin || isKbOwner(kb)
   const canDeleteKb = () => isTeamAdmin
 
   // 过滤知识库

--- a/frontend/app/(platform)/app/page.tsx
+++ b/frontend/app/(platform)/app/page.tsx
@@ -528,12 +528,6 @@ export default function PlatformHomePage() {
                         height={40}
                         wrapperStyle={{ color: 'var(--chart-label)', cursor: 'pointer' }}
                         onClick={(entry) => toggleUsageSeries(entry.dataKey)}
-                        payload={isTeamAdmin ? usageUserKeys.map((userId, index) => ({
-                          value: usageUserNames[userId] || userId,
-                          type: 'circle',
-                          color: CHART_COLORS[index % CHART_COLORS.length],
-                          dataKey: `${userId}:conversations`,
-                        })) : undefined}
                       />
                       {isTeamAdmin ? (
                         usageUserKeys.flatMap((userId, index) => [

--- a/frontend/app/(platform)/app/page.tsx
+++ b/frontend/app/(platform)/app/page.tsx
@@ -289,7 +289,7 @@ export default function PlatformHomePage() {
     },
   } satisfies ChartConfig
   const { currentTeam, isLoading: isTeamLoading } = useTeam()
-  const { user } = usePermissions()
+  const { user, loading: permissionsLoading } = usePermissions()
   const isTeamAdmin = Boolean(user?.is_superuser || currentTeam?.role === 'owner' || currentTeam?.role === 'admin')
   const [stats, setStats] = React.useState<StatsData>({
     knowledgeBases: 0,
@@ -330,7 +330,7 @@ export default function PlatformHomePage() {
 
   // 加载统计数据和最近项目
   const fetchData = React.useCallback(async () => {
-    if (!currentTeam) return
+    if (!currentTeam || permissionsLoading) return
 
     try {
       setIsLoading(true)
@@ -387,7 +387,13 @@ export default function PlatformHomePage() {
       } else {
         setUsageUserKeys([])
         setUsageUserNames({})
-        setUsageTrendData(trendsResponse.data)
+        const trendData = trendsResponse.data.map((item) => ({
+          date: item.date,
+          conversations: item.conversations,
+          messages: item.messages,
+          tokens: item.tokens,
+        }))
+        setUsageTrendData(trendData)
       }
 
       // 合并最近的 agents 和 workflows
@@ -416,7 +422,7 @@ export default function PlatformHomePage() {
     } finally {
       setIsLoading(false)
     }
-  }, [currentTeam, isTeamAdmin])
+  }, [currentTeam, isTeamAdmin, permissionsLoading])
 
   React.useEffect(() => {
     if (currentTeam) {

--- a/frontend/app/(platform)/app/page.tsx
+++ b/frontend/app/(platform)/app/page.tsx
@@ -20,8 +20,9 @@ import {
   Coins,
 } from 'lucide-react'
 import { useTeam } from '@/contexts/team-context'
+import { usePermissions } from '@/hooks/use-permissions'
 import { knowledgeBasesApi, teamModelsApi, agentsApi, workflowsApi, type TeamModel } from '@/lib/api'
-import { conversationsApi } from '@/lib/api/admin/conversations'
+import { conversationsApi } from '@/lib/api/agents'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -39,8 +40,9 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  AreaChart,
+  ComposedChart,
   Area,
+  Line,
   Cell,
   ResponsiveContainer,
   Tooltip,
@@ -287,6 +289,8 @@ export default function PlatformHomePage() {
     },
   } satisfies ChartConfig
   const { currentTeam, isLoading: isTeamLoading } = useTeam()
+  const { user } = usePermissions()
+  const isTeamAdmin = Boolean(user?.is_superuser || currentTeam?.role === 'owner' || currentTeam?.role === 'admin')
   const [stats, setStats] = React.useState<StatsData>({
     knowledgeBases: 0,
     models: 0,
@@ -299,11 +303,30 @@ export default function PlatformHomePage() {
   })
   const [recentItems, setRecentItems] = React.useState<RecentItem[]>([])
   const [isLoading, setIsLoading] = React.useState(true)
-  const [usageTrendData, setUsageTrendData] = React.useState<Array<{
-    date: string
-    conversations: number
-    tokens: number
-  }>>([])
+  const [usageTrendData, setUsageTrendData] = React.useState<Array<Record<string, number | string>>>([])
+  const [usageUserKeys, setUsageUserKeys] = React.useState<string[]>([])
+  const [usageUserNames, setUsageUserNames] = React.useState<Record<string, string>>({})
+  const [hiddenUsageSeries, setHiddenUsageSeries] = React.useState<Set<string>>(new Set())
+
+  const toggleUsageSeries = (dataKey: unknown) => {
+    if (!dataKey) return
+    const key = String(dataKey)
+    const keys = key.endsWith(':conversations')
+      ? [key, key.replace(':conversations', ':tokens')]
+      : [key]
+    setHiddenUsageSeries((current) => {
+      const next = new Set(current)
+      const shouldShow = keys.some((item) => next.has(item))
+      keys.forEach((item) => {
+        if (shouldShow) {
+          next.delete(item)
+        } else {
+          next.add(item)
+        }
+      })
+      return next
+    })
+  }
 
   // 加载统计数据和最近项目
   const fetchData = React.useCallback(async () => {
@@ -312,13 +335,14 @@ export default function PlatformHomePage() {
     try {
       setIsLoading(true)
 
+      const ownOnly = !isTeamAdmin
       // 并行请求
       const [kbResponse, modelsResponse, agentsResponse, workflowsResponse, trendsResponse] = await Promise.all([
-        knowledgeBasesApi.getKnowledgeBases({ pageSize: 1, teamId: currentTeam.id }),
+        knowledgeBasesApi.getKnowledgeBases({ pageSize: 1, teamId: currentTeam.id, ownOnly }),
         teamModelsApi.getTeamModels(currentTeam.id),
-        agentsApi.getAgents({ pageSize: 8, teamId: currentTeam.id }),
-        workflowsApi.getWorkflows({ pageSize: 8, teamId: currentTeam.id }),
-        conversationsApi.getTrends({ team_id: currentTeam.id, period: '7d' }),
+        agentsApi.getAgents({ pageSize: 8, teamId: currentTeam.id, ownOnly }),
+        workflowsApi.getWorkflows({ pageSize: 8, teamId: currentTeam.id, ownOnly }),
+        conversationsApi.getTrends(currentTeam.id, '7d'),
       ])
 
       // 计算总的对话数和消息数
@@ -335,7 +359,7 @@ export default function PlatformHomePage() {
 
       setStats({
         knowledgeBases: kbResponse.total,
-        models: modelsResponse.filter((m: TeamModel) => m.is_enabled).length,
+        models: ownOnly ? 0 : modelsResponse.filter((m: TeamModel) => m.is_enabled).length,
         agents: agentsResponse.total,
         workflows: workflowsResponse.total,
         totalConversations,
@@ -344,8 +368,27 @@ export default function PlatformHomePage() {
         successRate,
       })
 
-      // 设置趋势数据
-      setUsageTrendData(trendsResponse.data)
+      if (isTeamAdmin) {
+        const userNames: Record<string, string> = {}
+        const userKeys = new Set<string>()
+        const trendData = trendsResponse.data.map((item) => {
+          const row: Record<string, number | string> = { date: item.date }
+          Object.entries(item.users || {}).forEach(([userId, usage]) => {
+            userNames[userId] = usage.name
+            userKeys.add(userId)
+            row[`${userId}:conversations`] = usage.conversations
+            row[`${userId}:tokens`] = usage.tokens
+          })
+          return row
+        })
+        setUsageUserKeys(Array.from(userKeys).slice(0, 6))
+        setUsageUserNames(userNames)
+        setUsageTrendData(trendData)
+      } else {
+        setUsageUserKeys([])
+        setUsageUserNames({})
+        setUsageTrendData(trendsResponse.data)
+      }
 
       // 合并最近的 agents 和 workflows
       const recent: RecentItem[] = [
@@ -373,7 +416,7 @@ export default function PlatformHomePage() {
     } finally {
       setIsLoading(false)
     }
-  }, [currentTeam])
+  }, [currentTeam, isTeamAdmin])
 
   React.useEffect(() => {
     if (currentTeam) {
@@ -458,17 +501,7 @@ export default function PlatformHomePage() {
               ) : (
                 <ChartContainer config={usageTrendChartConfig} className="h-[220px] w-full aspect-auto">
                   <ResponsiveContainer width="100%" height="100%">
-                    <AreaChart data={usageTrendData} margin={{ left: 12, right: 12 }}>
-                      <defs>
-                        <linearGradient id="platformUsageConversations" x1="0" y1="0" x2="0" y2="1">
-                          <stop offset="5%" stopColor={CHART_COLORS[2]} stopOpacity={0.3} />
-                          <stop offset="95%" stopColor={CHART_COLORS[2]} stopOpacity={0} />
-                        </linearGradient>
-                        <linearGradient id="platformUsageTokens" x1="0" y1="0" x2="0" y2="1">
-                          <stop offset="5%" stopColor={CHART_COLORS[4]} stopOpacity={0.3} />
-                          <stop offset="95%" stopColor={CHART_COLORS[4]} stopOpacity={0} />
-                        </linearGradient>
-                      </defs>
+                    <ComposedChart data={usageTrendData} margin={{ left: 12, right: 12 }}>
                       <CartesianGrid stroke={CHART_GRID_COLOR} strokeDasharray="3 3" />
                       <XAxis
                         dataKey="date"
@@ -479,27 +512,74 @@ export default function PlatformHomePage() {
                       />
                       <YAxis yAxisId="left" className="text-xs" tick={{ fill: CHART_AXIS_COLOR }} hide />
                       <YAxis yAxisId="right" orientation="right" className="text-xs" tick={{ fill: CHART_AXIS_COLOR }} hide />
-                      <Tooltip cursor={CHART_HOVER_CURSOR} content={<UsageTrendTooltip />} />
-                      <Legend wrapperStyle={{ color: 'var(--chart-label)' }} />
-                      <Area
-                        yAxisId="left"
-                        type="monotone"
-                        dataKey="conversations"
-                        stroke={CHART_COLORS[2]}
-                        fillOpacity={1}
-                        fill="url(#platformUsageConversations)"
-                        name={t('stats.conversations')}
+                      <Tooltip
+                        cursor={CHART_HOVER_CURSOR}
+                        content={<UsageTrendTooltip />}
+                        wrapperStyle={{ zIndex: 50, pointerEvents: 'none' }}
                       />
-                      <Area
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="tokens"
-                        stroke={CHART_COLORS[4]}
-                        fillOpacity={1}
-                        fill="url(#platformUsageTokens)"
-                        name={t('stats.tokens')}
+                      <Legend
+                        verticalAlign="bottom"
+                        height={40}
+                        wrapperStyle={{ color: 'var(--chart-label)', cursor: 'pointer' }}
+                        onClick={(entry) => toggleUsageSeries(entry.dataKey)}
+                        payload={isTeamAdmin ? usageUserKeys.map((userId, index) => ({
+                          value: usageUserNames[userId] || userId,
+                          type: 'circle',
+                          color: CHART_COLORS[index % CHART_COLORS.length],
+                          dataKey: `${userId}:conversations`,
+                        })) : undefined}
                       />
-                    </AreaChart>
+                      {isTeamAdmin ? (
+                        usageUserKeys.flatMap((userId, index) => [
+                          <Area
+                            key={`${userId}:conversations`}
+                            yAxisId="left"
+                            type="monotone"
+                            stackId="conversations"
+                            dataKey={`${userId}:conversations`}
+                            stroke={CHART_COLORS[index % CHART_COLORS.length]}
+                            fill={CHART_COLORS[index % CHART_COLORS.length]}
+                            fillOpacity={0.18}
+                            name={`${usageUserNames[userId] || userId} · ${t('stats.conversations')}`}
+                            hide={hiddenUsageSeries.has(`${userId}:conversations`)}
+                          />,
+                          <Line
+                            key={`${userId}:tokens`}
+                            yAxisId="right"
+                            type="monotone"
+                            dataKey={`${userId}:tokens`}
+                            stroke={CHART_COLORS[index % CHART_COLORS.length]}
+                            strokeDasharray="4 3"
+                            dot={false}
+                            legendType="none"
+                            name={`${usageUserNames[userId] || userId} · ${t('stats.tokens')}`}
+                            hide={hiddenUsageSeries.has(`${userId}:tokens`)}
+                          />,
+                        ])
+                      ) : (
+                        <>
+                          <Area
+                            yAxisId="left"
+                            type="monotone"
+                            dataKey="conversations"
+                            stroke={CHART_COLORS[2]}
+                            fill={CHART_COLORS[2]}
+                            fillOpacity={0.18}
+                            name={t('stats.conversations')}
+                            hide={hiddenUsageSeries.has('conversations')}
+                          />
+                          <Line
+                            yAxisId="right"
+                            type="monotone"
+                            dataKey="tokens"
+                            stroke={CHART_COLORS[4]}
+                            dot={false}
+                            name={t('stats.tokens')}
+                            hide={hiddenUsageSeries.has('tokens')}
+                          />
+                        </>
+                      )}
+                    </ComposedChart>
                   </ResponsiveContainer>
                 </ChartContainer>
               )}

--- a/frontend/app/(platform)/app/page.tsx
+++ b/frontend/app/(platform)/app/page.tsx
@@ -359,7 +359,7 @@ export default function PlatformHomePage() {
 
       setStats({
         knowledgeBases: kbResponse.total,
-        models: ownOnly ? 0 : modelsResponse.filter((m: TeamModel) => m.is_enabled).length,
+        models: modelsResponse.filter((m: TeamModel) => m.is_enabled).length,
         agents: agentsResponse.total,
         workflows: workflowsResponse.total,
         totalConversations,

--- a/frontend/i18n/en/platform.json
+++ b/frontend/i18n/en/platform.json
@@ -114,7 +114,7 @@
       "resourceComposition": "Resource Composition",
       "resourceCompositionDesc": "Breakdown of resource types",
       "usageTrend": "Usage Trend",
-      "usageTrendDesc": "7-day conversation and token usage trend",
+      "usageTrendDesc": "Members see their own usage. Team admins see per-user conversations and token usage.",
       "resourceOverview": "Resource Overview",
       "resourceOverviewDesc": "Current resource allocation",
       "features": {

--- a/frontend/i18n/zh/platform.json
+++ b/frontend/i18n/zh/platform.json
@@ -114,7 +114,7 @@
       "resourceComposition": "资源组成",
       "resourceCompositionDesc": "资源类型的详细分布",
       "usageTrend": "使用趋势",
-      "usageTrendDesc": "近 7 天对话和 Token 使用趋势",
+      "usageTrendDesc": "成员查看自己的使用情况，团队管理员查看按用户统计的对话和 Token 消耗。",
       "resourceOverview": "资源概览",
       "resourceOverviewDesc": "当前资源分配情况",
       "features": {

--- a/frontend/lib/api/agents.ts
+++ b/frontend/lib/api/agents.ts
@@ -316,6 +316,7 @@ export interface AgentQueryParams {
   status?: AgentStatus
   visibility?: AgentVisibility
   teamId?: string
+  ownOnly?: boolean
 }
 
 // ============ Conversation Types ============
@@ -678,7 +679,7 @@ export const agentsApi = {
    * 获取 Agent 列表
    */
   getAgents: async (params: AgentQueryParams = {}): Promise<PageData<AgentListItem>> => {
-    const { page = 1, pageSize = 20, search, status, visibility, teamId } = params
+    const { page = 1, pageSize = 20, search, status, visibility, teamId, ownOnly } = params
     const queryParams = new URLSearchParams()
     queryParams.append('page', String(page))
     queryParams.append('page_size', String(pageSize))
@@ -686,6 +687,7 @@ export const agentsApi = {
     if (status) queryParams.append('status', status)
     if (visibility) queryParams.append('visibility', visibility)
     if (teamId) queryParams.append('team_id', teamId)
+    if (ownOnly) queryParams.append('own_only', 'true')
     return api.get<PageData<AgentListItem>>(`/agents?${queryParams.toString()}`)
   },
 
@@ -1137,6 +1139,11 @@ export interface ConversationTrends {
     conversations: number
     messages: number
     tokens: number
+    users?: Record<string, {
+      name: string
+      conversations: number
+      tokens: number
+    }>
   }>
 }
 

--- a/frontend/lib/api/knowledge-bases.ts
+++ b/frontend/lib/api/knowledge-bases.ts
@@ -101,6 +101,7 @@ export interface KnowledgeBaseQueryParams {
   search?: string
   status?: string[]
   teamId?: string
+  ownOnly?: boolean
 }
 
 // ============ Document Types ============
@@ -225,13 +226,14 @@ function createKnowledgeBasesApi(prefix: '/knowledge-bases' | '/admin/knowledge-
      * 获取知识库列表
      */
   getKnowledgeBases: async (params: KnowledgeBaseQueryParams = {}): Promise<PageData<KnowledgeBase>> => {
-    const { page = 1, pageSize = 20, search, status, teamId } = params
+    const { page = 1, pageSize = 20, search, status, teamId, ownOnly } = params
     const queryParams = new URLSearchParams()
     queryParams.append('page', String(page))
     queryParams.append('page_size', String(pageSize))
     if (search) queryParams.append('search', search)
     status?.forEach((value) => queryParams.append('status', value))
     if (teamId) queryParams.append('team_id', teamId)
+    if (ownOnly) queryParams.append('own_only', 'true')
     return api.get<PageData<KnowledgeBase>>(`${prefix}?${queryParams.toString()}`)
   },
 

--- a/frontend/lib/api/tools.ts
+++ b/frontend/lib/api/tools.ts
@@ -122,6 +122,7 @@ export interface Tool {
   code_config?: CodeConfig
   mcp_config?: McpConfig
   team_id?: string
+  created_by_id?: string | null
   created_by_name?: string
   // 工具共享相关字段
   is_owned?: boolean

--- a/frontend/lib/api/workflows.ts
+++ b/frontend/lib/api/workflows.ts
@@ -43,6 +43,8 @@ export interface WorkflowListItem {
   run_count: number
   success_count: number
   fail_count: number
+  created_by_id?: string | null
+  created_by_name?: string | null
   created_at: string
   updated_at: string
 }
@@ -241,6 +243,7 @@ export interface WorkflowQueryParams {
   visibility?: WorkflowVisibility
   triggerType?: TriggerType
   keyword?: string
+  ownOnly?: boolean
 }
 
 export interface WorkflowRunQueryParams {
@@ -289,7 +292,7 @@ export const workflowsApi = {
    * 获取工作流列表
    */
   getWorkflows: async (params: WorkflowQueryParams = {}): Promise<PageData<WorkflowListItem>> => {
-    const { page = 1, pageSize = 20, teamId, status, visibility, triggerType, keyword } = params
+    const { page = 1, pageSize = 20, teamId, status, visibility, triggerType, keyword, ownOnly } = params
     const queryParams = new URLSearchParams()
     queryParams.append('page', String(page))
     queryParams.append('page_size', String(pageSize))
@@ -298,6 +301,7 @@ export const workflowsApi = {
     if (visibility) queryParams.append('visibility', visibility)
     if (triggerType) queryParams.append('trigger_type', triggerType)
     if (keyword) queryParams.append('keyword', keyword)
+    if (ownOnly) queryParams.append('own_only', 'true')
     return api.get<PageData<WorkflowListItem>>(`/workflows?${queryParams.toString()}`)
   },
 


### PR DESCRIPTION
## Summary
- add scoped RBAC/team access helpers and migrate core permission checks
- restrict member edits/actions to owned resources while preserving team admin controls
- scope workbench home data by team role and show per-user admin usage trends
- update permission docs and scoped RBAC landing plan

## Validation
- git diff --check
- bun run lint (passes with existing coverage/block-navigation.js warning)
- cd backend && uv run ruff check <changed backend files>
- cd backend && uv run ruff format --check <changed backend files>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rolled out scoped RBAC enforcement for team-scoped operations (including agents, workflows, tools, API keys, knowledge bases, teams, and conversations).
  * Added **own-only** filtering to relevant lists and surfaced **created-by** details (including names) across supported cards.
  * Enhanced admin conversation trends with optional **per-user** usage breakdown; updated UI action availability using capability flags.

* **Bug Fixes**
  * Corrected admin dashboard access permission handling and tightened authorization for sensitive admin actions.
  * Enforced API key ownership and knowledge base export permission checks.

* **Documentation**
  * Updated RBAC/permissions docs, implementation plan, and added an access-control audit report.

* **Tests**
  * Added scoped RBAC authorization coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->