### PR TITLE
fix: skip onboarding tour without team

### DIFF
--- a/frontend/components/onboarding/onboarding-tour.tsx
+++ b/frontend/components/onboarding/onboarding-tour.tsx
@@ -12,6 +12,7 @@ import {
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
+import { useTeam } from '@/contexts/team-context'
 import { useOnboarding, type OnboardingTourId } from './onboarding-provider'
 import { getTourConfigById, allTourConfigs } from './steps/platform-steps'
 import type { OnboardingStep } from './steps/types'
@@ -89,6 +90,7 @@ export function OnboardingTour({ tourId }: OnboardingTourProps) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const pathnameRef = React.useRef(pathname)
+  const { currentTeam, isLoading: isTeamLoading } = useTeam()
   const { state, startTour, nextStep, goToStep, completeTour } = useOnboarding()
   const controlsRef = React.useRef<Controls | null>(null)
   const hasAutoStarted = React.useRef(false)
@@ -110,6 +112,8 @@ export function OnboardingTour({ tourId }: OnboardingTourProps) {
       !state.isRunning &&
       !state.completedTours.includes('overview') &&
       pathname === '/app' &&
+      !isTeamLoading &&
+      currentTeam &&
       !hasAutoStarted.current
     ) {
       hasAutoStarted.current = true
@@ -119,7 +123,7 @@ export function OnboardingTour({ tourId }: OnboardingTourProps) {
       }, 500)
       return () => clearTimeout(timer)
     }
-  }, [tourId, config, state.isRunning, state.completedTours, pathname, startTour])
+  }, [tourId, config, state.isRunning, state.completedTours, pathname, isTeamLoading, currentTeam, startTour])
 
   // Get all steps (no filtering by route)
   const steps = React.useMemo(() => {


### PR DESCRIPTION
## Summary
- prevent the overview onboarding tour from auto-starting while teams are loading
- require a selected team before auto-starting the platform homepage tour

## Validation
- bun run --cwd frontend lint

Fixes #291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the onboarding tour’s auto-start behavior so it waits for team information to load before appearing.
  * Reduced cases where the tour could fail to start correctly when team context was still initializing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->