### PR TITLE
fix: assign default team to SSO users

### DIFF
--- a/backend/app/services/sso.py
+++ b/backend/app/services/sso.py
@@ -86,6 +86,10 @@ class SSOService:
 
         if existing_user:
             # Link existing user to SSO provider
+            from app.services.team_role_sync import assign_default_team
+
+            await assign_default_team(existing_user)
+
             await UserSSOConnection.create(
                 user=existing_user,
                 provider=provider,
@@ -94,10 +98,6 @@ class SSOService:
                 provider_email=email,
                 provider_data=user_info,
             )
-
-            from app.services.team_role_sync import assign_default_team
-
-            await assign_default_team(existing_user)
             return existing_user, False
 
         # Create new user

--- a/backend/app/services/sso.py
+++ b/backend/app/services/sso.py
@@ -94,6 +94,10 @@ class SSOService:
                 provider_email=email,
                 provider_data=user_info,
             )
+
+            from app.services.team_role_sync import assign_default_team
+
+            await assign_default_team(existing_user)
             return existing_user, False
 
         # Create new user
@@ -153,6 +157,10 @@ class SSOService:
             from app.services.team_role_sync import assign_default_role
 
             await assign_default_role(new_user)
+
+        from app.services.team_role_sync import assign_default_team
+
+        await assign_default_team(new_user)
 
         # Create SSO connection
         await UserSSOConnection.create(

--- a/backend/tests/services/test_sso_service.py
+++ b/backend/tests/services/test_sso_service.py
@@ -36,7 +36,9 @@ async def test_find_or_create_user_assigns_default_team_to_email_matched_user(
 
     monkeypatch.setattr(sso_service.SiteSetting, "get_value", get_value)
     monkeypatch.setattr(sso_service.User, "filter", UserModel.filter)
-    monkeypatch.setattr(sso_service.UserSSOConnection, "filter", lambda **_kwargs: _ConnectionQuery())
+    monkeypatch.setattr(
+        sso_service.UserSSOConnection, "filter", lambda **_kwargs: _ConnectionQuery()
+    )
     monkeypatch.setattr(sso_service.UserSSOConnection, "create", AsyncMock())
     monkeypatch.setattr(team_role_sync, "assign_default_team", assign_default_team)
 
@@ -68,7 +70,9 @@ async def test_find_or_create_user_assigns_default_team_to_new_user(
         return values.get(key, default)
 
     class UserQuery:
-        def __init__(self, first_value: object = None, exists_value: bool = False) -> None:
+        def __init__(
+            self, first_value: object = None, exists_value: bool = False
+        ) -> None:
             self.first_value = first_value
             self.exists_value = exists_value
 
@@ -90,7 +94,9 @@ async def test_find_or_create_user_assigns_default_team_to_new_user(
     monkeypatch.setattr(sso_service.SiteSetting, "get_value", get_value)
     monkeypatch.setattr(sso_service.User, "filter", UserModel.filter)
     monkeypatch.setattr(sso_service.User, "create", UserModel.create)
-    monkeypatch.setattr(sso_service.UserSSOConnection, "filter", lambda **_kwargs: _ConnectionQuery())
+    monkeypatch.setattr(
+        sso_service.UserSSOConnection, "filter", lambda **_kwargs: _ConnectionQuery()
+    )
     monkeypatch.setattr(sso_service.UserSSOConnection, "create", AsyncMock())
     monkeypatch.setattr(team_role_sync, "assign_default_role", AsyncMock())
     monkeypatch.setattr(team_role_sync, "assign_default_team", assign_default_team)

--- a/backend/tests/services/test_sso_service.py
+++ b/backend/tests/services/test_sso_service.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services import sso as sso_service
+from app.services import team_role_sync
+
+
+class _ConnectionQuery:
+    def prefetch_related(self, *_args: object) -> "_ConnectionQuery":
+        return self
+
+    async def first(self) -> object:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_user_assigns_default_team_to_email_matched_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_user = SimpleNamespace(id="user-id", email="alice@example.com")
+    assign_default_team = AsyncMock(return_value=True)
+
+    async def get_value(key: str, default: object = None) -> object:
+        return True if key == "sso_match_by_email" else default
+
+    class UserQuery:
+        async def first(self) -> object:
+            return existing_user
+
+    class UserModel:
+        @staticmethod
+        def filter(**_kwargs: object) -> UserQuery:
+            return UserQuery()
+
+    monkeypatch.setattr(sso_service.SiteSetting, "get_value", get_value)
+    monkeypatch.setattr(sso_service.User, "filter", UserModel.filter)
+    monkeypatch.setattr(sso_service.UserSSOConnection, "filter", lambda **_kwargs: _ConnectionQuery())
+    monkeypatch.setattr(sso_service.UserSSOConnection, "create", AsyncMock())
+    monkeypatch.setattr(team_role_sync, "assign_default_team", assign_default_team)
+
+    user, is_new = await sso_service.SSOService.find_or_create_user(
+        provider=SimpleNamespace(name="oidc"),
+        provider_user_id="provider-user-id",
+        user_info={"email": "alice@example.com", "username": "alice"},
+    )
+
+    assert user is existing_user
+    assert is_new is False
+    assign_default_team.assert_awaited_once_with(existing_user)
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_user_assigns_default_team_to_new_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    new_user = SimpleNamespace(id="user-id", roles=SimpleNamespace(add=AsyncMock()))
+    assign_default_team = AsyncMock(return_value=True)
+
+    async def get_value(key: str, default: object = None) -> object:
+        values = {
+            "sso_match_by_email": True,
+            "sso_auto_create_users": True,
+            "sso_require_approval": False,
+            "default_language": "en",
+        }
+        return values.get(key, default)
+
+    class UserQuery:
+        def __init__(self, first_value: object = None, exists_value: bool = False) -> None:
+            self.first_value = first_value
+            self.exists_value = exists_value
+
+        async def first(self) -> object:
+            return self.first_value
+
+        async def exists(self) -> bool:
+            return self.exists_value
+
+    class UserModel:
+        @staticmethod
+        def filter(**_kwargs: object) -> UserQuery:
+            return UserQuery()
+
+        @staticmethod
+        async def create(**_kwargs: object) -> object:
+            return new_user
+
+    monkeypatch.setattr(sso_service.SiteSetting, "get_value", get_value)
+    monkeypatch.setattr(sso_service.User, "filter", UserModel.filter)
+    monkeypatch.setattr(sso_service.User, "create", UserModel.create)
+    monkeypatch.setattr(sso_service.UserSSOConnection, "filter", lambda **_kwargs: _ConnectionQuery())
+    monkeypatch.setattr(sso_service.UserSSOConnection, "create", AsyncMock())
+    monkeypatch.setattr(team_role_sync, "assign_default_role", AsyncMock())
+    monkeypatch.setattr(team_role_sync, "assign_default_team", assign_default_team)
+
+    user, is_new = await sso_service.SSOService.find_or_create_user(
+        provider=SimpleNamespace(
+            name="oidc",
+            allow_signup=True,
+            require_approval=False,
+            default_role_id=None,
+        ),
+        provider_user_id="provider-user-id",
+        user_info={"email": "alice@example.com", "username": "alice"},
+    )
+
+    assert user is new_user
+    assert is_new is True
+    assign_default_team.assert_awaited_once_with(new_user)

--- a/backend/tests/services/test_sso_service.py
+++ b/backend/tests/services/test_sso_service.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
@@ -20,7 +20,11 @@ async def test_find_or_create_user_assigns_default_team_to_email_matched_user(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     existing_user = SimpleNamespace(id="user-id", email="alice@example.com")
+    manager = Mock()
     assign_default_team = AsyncMock(return_value=True)
+    create_connection = AsyncMock()
+    manager.attach_mock(assign_default_team, "assign_default_team")
+    manager.attach_mock(create_connection, "create_connection")
 
     async def get_value(key: str, default: object = None) -> object:
         return True if key == "sso_match_by_email" else default
@@ -39,18 +43,29 @@ async def test_find_or_create_user_assigns_default_team_to_email_matched_user(
     monkeypatch.setattr(
         sso_service.UserSSOConnection, "filter", lambda **_kwargs: _ConnectionQuery()
     )
-    monkeypatch.setattr(sso_service.UserSSOConnection, "create", AsyncMock())
+    monkeypatch.setattr(sso_service.UserSSOConnection, "create", create_connection)
     monkeypatch.setattr(team_role_sync, "assign_default_team", assign_default_team)
 
+    provider = SimpleNamespace(name="oidc")
     user, is_new = await sso_service.SSOService.find_or_create_user(
-        provider=SimpleNamespace(name="oidc"),
+        provider=provider,
         provider_user_id="provider-user-id",
         user_info={"email": "alice@example.com", "username": "alice"},
     )
 
     assert user is existing_user
     assert is_new is False
-    assign_default_team.assert_awaited_once_with(existing_user)
+    assert manager.mock_calls == [
+        call.assign_default_team(existing_user),
+        call.create_connection(
+            user=existing_user,
+            provider=provider,
+            provider_user_id="provider-user-id",
+            provider_username="alice",
+            provider_email="alice@example.com",
+            provider_data={"email": "alice@example.com", "username": "alice"},
+        ),
+    ]
 
 
 @pytest.mark.asyncio
@@ -58,7 +73,11 @@ async def test_find_or_create_user_assigns_default_team_to_new_user(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     new_user = SimpleNamespace(id="user-id", roles=SimpleNamespace(add=AsyncMock()))
+    manager = Mock()
     assign_default_team = AsyncMock(return_value=True)
+    create_connection = AsyncMock()
+    manager.attach_mock(assign_default_team, "assign_default_team")
+    manager.attach_mock(create_connection, "create_connection")
 
     async def get_value(key: str, default: object = None) -> object:
         values = {
@@ -97,21 +116,32 @@ async def test_find_or_create_user_assigns_default_team_to_new_user(
     monkeypatch.setattr(
         sso_service.UserSSOConnection, "filter", lambda **_kwargs: _ConnectionQuery()
     )
-    monkeypatch.setattr(sso_service.UserSSOConnection, "create", AsyncMock())
+    monkeypatch.setattr(sso_service.UserSSOConnection, "create", create_connection)
     monkeypatch.setattr(team_role_sync, "assign_default_role", AsyncMock())
     monkeypatch.setattr(team_role_sync, "assign_default_team", assign_default_team)
 
+    provider = SimpleNamespace(
+        name="oidc",
+        allow_signup=True,
+        require_approval=False,
+        default_role_id=None,
+    )
     user, is_new = await sso_service.SSOService.find_or_create_user(
-        provider=SimpleNamespace(
-            name="oidc",
-            allow_signup=True,
-            require_approval=False,
-            default_role_id=None,
-        ),
+        provider=provider,
         provider_user_id="provider-user-id",
         user_info={"email": "alice@example.com", "username": "alice"},
     )
 
     assert user is new_user
     assert is_new is True
-    assign_default_team.assert_awaited_once_with(new_user)
+    assert manager.mock_calls == [
+        call.assign_default_team(new_user),
+        call.create_connection(
+            user=new_user,
+            provider=provider,
+            provider_user_id="provider-user-id",
+            provider_username="alice",
+            provider_email="alice@example.com",
+            provider_data={"email": "alice@example.com", "username": "alice"},
+        ),
+    ]

--- a/backend/tests/services/test_team_role_sync.py
+++ b/backend/tests/services/test_team_role_sync.py
@@ -40,6 +40,7 @@ async def test_assign_default_team_creates_membership(monkeypatch):
 
     monkeypatch.setattr(team_role_sync.SiteSetting, "get_value", get_value)
     monkeypatch.setattr(team_role_sync.Team, "filter", lambda **kwargs: TeamQuery())
+    monkeypatch.setattr(team_role_sync, "sync_scoped_role_assignment", AsyncMock())
     monkeypatch.setattr(
         team_role_sync.TeamMember,
         "get_or_create",
@@ -75,6 +76,7 @@ async def test_assign_default_team_falls_back_invalid_role(monkeypatch):
 
     monkeypatch.setattr(team_role_sync.SiteSetting, "get_value", get_value)
     monkeypatch.setattr(team_role_sync.Team, "filter", lambda **kwargs: TeamQuery())
+    monkeypatch.setattr(team_role_sync, "sync_scoped_role_assignment", AsyncMock())
     monkeypatch.setattr(
         team_role_sync.TeamMember,
         "get_or_create",

--- a/backend/tests/services/test_team_role_sync.py
+++ b/backend/tests/services/test_team_role_sync.py
@@ -38,13 +38,18 @@ async def test_assign_default_team_creates_membership(monkeypatch):
         async def first(self):
             return team
 
+    membership = SimpleNamespace(role="viewer")
+    sync_scoped_role_assignment = AsyncMock()
+
     monkeypatch.setattr(team_role_sync.SiteSetting, "get_value", get_value)
     monkeypatch.setattr(team_role_sync.Team, "filter", lambda **kwargs: TeamQuery())
-    monkeypatch.setattr(team_role_sync, "sync_scoped_role_assignment", AsyncMock())
+    monkeypatch.setattr(
+        team_role_sync, "sync_scoped_role_assignment", sync_scoped_role_assignment
+    )
     monkeypatch.setattr(
         team_role_sync.TeamMember,
         "get_or_create",
-        AsyncMock(return_value=(SimpleNamespace(role="viewer"), True)),
+        AsyncMock(return_value=(membership, True)),
     )
 
     assigned = await team_role_sync.assign_default_team(user)
@@ -55,6 +60,7 @@ async def test_assign_default_team_creates_membership(monkeypatch):
         user=user,
         defaults={"role": "viewer"},
     )
+    sync_scoped_role_assignment.assert_awaited_once_with(membership)
 
 
 @pytest.mark.asyncio
@@ -74,13 +80,18 @@ async def test_assign_default_team_falls_back_invalid_role(monkeypatch):
         async def first(self):
             return team
 
+    membership = SimpleNamespace(role="member")
+    sync_scoped_role_assignment = AsyncMock()
+
     monkeypatch.setattr(team_role_sync.SiteSetting, "get_value", get_value)
     monkeypatch.setattr(team_role_sync.Team, "filter", lambda **kwargs: TeamQuery())
-    monkeypatch.setattr(team_role_sync, "sync_scoped_role_assignment", AsyncMock())
+    monkeypatch.setattr(
+        team_role_sync, "sync_scoped_role_assignment", sync_scoped_role_assignment
+    )
     monkeypatch.setattr(
         team_role_sync.TeamMember,
         "get_or_create",
-        AsyncMock(return_value=(SimpleNamespace(role="member"), True)),
+        AsyncMock(return_value=(membership, True)),
     )
 
     assigned = await team_role_sync.assign_default_team(user)
@@ -91,6 +102,7 @@ async def test_assign_default_team_falls_back_invalid_role(monkeypatch):
         user=user,
         defaults={"role": "member"},
     )
+    sync_scoped_role_assignment.assert_awaited_once_with(membership)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- assign configured default team when SSO creates a new user
- assign configured default team when an existing email-matched user links SSO for the first time
- add focused SSO provisioning regression tests

Fixes #290

## Tests
- cd backend && PYTHONPATH=. uv run pytest tests/services/test_sso_service.py tests/services/test_team_role_sync.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SSO sign-ins now consistently assign users to their default team for both existing accounts and newly provisioned users.
  * Default team membership setup is applied more reliably during initial SSO user provisioning and subsequent SSO connections.

* **Tests**
  * Added async coverage for default team assignment in SSO flows (email-matched existing user vs new user creation).
  * Updated team-role sync tests to assert scoped role assignment is invoked as part of default team setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->