### PR TITLE
fix(admin): 修复团队卡片中用户名过长导致日期换行的问题

### DIFF
--- a/frontend/app/(dashboard)/teams/_components/teams-client.tsx
+++ b/frontend/app/(dashboard)/teams/_components/teams-client.tsx
@@ -379,13 +379,13 @@ export function TeamsClient() {
               
               {/* 卡片底部信息 */}
               <div className="mt-4 pt-4 border-t flex items-center justify-between text-sm text-muted-foreground">
-                <div className="flex items-center gap-1.5">
-                  <Crown className="h-4 w-4 text-yellow-500" />
+                <div className="flex items-center gap-1.5 min-w-0">
+                  <Crown className="h-4 w-4 text-yellow-500 shrink-0" />
                   <span className="truncate max-w-[100px]">{team.owner?.username || '-'}</span>
                 </div>
-                <div className="flex items-center gap-1.5">
-                  <Calendar className="h-4 w-4" />
-                  <span>{formatDateTime(team.created_at)}</span>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <Calendar className="h-4 w-4 shrink-0" />
+                  <span className="whitespace-nowrap">{formatDateTime(team.created_at)}</span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## 问题

YUN-119 — 后台团队管理页面，当团队所有者用户名过长时，卡片底部的日期会换行，破坏整体布局。

## 根因

卡片底部使用 `flex justify-between` 布局，左侧（皇冠图标 + 用户名）未设置 `min-w-0`，导致 flex 无法将其收缩至内容尺寸以下；右侧（日历图标 + 日期）未设置 `shrink-0`，被挤压换行。

## 修复

`teams-client.tsx` 卡片底部 4 处 CSS class 调整：

| 元素 | 新增 class | 作用 |
|---|---|---|
| 左侧 `<div>` | `min-w-0` | 允许 flex 收缩以触发截断 |
| 皇冠图标 | `shrink-0` | 防止图标被挤压 |
| 右侧 `<div>` | `shrink-0` | 防止日期区域换行 |
| 日期 `<span>` | `whitespace-nowrap` | 日期文字永不换行 |

## 验证

- TypeScript 编译通过
- 5/5 bun 测试通过