### PR TITLE
fix(YUN-120): prevent PublicThemeApplicator from overwriting user theme preference

### DIFF
--- a/frontend/contexts/site-settings-context.tsx
+++ b/frontend/contexts/site-settings-context.tsx
@@ -108,8 +108,13 @@ function PublicThemeApplicator({ settings }: { settings: PublicSiteSettings }) {
     theme_chart_5_color,
   } = settings
 
+  // Only force the theme when the site admin explicitly sets a fixed mode (light/dark).
+  // When theme_mode is 'system', don't call setTheme at all — let next-themes manage
+  // the user's own preference from localStorage.
   React.useEffect(() => {
-    setTheme(shouldApplySiteThemeMode(theme_mode) ? theme_mode : 'system')
+    if (shouldApplySiteThemeMode(theme_mode)) {
+      setTheme(theme_mode)
+    }
   }, [theme_mode, setTheme])
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes YUN-120: Light and dark themes cannot be switched properly.

## Root Cause

`PublicThemeApplicator` in `frontend/contexts/site-settings-context.tsx` unconditionally called `setTheme("system")` on every page mount when the site `theme_mode` was `"system"`. This overwrote `next-themes` localStorage-saved user preference, resetting any theme choice (light/dark) to OS-default on every page load or refresh.

## Fix

Only call `setTheme` when the admin explicitly forces `"light"` or `"dark"` mode. When `theme_mode` is `"system"`, let `next-themes` preserve the user's own localStorage preference.

| `theme_mode` | Before (broken) | After (fixed) |
|---|---|---|
| `"system"` | Forces system on every mount, erases user choice | No-op — `next-themes` preserves localStorage |
| `"light"` / `"dark"` | Forces that theme | Forces that theme (unchanged) |

## Verification

- All 8 existing tests pass
- Frontend builds without errors