### PR TITLE
fix: fetch all unread notification pages when unread_only filter is active

### DIFF
--- a/frontend/app/(platform)/app/notifications/_components/notifications-client.tsx
+++ b/frontend/app/(platform)/app/notifications/_components/notifications-client.tsx
@@ -127,20 +127,37 @@ export function NotificationsClient({ onReadUpdated }: NotificationsClientProps)
   const fetchList = React.useCallback(async () => {
     try {
       setIsLoading(true)
+      const unreadOnly = readFilter.has('unread')
       const scope = Array.from(scopeFilter)[0] as NotificationScope | undefined
       const level = Array.from(levelFilter)[0] as NotificationLevel | undefined
-      const listParams = {
-        page,
+      const baseParams = {
         page_size: pageSize,
         scope: scope || undefined,
         level: level || undefined,
         search: debouncedSearchQuery || undefined,
-        unread_only: readFilter.has('unread'),
+        unread_only: unreadOnly,
       }
-      const result = await notificationsApi.list(listParams)
 
-      setItems(result.items)
-      setTotal(result.total)
+      if (unreadOnly) {
+        // Fetch all pages so the user sees the complete unread set.
+        const allItems: NotificationItem[] = []
+        let currentPage = 1
+        let totalCount = 0
+
+        while (true) {
+          const result = await notificationsApi.list({ ...baseParams, page: currentPage })
+          allItems.push(...result.items)
+          totalCount = result.total
+          if (allItems.length >= totalCount) break
+          currentPage += 1
+        }
+        setItems(allItems)
+        setTotal(totalCount)
+      } else {
+        const result = await notificationsApi.list({ ...baseParams, page })
+        setItems(result.items)
+        setTotal(result.total)
+      }
     } catch (error) {
       console.error('Failed to fetch notifications:', error)
     } finally {
@@ -324,27 +341,29 @@ export function NotificationsClient({ onReadUpdated }: NotificationsClientProps)
         </Table>
       </div>
 
-      <div className="flex items-center justify-end gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setPage((prev) => Math.max(1, prev - 1))}
-          disabled={page <= 1}
-          className="cursor-pointer"
-        >
-          <ChevronLeft className="size-4" />
-        </Button>
-        <span className="text-sm text-muted-foreground">{page} / {totalPages}</span>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
-          disabled={page >= totalPages}
-          className="cursor-pointer"
-        >
-          <ChevronRight className="size-4" />
-        </Button>
-      </div>
+      {!readFilter.has('unread') && (
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+            disabled={page <= 1}
+            className="cursor-pointer"
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <span className="text-sm text-muted-foreground">{page} / {totalPages}</span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
+            disabled={page >= totalPages}
+            className="cursor-pointer"
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+      )}
 
       <Dialog open={detailOpen} onOpenChange={setDetailOpen}>
         <DialogContent className="max-h-[80vh] overflow-hidden sm:max-w-xl">


### PR DESCRIPTION
## Summary

Fixes `YUN-121` — notification fetch only loads a partial unread set.

## Problem

When the "unread only" filter is active, only one page (20 items) is fetched. Unread notifications spanning multiple pages cause a misleading UX:

1. User sees page 1 with 20 unread → marks some read → refreshes  
2. Backend excludes read items, so page 1 fills with items formerly on page 2  
3. User perceives notifications "reappearing" or "weren't fully loaded"

## Solution

- When `unread_only=true`, loop through all pages until the complete unread set is collected, then display it at once
- Hide pagination controls in this mode (all items are visible)
- When `unread_only=false`, behavior is unchanged — single-page fetch with pagination

## Files Changed

- `frontend/app/(platform)/app/notifications/_components/notifications-client.tsx`

## Verification

- TypeScript compiles clean
- Existing tests pass (4/4)