### PR TITLE
fix(publish): checkout before download to avoid workspace cleanup

### DIFF
--- a/.github/workflows/postgres-image.yml
+++ b/.github/workflows/postgres-image.yml
@@ -89,14 +89,14 @@ jobs:
     needs: build-and-test
 
     steps:
+      - name: Checkout release validation
+        uses: actions/checkout@v7
+
       - name: Download tested release images
         uses: actions/download-artifact@v5
         with:
           pattern: postgres-*
           merge-multiple: true
-
-      - name: Checkout release validation
-        uses: actions/checkout@v7
 
       - name: Load tested release images
         run: |


### PR DESCRIPTION
The publish-manifest job ran download-artifact before checkout. The checkout's default clean:true removed the downloaded .tar.gz files before docker load could read them, causing the pipeline to fail with No such file or directory.

Fix: Swap the order so checkout happens first, then download into the workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PostgreSQL image publishing workflow step order.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->