### PR TITLE
fix(postgres): publish one multi-arch release tag

### DIFF
--- a/.github/workflows/postgres-image.yml
+++ b/.github/workflows/postgres-image.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Verify release tag is on main
         if: startsWith(github.ref, 'refs/tags/postgres-pg-search-')
         run: |
+          test "$GITHUB_REF_NAME" = "postgres-pg-search-0.24.3-pg17-alpine1"
           git fetch origin main
           git merge-base --is-ancestor "$GITHUB_SHA" origin/main
 
@@ -67,19 +68,52 @@ jobs:
           python3 deploy/postgres/validate-release.py image \
             clouisle-postgres-pg-search:test "$ARCH"
 
-      - name: Export tested release image
+      - name: Login to ACR
+        if: startsWith(github.ref, 'refs/tags/postgres-pg-search-')
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ secrets.ACR_REGISTRY }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Push tested image by digest
+        id: push_digest
+        if: startsWith(github.ref, 'refs/tags/postgres-pg-search-')
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/postgres/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ secrets.ACR_REGISTRY }}/${{ secrets.ACR_NAMESPACE }}/clouisle-postgres-pg-search,push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=postgres-pg-search-${{ matrix.arch }}
+
+      - name: Verify pushed image digest
         if: startsWith(github.ref, 'refs/tags/postgres-pg-search-')
         env:
           ARCH: ${{ matrix.arch }}
-        run: docker save clouisle-postgres-pg-search:test | gzip > "postgres-$ARCH.tar.gz"
+          PLATFORM: ${{ matrix.platform }}
+          IMAGE: ${{ secrets.ACR_REGISTRY }}/${{ secrets.ACR_NAMESPACE }}/clouisle-postgres-pg-search
+          DIGEST: ${{ steps.push_digest.outputs.digest }}
+        run: |
+          local_id=$(docker image inspect --format '{{.Id}}' clouisle-postgres-pg-search:test)
+          docker pull --platform "$PLATFORM" "$IMAGE@$DIGEST"
+          python3 deploy/postgres/validate-release.py image "$IMAGE@$DIGEST" "$ARCH"
+          remote_id=$(docker image inspect --format '{{.Id}}' "$IMAGE@$DIGEST")
+          if [ "$local_id" != "$remote_id" ]; then
+            echo "pushed digest does not match the tested image" >&2
+            exit 1
+          fi
+          mkdir -p digests
+          printf '%s\n' "$DIGEST" > "digests/$ARCH"
 
-      - name: Upload tested release image
+      - name: Upload architecture digest
         if: startsWith(github.ref, 'refs/tags/postgres-pg-search-')
         uses: actions/upload-artifact@v4
         with:
-          name: postgres-${{ matrix.arch }}
-          path: postgres-${{ matrix.arch }}.tar.gz
-          compression-level: 0
+          name: postgres-digest-${{ matrix.arch }}
+          path: digests/${{ matrix.arch }}
           retention-days: 1
 
   publish-manifest:
@@ -92,18 +126,15 @@ jobs:
       - name: Checkout release validation
         uses: actions/checkout@v7
 
-      - name: Download tested release images
+      - name: Download tested image digests
         uses: actions/download-artifact@v5
         with:
-          pattern: postgres-*
+          pattern: postgres-digest-*
+          path: digests
           merge-multiple: true
 
-      - name: Load tested release images
-        run: |
-          docker load < postgres-amd64.tar.gz
-          docker tag clouisle-postgres-pg-search:test clouisle-postgres-pg-search:amd64
-          docker load < postgres-arm64.tar.gz
-          docker tag clouisle-postgres-pg-search:test clouisle-postgres-pg-search:arm64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to ACR
         uses: docker/login-action@v4
@@ -112,7 +143,7 @@ jobs:
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
 
-      - name: Push immutable architecture images and manifest
+      - name: Publish multi-platform image
         env:
           REGISTRY: ${{ secrets.ACR_REGISTRY }}
           NAMESPACE: ${{ secrets.ACR_NAMESPACE }}
@@ -124,52 +155,9 @@ jobs:
             exit 1
           fi
           image="$REGISTRY/$NAMESPACE/clouisle-postgres-pg-search"
+          amd64_digest=$(cat digests/amd64)
+          arm64_digest=$(cat digests/arm64)
 
-          ensure_architecture_image() {
-            arch=$1
-            local_image="clouisle-postgres-pg-search:$arch"
-            remote_image="$image:$version-$arch"
-            python3 deploy/postgres/validate-release.py image "$local_image" "$arch"
-            local_id=$(docker image inspect --format '{{.Id}}' "$local_image")
-            if docker buildx imagetools inspect "$remote_image" >/dev/null 2>&1; then
-              docker pull --platform "linux/$arch" "$remote_image"
-              python3 deploy/postgres/validate-release.py image "$remote_image" "$arch"
-              remote_id=$(docker image inspect --format '{{.Id}}' "$remote_image")
-              if [ "$local_id" != "$remote_id" ]; then
-                echo "existing immutable image $remote_image has different content" >&2
-                exit 1
-              fi
-            else
-              docker tag "$local_image" "$remote_image"
-              docker push "$remote_image"
-            fi
-
-            docker buildx imagetools inspect \
-              --format '{{json .Manifest}}' "$remote_image" > "$arch-descriptor.json"
-            python3 - "$arch-descriptor.json" > "$arch.digest" <<'PY'
-          import json
-          import pathlib
-          import sys
-
-          descriptor = json.loads(pathlib.Path(sys.argv[1]).read_text())
-          digest = descriptor.get("digest")
-          if not isinstance(digest, str) or not digest.startswith("sha256:"):
-              raise SystemExit("architecture descriptor has no immutable digest")
-          print(digest)
-          PY
-          }
-
-          ensure_architecture_image amd64
-          ensure_architecture_image arm64
-          amd64_digest=$(cat amd64.digest)
-          arm64_digest=$(cat arm64.digest)
-          if docker buildx imagetools inspect "$image:$version" >/dev/null 2>&1; then
-            docker buildx imagetools inspect --raw "$image:$version" > manifest.json
-            python3 deploy/postgres/validate-release.py manifest \
-              manifest.json "$amd64_digest" "$arm64_digest"
-            echo "validated existing release manifest $image:$version"
-            exit 0
-          fi
           docker buildx imagetools create \
             --tag "$image:$version" \
             "$image@$amd64_digest" \

--- a/docs/plan/postgres-pg-search-alpine-image.md
+++ b/docs/plan/postgres-pg-search-alpine-image.md
@@ -20,7 +20,7 @@ The Dockerfile downloads the exact ParadeDB source commit, verifies its archive 
 
 The build uses `RUSTFLAGS="-C target-feature=-crt-static"` because PostgreSQL must dynamically load the musl `cdylib`. It does not copy ParadeDB's glibc packages into Alpine, remove tokenizer dictionaries, alter pg_search features, or compress the shared library with UPX.
 
-A standalone image test script enforces the byte limit and exercises the production preload, extension, BM25, lifecycle, and recovery behavior. Release CI builds and tests each architecture natively, publishes architecture digests only after validation, then assembles the multi-platform manifest.
+A standalone image test script enforces the byte limit and exercises the production preload, extension, BM25, lifecycle, and recovery behavior. Release CI builds and tests each architecture natively, publishes the validated artifacts as untagged architecture digests, then assembles the multi-platform manifest under one release tag.
 
 ## Implementation Plan
 
@@ -53,8 +53,8 @@ A standalone image test script enforces the byte limit and exercises the product
 - **Specific logic**:
   - Run affected pull-request builds without pushing images.
   - Build/test amd64 and arm64 on native Linux runners with architecture-specific caches.
-  - Export tested artifacts per architecture, then push both immutable architecture tags only after the complete matrix passes.
-  - Assemble a manifest containing exactly linux/amd64 and linux/arm64; publish a revision tag such as `0.24.3-pg17-alpine1`, not `latest`.
+  - Push each validated native artifact by digest without architecture-specific tags; create the shared release tag only after the complete matrix passes.
+  - Assemble a manifest containing exactly linux/amd64 and linux/arm64 under a single revision tag such as `0.24.3-pg17-alpine1`, not `latest`.
   - Keep database image publication separate from application release tags so ordinary application releases do not rebuild this pinned database artifact.
 - **Validation**: Inspect manifest platforms and record both digests and unpacked sizes in workflow evidence.
 
@@ -71,7 +71,7 @@ A standalone image test script enforces the byte limit and exercises the product
 ## Current Validation Evidence
 
 - Native ARM64 validation completed on 2026-07-29: image `426,942,814` bytes, pg_search shared library `136,636,872` bytes; ELF and runtime acceptance passed.
-- Release CI now requires the same native acceptance on amd64 and arm64, validates tested image architecture and labels, and accepts an existing or newly created manifest only when it contains exactly the validated `linux/amd64` and `linux/arm64` descriptor digests.
+- Release CI now requires the same native acceptance on amd64 and arm64, verifies that each pushed digest matches its tested image, and publishes only the shared release tag when the manifest contains exactly those validated `linux/amd64` and `linux/arm64` descriptor digests.
 - The canonical deployment reference is `registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-postgres-pg-search:0.24.3-pg17-alpine1`; registry publication remains a release-workflow operation.
 
 ## Testing Strategy


### PR DESCRIPTION
## Problem
The release workflow published permanent architecture tags and then treated an existing single-architecture release tag as an OCI index, failing with: `OCI index must contain a manifests array`.

## Change
- build and test amd64/arm64 on native runners
- push validated images by digest without architecture-specific tags
- verify each pushed digest matches the tested local image
- create exactly one release tag, `0.24.3-pg17-alpine1`, containing the two-platform manifest
- replace the existing single-architecture release reference instead of accepting it as a valid index

## Verification
- `python3 -m unittest deploy/postgres/test_validate_release.py`
- workflow YAML parsed with Ruby Psych
- all workflow shell blocks pass `bash -n`
- no architecture-tag publication patterns remain