### PR TITLE
feat: render chunk details as Markdown in knowledge base hit test page

### DIFF
--- a/frontend/components/knowledge-bases/retrieval-lab.test.tsx
+++ b/frontend/components/knowledge-bases/retrieval-lab.test.tsx
@@ -255,9 +255,9 @@ describe('RetrievalLab', () => {
     const resultButtons = elements(tree).filter(element => element.type === 'button' && String(element.props['aria-label']).startsWith('selectResult'))
     resultButtons[1].props.onClick()
     tree = render()
-    const detailText = text(elements(tree).find(element => element.type === 'aside')!)
-    expect(detailText).toContain('Content from B')
-    expect(detailText).not.toContain('Content from A')
+    const markdown = find(elements(tree).find(element => element.type === 'aside')!, 'markdown-preview')
+    expect(markdown.props.source).toBe('Content from B')
+    expect(markdown.props.source).not.toBe('Content from A')
 
     find(tree, 'button', props => props['aria-label'] === 'closeResultDetails').props.onClick()
     tree = render()

--- a/frontend/components/knowledge-bases/retrieval-lab/index.tsx
+++ b/frontend/components/knowledge-bases/retrieval-lab/index.tsx
@@ -250,13 +250,9 @@ function ResultDetail({ result, side, rank, query, authenticatedMarkdown, resolv
           </span>
         </div>
         <div className="min-w-0 rounded-md border bg-muted/20 p-4" data-color-mode={resolvedTheme === 'dark' ? 'dark' : 'light'}>
-          {authenticatedMarkdown ? (
-            <div className="w-full max-w-[75ch] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_img]:my-3 [&_img]:block [&_img]:h-auto [&_img]:max-h-80 [&_img]:max-w-full [&_img]:rounded-md [&_img]:object-contain [&_a.anchor]:!ml-0 [&_a]:break-words [&_code]:text-xs [&_h1]:text-lg [&_h2]:text-base [&_h3]:text-sm [&_h4]:text-sm [&_h5]:text-sm [&_h6]:text-sm [&_li]:text-sm [&_p]:text-sm [&_p]:leading-relaxed [&_pre]:overflow-x-auto [&_pre]:text-xs [&_table]:text-sm">
-              <MDPreview source={result.content} components={{ img: ({ src, alt }) => <AuthenticatedMarkdownImage src={typeof src === 'string' ? src : undefined} alt={alt} /> }} />
-            </div>
-          ) : (
-            <p className="max-w-[75ch] whitespace-pre-wrap text-sm leading-relaxed"><Highlight text={result.content} query={query} /></p>
-          )}
+          <div className="w-full max-w-[75ch] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_img]:my-3 [&_img]:block [&_img]:h-auto [&_img]:max-h-80 [&_img]:max-w-full [&_img]:rounded-md [&_img]:object-contain [&_a.anchor]:!ml-0 [&_a]:break-words [&_code]:text-xs [&_h1]:text-lg [&_h2]:text-base [&_h3]:text-sm [&_h4]:text-sm [&_h5]:text-sm [&_h6]:text-sm [&_li]:text-sm [&_p]:text-sm [&_p]:leading-relaxed [&_pre]:overflow-x-auto [&_pre]:text-xs [&_table]:text-sm">
+            <MDPreview source={result.content} components={authenticatedMarkdown ? { img: ({ src, alt }) => <AuthenticatedMarkdownImage src={typeof src === 'string' ? src : undefined} alt={alt} /> } : undefined} />
+          </div>
         </div>
         {(result.degradation_reasons?.length || result.rerank_reason) && <p className="text-xs text-amber-700 dark:text-amber-300">{t('fallbackReasons')}: {[...(result.degradation_reasons ?? []).map(reason => `${reason.channel}: ${reason.error}`), result.rerank_reason].filter(Boolean).join('; ')}</p>}
       </div>


### PR DESCRIPTION
## Summary

Render segment/chunk content as Markdown in the knowledge base hit test page's detail view, instead of plain text.

## Changes

- **`frontend/components/knowledge-bases/retrieval-lab/index.tsx`**: In `ResultDetail`, removed the conditional that rendered plain text (`whitespace-pre-wrap` + `Highlight`) when `authenticatedMarkdown` was `false`. Now always uses `MDPreview` (the existing markdown renderer from `@uiw/react-md-editor`) for both auth and non-auth paths. The `authenticatedMarkdown` flag now only controls whether `AuthenticatedMarkdownImage` is used for embedded images.

- **`frontend/components/knowledge-bases/retrieval-lab.test.tsx`**: Updated test to verify content via `MDPreview`'s `source` prop instead of text extraction.

## Verification

- All 16 tests pass
- TypeScript compiles cleanly
- No new dependencies — reuses the existing `MDPreview` already imported in the same file

Closes YUN-122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved result detail rendering by consistently displaying content with Markdown formatting.
  * Preserved support for authenticated images in Markdown content.
  * Updated desktop A/B detail selection validation to ensure the selected result displays the correct content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->