### PR TITLE
fix(ui): prevent dialog content overflow

### DIFF
--- a/frontend/components/ui/dialog.test.tsx
+++ b/frontend/components/ui/dialog.test.tsx
@@ -92,6 +92,7 @@ describe("dialog wrappers", () => {
     const content = renderContent({ children: "body" })
     const contentChildren = content.props.children as Node[]
     expect(contentChildren[0].type).toBe(dialog.DialogOverlay)
+    expect(contentChildren[1].props.className).toContain("grid-cols-[minmax(0,1fr)]")
     expect((contentChildren[1].props.children as unknown[])[0]).toBe("body")
     expect((contentChildren[1].props.children as Node[])[1].type).toBe(Close)
 

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -90,7 +90,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 w-full -translate-x-1/2 -translate-y-1/2 outline-none z-50",
+          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid grid-cols-[minmax(0,1fr)] max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 w-full -translate-x-1/2 -translate-y-1/2 outline-none z-50",
           className
         )}
         {...props}


### PR DESCRIPTION
## 背景

知识库上传文档弹窗在选择多个长文件名时，隐式 CSS Grid 列会被内容的最小宽度撑大，导致拖放区、文件列表和底部操作按钮越出弹窗边界。

## 改动内容

- 将共享 `DialogContent` 的单列约束为 `minmax(0, 1fr)`，允许内容在弹窗最大宽度内正确收缩。
- 增加回归断言，防止共享弹窗丢失可收缩网格列约束。

## 验证方式

- [x] `bun test components/ui/dialog.test.tsx`
- [x] 分别运行平台端和管理端上传弹窗测试，共 10 个用例通过
- [x] `bun run lint components/ui/dialog.tsx components/ui/dialog.test.tsx`
- [x] 在 1280px 桌面视口和 390x844 窄屏视口选择 4 个长文件名，确认内容均未越界且控制台无错误或警告

## 风险与影响

改动作用于共享弹窗组件，会让所有弹窗子内容遵守现有最大宽度；不改变上传逻辑或 API。风险较低，可通过回退本提交恢复原行为。

## 关联信息

Fixes #319


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog content layout by ensuring it displays in a single-column grid for more consistent presentation.

* **Tests**
  * Added coverage verifying the dialog uses the expected single-column layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->