### PR TITLE
feat: add contributors section and skip auto-assign for fork PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -6,6 +6,7 @@ on:
     types: [opened]
 jobs:
   run:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Build, deploy, and manage intelligent AI agents with RAG-powered knowledge retri
 - [Roadmap](#roadmap)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
+- [Contributors](#contributors)
 - [License](#license)
 
 ---
@@ -329,6 +330,15 @@ Configure via the admin dashboard:
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 
 For development setup and commands (lint, test, build), see the [Development Guide](docs/guide/getting-started/development.md).
+
+## Contributors
+
+Thanks to all the people who have contributed to Clouisle:
+
+<a href="https://github.com/clouisle/Clouisle/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=clouisle/Clouisle" />
+</a>
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ For development setup and commands (lint, test, build), see the [Development Gui
 Thanks to all the people who have contributed to Clouisle:
 
 <a href="https://github.com/clouisle/Clouisle/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=clouisle/Clouisle" />
+  <img alt="Clouisle contributor avatars" src="https://contrib.rocks/image?repo=clouisle/Clouisle" />
 </a>
 
 

--- a/docs/guide/README_zh-CN.md
+++ b/docs/guide/README_zh-CN.md
@@ -42,6 +42,7 @@
 - [使用场景](#使用场景)
 - [路线图](#路线图)
 - [参与贡献](#参与贡献)
+- [贡献者](#贡献者)
 - [许可证](#许可证)
 
 ---
@@ -316,6 +317,16 @@ docker compose --env-file .env up -d
 我们欢迎贡献！请查看 [贡献指南](../CONTRIBUTING.md) 了解详情。
 
 开发环境搭建和命令（代码检查、测试、构建等）请参考 [开发指南](getting-started/development_zh-CN.md)。
+
+## 贡献者
+
+感谢所有为 Clouisle 做出贡献的人：
+
+<a href="https://github.com/clouisle/Clouisle/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=clouisle/Clouisle" />
+</a>
+
+
 ---
 
 ## 许可证


### PR DESCRIPTION
## 改动内容

- 在 README.md 和 docs/guide/README_zh-CN.md 添加贡献者章节，使用 contrib.rocks 自动生成头像墙
- 跳过 fork PR 的 Auto Assign 工作流，避免权限不足导致的 failure

## 验证方式

- [x] Auto Assign workflow 对 fork PR 会被 skip
- [x] README 中贡献者头像正常显示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Contributors section to the main README, including contributor acknowledgments and a visual contributor graph.
  - Added the corresponding Contributors section and contributor visualization to the Chinese documentation.
  - Updated both documentation table-of-contents entries for easier navigation.

- **Bug Fixes**
  - Automatic assignment workflows now run only for issues and pull requests originating from the same repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->