### PR TITLE
fix(security): stop leaking exception text to users in tool errors

### DIFF
--- a/backend/app/api/v1/endpoints/chat_tools.py
+++ b/backend/app/api/v1/endpoints/chat_tools.py
@@ -27,7 +27,7 @@ async def execute_tool_call(
     from app.core.i18n import t
     from app.models.tool import Tool, CustomToolType
     from app.llm.tools import tool_registry
-    from app.services.error_messages import resolve_user_visible_error
+    from app.services.error_messages import exception_to_user_message
 
     # Initialize default timeouts if not provided
     if tool_timeouts is None:
@@ -127,7 +127,14 @@ async def execute_tool_call(
             return json.dumps(result, ensure_ascii=False)
         except Exception as e:
             logger.exception("Memory tool failed: %s", e)
-            return json.dumps({"error": str(e)}, ensure_ascii=False)
+            return json.dumps(
+                {
+                    "error": exception_to_user_message(
+                        e, fallback_key="memory_tool_execution_failed"
+                    )
+                },
+                ensure_ascii=False,
+            )
 
     # Skill tool (format: skill_<name>_<short_id>)
     if tool_name.startswith("skill_"):
@@ -160,9 +167,8 @@ async def execute_tool_call(
             logger.exception("Skill execution failed: %s", e)
             return json.dumps(
                 {
-                    "error": resolve_user_visible_error(
-                        str(e),
-                        fallback_key="skill_execution_failed",
+                    "error": exception_to_user_message(
+                        e, fallback_key="skill_execution_failed"
                     )
                 },
                 ensure_ascii=False,
@@ -207,8 +213,8 @@ async def execute_tool_call(
                 logger.exception("MCP tool execution failed: %s", e)
                 return json.dumps(
                     {
-                        "error": resolve_user_visible_error(
-                            str(e), fallback_key="mcp_tool_failed"
+                        "error": exception_to_user_message(
+                            e, fallback_key="mcp_tool_execution_failed"
                         )
                     },
                     ensure_ascii=False,
@@ -246,8 +252,8 @@ async def execute_tool_call(
                 logger.exception("HTTP tool execution failed: %s", e)
                 return json.dumps(
                     {
-                        "error": resolve_user_visible_error(
-                            str(e), fallback_key="http_tool_failed"
+                        "error": exception_to_user_message(
+                            e, fallback_key="tool_execution_failed"
                         )
                     },
                     ensure_ascii=False,
@@ -268,8 +274,8 @@ async def execute_tool_call(
                 logger.exception("Code tool execution failed: %s", e)
                 return json.dumps(
                     {
-                        "error": resolve_user_visible_error(
-                            str(e), fallback_key="code_tool_failed"
+                        "error": exception_to_user_message(
+                            e, fallback_key="code_tool_execution_failed"
                         )
                     },
                     ensure_ascii=False,
@@ -298,8 +304,8 @@ async def execute_tool_call(
             logger.exception("File download failed: %s", e)
             return json.dumps(
                 {
-                    "error": resolve_user_visible_error(
-                        str(e), fallback_key="download_failed"
+                    "error": exception_to_user_message(
+                        e, fallback_key="tool_execution_failed"
                     )
                 },
                 ensure_ascii=False,
@@ -330,8 +336,8 @@ async def execute_tool_call(
             logger.exception("Builtin tool execution failed: %s", e)
             return json.dumps(
                 {
-                    "error": resolve_user_visible_error(
-                        str(e), fallback_key="tool_execution_failed"
+                    "error": exception_to_user_message(
+                        e, fallback_key="tool_execution_failed"
                     )
                 },
                 ensure_ascii=False,
@@ -389,6 +395,7 @@ async def _execute_code_tool(
 ) -> dict[str, Any]:
     """Execute a code tool."""
     from app.llm.tools.sandbox import execute_code
+    from app.services.error_messages import exception_to_user_message
 
     code_config = tool.code_config or {}
     language = code_config.get("language", "python")
@@ -416,7 +423,12 @@ async def _execute_code_tool(
         }
     except Exception as e:
         logger.exception("Code tool execution failed: %s", e)
-        return {"error": str(e), "success": False}
+        return {
+            "error": exception_to_user_message(
+                e, fallback_key="code_tool_execution_failed"
+            ),
+            "success": False,
+        }
 
 
 # ============ Additional Tool Functions ============
@@ -470,7 +482,7 @@ async def execute_code_tool(
     """
     from app.core.i18n import t
     from app.llm.tools.sandbox import execute_code
-    from app.services.error_messages import resolve_user_visible_error
+    from app.services.error_messages import exception_to_user_message
 
     code_config = tool.code_config or {}
     language = code_config.get("language", "python")
@@ -513,8 +525,8 @@ async def execute_code_tool(
         logger.exception("Code tool execution error: %s", e)
         return json.dumps(
             {
-                "error": resolve_user_visible_error(
-                    str(e),
+                "error": exception_to_user_message(
+                    e,
                     fallback_key="code_tool_execution_failed",
                 )
             },

--- a/backend/app/llm/tools/builtin/media.py
+++ b/backend/app/llm/tools/builtin/media.py
@@ -18,7 +18,8 @@ from app.core.i18n import t
 from app.llm import model_manager
 from app.llm.adapters.media_utils import parse_image_data_url
 from app.models.model import ModelType
-from app.services.error_messages import resolve_user_visible_error
+from app.schemas.response import BusinessError
+from app.services.error_messages import exception_to_user_message
 from app.llm.types import (
     GeneratedImage,
     ImageContent,
@@ -96,7 +97,9 @@ def _validate_allowed_providers(
 
     provider = model_ref.split("/", 1)[0]
     if provider not in allowed_providers:
-        raise ValueError(t("media_provider_not_allowed_for_agent", provider=provider))
+        raise BusinessError(
+            msg_key="media_provider_not_allowed_for_agent", provider=provider
+        )
 
 
 def _get_provider_from_model_ref(model_ref: str | None) -> str | None:
@@ -130,12 +133,10 @@ async def _normalize_image_quality(
         supported_values = OPENAI_DALLE_IMAGE_QUALITY_VALUES
 
     if mapped_quality is None:
-        raise ValueError(
-            t(
-                "image_generation_invalid_quality",
-                quality=quality,
-                supported=", ".join(supported_values),
-            )
+        raise BusinessError(
+            msg_key="image_generation_invalid_quality",
+            quality=quality,
+            supported=", ".join(supported_values),
         )
     return mapped_quality
 
@@ -172,7 +173,7 @@ def _chat_image_to_generation_image(image: Any, *, index: int) -> ImageContent:
             if path.is_file():
                 return ImageContent(file_path=str(path))
 
-    raise ValueError(t("image_reference_invalid_uploaded_image", index=index))
+    raise BusinessError(msg_key="image_reference_invalid_uploaded_image", index=index)
 
 
 def _deduplicate_indexes(indexes: Sequence[Any]) -> list[int]:
@@ -198,7 +199,7 @@ def _resolve_generation_reference_images(
     current_images: Sequence[Any] | None,
 ) -> list[ImageContent] | None:
     if images and reference_image_indexes:
-        raise ValueError(t("image_reference_images_conflict"))
+        raise BusinessError(msg_key="image_reference_images_conflict")
     if images:
         return [ImageContent.model_validate(image) for image in images]
     if reference_image_indexes is None:
@@ -208,18 +209,16 @@ def _resolve_generation_reference_images(
     if not selected_indexes:
         return None
     if not current_images:
-        raise ValueError(t("image_reference_no_uploaded_images"))
+        raise BusinessError(msg_key="image_reference_no_uploaded_images")
 
     resolved: list[ImageContent] = []
     available_count = len(current_images)
     for index in selected_indexes:
         if index < 1 or index > available_count:
-            raise ValueError(
-                t(
-                    "image_reference_image_index_out_of_range",
-                    index=index,
-                    count=available_count,
-                )
+            raise BusinessError(
+                msg_key="image_reference_image_index_out_of_range",
+                index=index,
+                count=available_count,
             )
         resolved.append(
             _chat_image_to_generation_image(current_images[index - 1], index=index)
@@ -428,7 +427,7 @@ async def generate_image(
     resolved_model_ref: str | None = None
     try:
         if agent and not getattr(agent, "enable_image_generation", False):
-            raise ValueError(t("image_generation_not_enabled_for_agent"))
+            raise BusinessError(msg_key="image_generation_not_enabled_for_agent")
 
         config = _get_agent_module_config(agent, "image_generation_config")
         resolved_model_ref = config.get("default_model_ref") or None
@@ -443,7 +442,7 @@ async def generate_image(
             current_images=current_images,
         )
         if reference_images and not config.get("allow_reference_images", True):
-            raise ValueError(t("image_reference_images_disabled"))
+            raise BusinessError(msg_key="image_reference_images_disabled")
 
         normalized_quality = await _normalize_image_quality(
             quality,
@@ -491,8 +490,8 @@ async def generate_image(
         )
     except Exception as exc:
         logger.exception("Image generation tool failed: %s", exc)
-        error_message = resolve_user_visible_error(
-            str(exc),
+        error_message = exception_to_user_message(
+            exc,
             fallback_key="unknown_error_generic",
         )
         display_result = build_image_tool_result(
@@ -529,7 +528,7 @@ async def generate_video(
 
     try:
         if agent and not getattr(agent, "enable_video_generation", False):
-            raise ValueError(t("video_generation_not_enabled_for_agent"))
+            raise BusinessError(msg_key="video_generation_not_enabled_for_agent")
 
         config = _get_agent_module_config(agent, "video_generation_config")
         resolved_model_ref = config.get("default_model_ref") or None
@@ -538,11 +537,9 @@ async def generate_video(
         final_duration = duration or float(config.get("default_duration", 5.0))
         max_duration = float(config.get("max_duration", 10.0))
         if final_duration > max_duration:
-            raise ValueError(
-                t(
-                    "video_generation_duration_exceeds_agent_limit",
-                    max_duration=f"{max_duration:.1f}",
-                )
+            raise BusinessError(
+                msg_key="video_generation_duration_exceeds_agent_limit",
+                max_duration=f"{max_duration:.1f}",
             )
 
         poll_interval_ms = int(config.get("poll_interval_ms", 3000))
@@ -597,8 +594,8 @@ async def generate_video(
         )
     except Exception as exc:
         logger.exception("Video generation tool failed: %s", exc)
-        error_message = resolve_user_visible_error(
-            str(exc),
+        error_message = exception_to_user_message(
+            exc,
             fallback_key="unknown_error_generic",
         )
         display_result = build_video_tool_result(

--- a/backend/app/llm/tools/executors.py
+++ b/backend/app/llm/tools/executors.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 import httpx
 
 from app.core.i18n import t
+from app.schemas.response import BusinessError
 
 logger = logging.getLogger(__name__)
 
@@ -44,25 +45,25 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
 def _validate_external_http_url(value: str) -> _ValidatedExternalUrl:
     parsed = urlparse(value)
     if parsed.scheme not in {"http", "https"} or not parsed.hostname:
-        raise ValueError(t("http_tool_url_invalid"))
+        raise BusinessError(msg_key="http_tool_url_invalid")
     host = parsed.hostname.lower().rstrip(".")
     if host in _BLOCKED_HOSTS:
-        raise ValueError(t("http_tool_url_host_not_allowed"))
+        raise BusinessError(msg_key="http_tool_url_host_not_allowed")
     try:
         ip = ipaddress.ip_address(host)
     except ValueError:
         ip = None
     if ip and _is_blocked_ip(ip):
-        raise ValueError(t("http_tool_url_host_not_allowed"))
+        raise BusinessError(msg_key="http_tool_url_host_not_allowed")
     try:
         resolved = socket.getaddrinfo(
             host, parsed.port or None, type=socket.SOCK_STREAM
         )
     except socket.gaierror as exc:
-        raise ValueError(t("http_tool_url_host_cannot_be_resolved")) from exc
+        raise BusinessError(msg_key="http_tool_url_host_cannot_be_resolved") from exc
     for *_, sockaddr in resolved:
         if _is_blocked_ip(ipaddress.ip_address(sockaddr[0])):
-            raise ValueError(t("http_tool_url_host_not_allowed"))
+            raise BusinessError(msg_key="http_tool_url_host_not_allowed")
     return _ValidatedExternalUrl(value)
 
 
@@ -321,8 +322,10 @@ async def execute_http_tool(
     raw_url = str(http_config.get("url", ""))
     try:
         if _extract_placeholder_name(raw_url) or "{{" in raw_url or "}}" in raw_url:
-            raise ValueError(t("http_tool_url_templates_not_supported"))
+            raise BusinessError(msg_key="http_tool_url_templates_not_supported")
         url = _validate_external_http_url(raw_url)
+    except BusinessError as exc:
+        return {"success": False, "error": t(exc.msg_key, **exc.kwargs)}
     except ValueError as exc:
         return {"success": False, "error": str(exc)}
 

--- a/backend/app/llm/tools/executors.py
+++ b/backend/app/llm/tools/executors.py
@@ -50,15 +50,17 @@ def _validate_external_http_url(value: str) -> _ValidatedExternalUrl:
     if host in _BLOCKED_HOSTS:
         raise BusinessError(msg_key="http_tool_url_host_not_allowed")
     try:
+        port = parsed.port
+    except ValueError:
+        raise BusinessError(msg_key="http_tool_url_invalid")
+    try:
         ip = ipaddress.ip_address(host)
     except ValueError:
         ip = None
     if ip and _is_blocked_ip(ip):
         raise BusinessError(msg_key="http_tool_url_host_not_allowed")
     try:
-        resolved = socket.getaddrinfo(
-            host, parsed.port or None, type=socket.SOCK_STREAM
-        )
+        resolved = socket.getaddrinfo(host, port or None, type=socket.SOCK_STREAM)
     except socket.gaierror as exc:
         raise BusinessError(msg_key="http_tool_url_host_cannot_be_resolved") from exc
     for *_, sockaddr in resolved:

--- a/backend/app/llm/tools/mcp_client.py
+++ b/backend/app/llm/tools/mcp_client.py
@@ -22,7 +22,10 @@ from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.client.streamable_http import streamable_http_client as streamablehttp_client
 from mcp.shared._httpx_utils import create_mcp_http_client
 
-from app.services.error_messages import resolve_user_visible_error
+from app.services.error_messages import (
+    exception_to_user_message,
+    resolve_user_visible_error,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -237,8 +240,8 @@ class McpClient:
             logger.exception("MCP tool execution error")
             return McpToolResult(
                 success=False,
-                error=resolve_user_visible_error(
-                    str(e),
+                error=exception_to_user_message(
+                    e,
                     fallback_key="mcp_tool_execution_failed",
                 ),
             )

--- a/backend/app/services/error_messages.py
+++ b/backend/app/services/error_messages.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 
 from app.core.i18n import has_translation, t
+from app.schemas.response import BusinessError
 
 
 _TRANSLATION_KEY_PATTERN = re.compile(r"^[a-z0-9]+(?:[._-][a-z0-9]+)+$", re.IGNORECASE)
@@ -53,4 +54,21 @@ def resolve_user_visible_error(
     if is_safe_user_visible_error(normalized):
         return normalized
 
+    return t(fallback_key)
+
+
+def exception_to_user_message(
+    e: BaseException,
+    *,
+    fallback_key: str = "tool_execution_failed",
+) -> str:
+    """Map an exception to a user-safe message.
+
+    Never returns raw exception text. Only exceptions carrying an explicit
+    translation key (``BusinessError``) are surfaced to the user; anything
+    else is replaced with the localized fallback. Full details belong in
+    server logs.
+    """
+    if isinstance(e, BusinessError) and e.msg_key:
+        return t(e.msg_key, **e.kwargs)
     return t(fallback_key)

--- a/backend/tests/llm/test_http_tool_executors_issue255.py
+++ b/backend/tests/llm/test_http_tool_executors_issue255.py
@@ -30,6 +30,7 @@ class _Response:
     "url,error",
     [
         ("ftp://example.com", "http_tool_url_invalid"),
+        ("https://example.com:bad", "http_tool_url_invalid"),
         ("http://127.0.0.1", "http_tool_url_host_not_allowed"),
     ],
 )

--- a/backend/tests/llm/test_http_tool_executors_issue255.py
+++ b/backend/tests/llm/test_http_tool_executors_issue255.py
@@ -14,6 +14,7 @@ from app.llm.tools.executors import (
     execute_http_tool,
     format_http_result_for_llm,
 )
+from app.schemas.response import BusinessError
 
 
 class _Response:
@@ -33,7 +34,7 @@ class _Response:
     ],
 )
 def test_url_validation_rejects_invalid_and_private_hosts(url, error):
-    with pytest.raises(ValueError, match=t(error)):
+    with pytest.raises(BusinessError, match=error):
         _validate_external_http_url(url)
 
 
@@ -47,12 +48,12 @@ def test_url_validation_handles_dns_success_private_result_and_failure():
         )
     with (
         patch("socket.getaddrinfo", return_value=private),
-        pytest.raises(ValueError, match=t("http_tool_url_host_not_allowed")),
+        pytest.raises(BusinessError, match="http_tool_url_host_not_allowed"),
     ):
         _validate_external_http_url("https://example.com")
     with (
         patch("socket.getaddrinfo", side_effect=socket.gaierror),
-        pytest.raises(ValueError, match=t("http_tool_url_host_cannot_be_resolved")),
+        pytest.raises(BusinessError, match="http_tool_url_host_cannot_be_resolved"),
     ):
         _validate_external_http_url("https://missing.example")
 

--- a/backend/tests/llm/test_http_tool_executors_residual_issue255.py
+++ b/backend/tests/llm/test_http_tool_executors_residual_issue255.py
@@ -18,6 +18,7 @@ from app.llm.tools.executors import (
     execute_http_tool,
     format_http_result_for_llm,
 )
+from app.schemas.response import BusinessError
 
 
 @pytest.mark.parametrize(
@@ -29,7 +30,7 @@ from app.llm.tools.executors import (
     ],
 )
 def test_url_validation_rejects_invalid_and_blocked_hosts(value, message):
-    with pytest.raises(ValueError, match=t(message)):
+    with pytest.raises(BusinessError, match=message):
         _validate_external_http_url(value)
 
 
@@ -38,7 +39,7 @@ def test_url_validation_checks_dns_results():
         "app.llm.tools.executors.socket.getaddrinfo", side_effect=socket.gaierror
     ):
         with pytest.raises(
-            ValueError, match=t("http_tool_url_host_cannot_be_resolved")
+            BusinessError, match="http_tool_url_host_cannot_be_resolved"
         ):
             _validate_external_http_url("https://missing.example")
 
@@ -46,7 +47,7 @@ def test_url_validation_checks_dns_results():
         "app.llm.tools.executors.socket.getaddrinfo",
         return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 443))],
     ):
-        with pytest.raises(ValueError, match=t("http_tool_url_host_not_allowed")):
+        with pytest.raises(BusinessError, match="http_tool_url_host_not_allowed"):
             _validate_external_http_url("https://example.com")
 
     with patch(

--- a/backend/tests/llm/test_mcp_client.py
+++ b/backend/tests/llm/test_mcp_client.py
@@ -162,8 +162,9 @@ async def test_execute_tool_returns_structured_success(monkeypatch, content, exp
 @pytest.mark.asyncio
 async def test_execute_tool_maps_server_timeout_and_connection_errors(monkeypatch):
     resolve_error = MagicMock(side_effect=lambda message, **kwargs: f"safe:{message}")
+    mask_error = MagicMock(return_value="masked:offline")
     monkeypatch.setattr(mcp_client, "resolve_user_visible_error", resolve_error)
-    monkeypatch.setattr(mcp_client, "exception_to_user_message", resolve_error)
+    monkeypatch.setattr(mcp_client, "exception_to_user_message", mask_error)
     client = mcp_client.McpClient({})
 
     error_session = SimpleNamespace(
@@ -196,13 +197,13 @@ async def test_execute_tool_maps_server_timeout_and_connection_errors(monkeypatc
 
     monkeypatch.setattr(client, "connect", failing_context)
     assert await client.execute_tool("fail", {}) == mcp_client.McpToolResult(
-        success=False, error="safe:offline"
+        success=False, error="masked:offline"
     )
 
     assert resolve_error.call_args_list[1].kwargs == {"fallback_key": "request_timeout"}
-    assert resolve_error.call_args_list[2].kwargs == {
-        "fallback_key": "mcp_tool_execution_failed"
-    }
+    mask_error.assert_called_once()
+    assert isinstance(mask_error.call_args.args[0], RuntimeError)
+    assert mask_error.call_args.kwargs == {"fallback_key": "mcp_tool_execution_failed"}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/llm/test_mcp_client.py
+++ b/backend/tests/llm/test_mcp_client.py
@@ -163,6 +163,7 @@ async def test_execute_tool_returns_structured_success(monkeypatch, content, exp
 async def test_execute_tool_maps_server_timeout_and_connection_errors(monkeypatch):
     resolve_error = MagicMock(side_effect=lambda message, **kwargs: f"safe:{message}")
     monkeypatch.setattr(mcp_client, "resolve_user_visible_error", resolve_error)
+    monkeypatch.setattr(mcp_client, "exception_to_user_message", resolve_error)
     client = mcp_client.McpClient({})
 
     error_session = SimpleNamespace(

--- a/backend/tests/llm/test_media_builtin_payload_helpers.py
+++ b/backend/tests/llm/test_media_builtin_payload_helpers.py
@@ -9,6 +9,7 @@ from app.llm.tools.builtin.media import (
     build_video_tool_result,
     normalize_image_generation_response,
 )
+from app.schemas.response import BusinessError
 from app.llm.types import (
     GeneratedImage,
     ImageContent,
@@ -59,19 +60,21 @@ def test_media_payload_builders_normalize_status_and_serialized_images():
 def test_reference_indexes_discard_invalid_values_and_reject_missing_sources():
     assert _deduplicate_indexes(["2", 2, True, None, "bad", 1.8, 1]) == [2, 1]
 
-    with pytest.raises(ValueError, match="No conversation images"):
+    with pytest.raises(BusinessError) as exc_info:
         _resolve_generation_reference_images(
             images=None,
             reference_image_indexes=[1],
             current_images=None,
         )
+    assert exc_info.value.msg_key == "image_reference_no_uploaded_images"
 
-    with pytest.raises(ValueError, match="not both"):
+    with pytest.raises(BusinessError) as exc_info:
         _resolve_generation_reference_images(
             images=[{"url": "https://example.com/ref.png"}],
             reference_image_indexes=[1],
             current_images=[{"url": "data:image/png;base64,cmVm"}],
         )
+    assert exc_info.value.msg_key == "image_reference_images_conflict"
 
 
 @pytest.mark.anyio

--- a/backend/tests/llm/test_media_builtin_tools.py
+++ b/backend/tests/llm/test_media_builtin_tools.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+from app.core.i18n import t
 from app.models.model import ModelType
 
 import pytest
@@ -400,7 +401,7 @@ async def test_generate_video_reports_unsupported_start_image_reference():
 
     mock_generate.assert_awaited_once()
     assert result.display_result["success"] is False
-    assert "does not support uploaded images" in result.display_result["error"]
+    assert result.display_result["error"] == t("unknown_error_generic")
 
 
 def test_build_media_llm_summaries_are_compact():

--- a/backend/tests/llm/test_media_builtin_tools_branches.py
+++ b/backend/tests/llm/test_media_builtin_tools_branches.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.core.i18n import t
 from app.llm.tools.builtin.media import (
     _deduplicate_indexes,
     _get_provider_from_model_ref,
@@ -282,4 +283,4 @@ async def test_generate_video_reports_limit_and_manager_errors():
     assert manager_call.await_count == 1
     assert "agent limit" in too_long.display_result["error"].lower()
     assert manager_error.display_result["success"] is False
-    assert "provider unavailable" in manager_error.display_result["error"]
+    assert manager_error.display_result["error"] == t("unknown_error_generic")

--- a/backend/tests/services/test_chat_tools_branches_issue255.py
+++ b/backend/tests/services/test_chat_tools_branches_issue255.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import pytest
 
 from app.api.v1.endpoints.chat_tools import execute_tool_call
+from app.core.i18n import t
 from app.models.tool import CustomToolType
 
 
@@ -217,7 +218,7 @@ async def test_custom_http_tool_returns_formatted_result_and_masks_executor_erro
         patch("app.llm.tools.executors.execute_http_tool", executor),
     ):
         error = await execute_tool_call("custom_weather", {})
-    assert json.loads(error) == {"error": "secret provider detail"}
+    assert json.loads(error) == {"error": t("tool_execution_failed")}
 
 
 @pytest.mark.anyio

--- a/backend/tests/services/test_chat_tools_remaining_issue255.py
+++ b/backend/tests/services/test_chat_tools_remaining_issue255.py
@@ -263,7 +263,7 @@ async def test_mcp_routes_invalid_missing_success_and_error():
             new=AsyncMock(side_effect=RuntimeError("network secret")),
         ),
         patch(
-            "app.services.error_messages.resolve_user_visible_error",
+            "app.services.error_messages.exception_to_user_message",
             return_value="MCP unavailable",
         ),
     ):
@@ -313,7 +313,7 @@ async def test_custom_http_routes_success_error_missing_and_unsupported():
             new=AsyncMock(side_effect=RuntimeError("network secret")),
         ),
         patch(
-            "app.services.error_messages.resolve_user_visible_error",
+            "app.services.error_messages.exception_to_user_message",
             return_value="HTTP unavailable",
         ),
     ):
@@ -359,7 +359,7 @@ async def test_download_builtin_and_unknown_route_errors():
             new=AsyncMock(side_effect=RuntimeError("download secret")),
         ),
         patch(
-            "app.services.error_messages.resolve_user_visible_error",
+            "app.services.error_messages.exception_to_user_message",
             return_value="Download unavailable",
         ),
     ):
@@ -377,7 +377,7 @@ async def test_download_builtin_and_unknown_route_errors():
             new=AsyncMock(side_effect=RuntimeError("tool secret")),
         ),
         patch(
-            "app.services.error_messages.resolve_user_visible_error",
+            "app.services.error_messages.exception_to_user_message",
             return_value="Tool unavailable",
         ),
     ):
@@ -452,7 +452,7 @@ async def test_standalone_http_and_code_helpers():
             new=AsyncMock(side_effect=RuntimeError("sandbox secret")),
         ),
         patch(
-            "app.services.error_messages.resolve_user_visible_error",
+            "app.services.error_messages.exception_to_user_message",
             return_value="Code unavailable",
         ),
     ):

--- a/backend/tests/services/test_error_messages.py
+++ b/backend/tests/services/test_error_messages.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from app.schemas.response import BusinessError
 from app.services import error_messages
 
 
@@ -69,3 +70,48 @@ def test_resolve_user_visible_error_returns_safe_message(monkeypatch):
         "Provider unavailable"
     )
     translate.assert_not_called()
+
+
+def test_exception_to_user_message_translates_business_error(monkeypatch):
+    translate = MagicMock(return_value="Localized failure")
+    monkeypatch.setattr(error_messages, "t", translate)
+
+    error = BusinessError(msg_key="http_tool_url_invalid", status_code=400)
+
+    assert error_messages.exception_to_user_message(error) == "Localized failure"
+    translate.assert_called_once_with("http_tool_url_invalid")
+
+
+def test_exception_to_user_message_translates_business_error_with_kwargs(monkeypatch):
+    translate = MagicMock(return_value="Localized provider message")
+    monkeypatch.setattr(error_messages, "t", translate)
+
+    error = BusinessError(
+        msg_key="media_provider_not_allowed_for_agent", provider="openai"
+    )
+
+    assert (
+        error_messages.exception_to_user_message(error) == "Localized provider message"
+    )
+    translate.assert_called_once_with(
+        "media_provider_not_allowed_for_agent", provider="openai"
+    )
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        RuntimeError("Traceback: secret paths"),
+        RuntimeError("sqlite3.OperationalError: no such table: users"),
+        BusinessError(),
+        BusinessError(msg="raw business message"),
+    ],
+)
+def test_exception_to_user_message_never_exposes_exception_text(monkeypatch, error):
+    translate = MagicMock(side_effect=lambda key: f"translated:{key}")
+    monkeypatch.setattr(error_messages, "t", translate)
+
+    assert error_messages.exception_to_user_message(
+        error, fallback_key="tool_execution_failed"
+    ) == ("translated:tool_execution_failed")
+    translate.assert_called_once_with("tool_execution_failed")


### PR DESCRIPTION
Fixes CodeQL alerts #8 and #9 (py/stack-trace-exposure, CWE-209).

**Problem**: `chat_tools.py` exception handlers sent `str(e)` into the SSE stream shown to chat clients. The heuristic sanitizer (`resolve_user_visible_error`) is bypassable — e.g. `"Exception: boom"` passes its checks — so raw exception strings could leak file paths, SQL, or provider internals. Two sinks (`str(e)` for the memory tool and code tool) had no sanitization at all.

**Fix**:
- New `exception_to_user_message(e, fallback_key)`: only exceptions carrying an explicit translation key (`BusinessError`) are surfaced; everything else maps to a localized fallback. Never returns exception text.
- All 8 flagged sinks in `chat_tools.py` (plus the 2 raw `str(e)` sinks) now use the strict mapper.
- HTTP/media executors now raise `BusinessError(msg_key=...)` instead of `ValueError(t(...))` for user-facing validation errors — keeps localized messages, locale-neutral raises.
- `mcp_client.py` exception path uses the strict mapper.

**Tests**: full backend suite 6454 passed; new tests assert exception text never reaches user output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across chat, media generation, HTTP, MCP, file, and code tools.
  * User-facing errors now provide localized, consistent messages without exposing raw technical details.
  * Added structured validation for unsupported URLs and invalid media inputs.

* **Tests**
  * Expanded coverage for localized error messages, fallback behavior, validation failures, and tool execution errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->