### PR TITLE
fix(security): resolve remaining CodeQL alerts

### DIFF
--- a/backend/app/api/v1/endpoints/sso.py
+++ b/backend/app/api/v1/endpoints/sso.py
@@ -104,10 +104,11 @@ async def sso_login(
     """Initiate SSO login flow"""
     provider = await SSOProvider.get_or_none(name=provider_name, is_enabled=True)
     if not provider:
-        return await _sso_error_redirect("sso_provider_not_found", redirect)
+        return await _sso_error_redirect("sso_provider_not_found")
 
     session_id = secrets.token_urlsafe(32)
     expires_at = now_utc() + timedelta(minutes=10)
+    safe_redirect = _safe_sso_redirect(redirect)
 
     try:
         provider_instance = SSOService.get_provider_instance(provider)
@@ -131,7 +132,7 @@ async def sso_login(
                 provider=provider,
                 code_verifier=code_verifier,
                 nonce=nonce,
-                redirect_url=redirect,
+                redirect_url=safe_redirect,
                 expires_at=expires_at,
             )
 
@@ -144,7 +145,7 @@ async def sso_login(
             await SSOSession.create(
                 session_id=session_id,
                 provider=provider,
-                redirect_url=redirect,
+                redirect_url=safe_redirect,
                 expires_at=expires_at,
             )
 
@@ -157,7 +158,7 @@ async def sso_login(
             await SSOSession.create(
                 session_id=session_id,
                 provider=provider,
-                redirect_url=redirect,
+                redirect_url=safe_redirect,
                 expires_at=expires_at,
             )
 
@@ -173,7 +174,7 @@ async def sso_login(
         logger.exception(
             "Failed to initialize SSO login for provider %s", provider_name
         )
-        return await _sso_error_redirect("sso_login_failed", redirect)
+        return await _sso_error_redirect("sso_login_failed")
 
 
 @router.get("/callback/{provider_name}")

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -14,7 +14,7 @@ import re
 import shutil
 import tempfile
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from urllib.parse import urlparse
 from typing import Any
 from uuid import UUID
@@ -23,6 +23,7 @@ from app.models.knowledge_base import (
     DocumentType,
 )
 from app.services.upload_storage import get_upload_storage_backend
+from app.services.skill_package import resolve_child_path
 import bleach
 
 logger = logging.getLogger(__name__)
@@ -113,17 +114,25 @@ class DocumentProcessor:
     def _storage_key(self, path: str) -> str:
         if path.startswith("s3://"):
             parsed = urlparse(path)
-            key = parsed.path.lstrip("/")
-            if not parsed.netloc or not key:
+            key_path = PurePosixPath(parsed.path.lstrip("/"))
+            if not parsed.netloc or not key_path.parts or ".." in key_path.parts:
                 raise ValueError("validation_error")
-            return key
+            return key_path.as_posix()
         if path.startswith("documents/"):
-            return path
+            key_path = PurePosixPath(path)
+            if key_path.is_absolute() or ".." in key_path.parts:
+                raise ValueError("validation_error")
+            return key_path.as_posix()
         root = self._storage_root()
-        candidate = Path(path).resolve()
-        if candidate == root or root not in candidate.parents:
+        candidate = Path(path)
+        try:
+            relative_parts = candidate.relative_to(root).parts
+        except ValueError as exc:
+            raise ValueError("validation_error") from exc
+        resolved = resolve_child_path(root, PurePosixPath(*relative_parts))
+        if resolved is None or resolved == root or root not in resolved.parents:
             raise ValueError("validation_error")
-        return candidate.relative_to(root).as_posix()
+        return resolved.relative_to(root).as_posix()
 
     def _resolve_storage_path(self, *parts: str) -> Path:
         """Resolve a path under the document upload directory."""
@@ -177,7 +186,7 @@ class DocumentProcessor:
         date_path = datetime.now().strftime("%Y/%m")
 
         # Generate unique filename
-        file_hash = hashlib.md5(
+        file_hash = hashlib.sha256(
             f"{kb_id}{safe_filename}{datetime.now().isoformat()}".encode()
         ).hexdigest()[:8]
         ext = os.path.splitext(safe_filename)[1]

--- a/backend/tests/services/test_document_processor_branches.py
+++ b/backend/tests/services/test_document_processor_branches.py
@@ -49,6 +49,8 @@ def test_paths_and_media_resource_cleanup(processor):
     for invalid in (
         str(processor._storage_root()),
         str(processor._storage_root() / ".."),
+        "documents/../outside.txt",
+        "s3://bucket/../outside.txt",
     ):
         with pytest.raises(ValueError, match="validation_error"):
             processor._storage_key(invalid)

--- a/backend/tests/test_feishu_issue255.py
+++ b/backend/tests/test_feishu_issue255.py
@@ -1,3 +1,4 @@
+import ast
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -165,7 +166,8 @@ async def test_app_message_guards_and_posts_card(monkeypatch):
     )
     assert args.kwargs["headers"]["Authorization"] == "Bearer token"
     assert args.kwargs["json"]["receive_id"] == "chat"
-    assert "https://app.test" in args.kwargs["json"]["content"]
+    card = ast.literal_eval(args.kwargs["json"]["content"])["card"]
+    assert card["elements"][1]["actions"][0]["url"] == "https://app.test"
 
 
 @pytest.mark.anyio

--- a/frontend/app/(platform)/app/apps/workflow/[id]/_components/node-config/configs/index.test.ts
+++ b/frontend/app/(platform)/app/apps/workflow/[id]/_components/node-config/configs/index.test.ts
@@ -9,7 +9,7 @@ const modules = [
 ]
 
 for (const name of modules) {
-  const componentName = name.split('-').map((part) => part[0].toUpperCase() + part.slice(1)).join('').replace('Config', 'Config')
+  const componentName = name.split('-').map((part) => part[0].toUpperCase() + part.slice(1)).join('')
   mock.module(`./${name}`, () => ({
     [componentName]: componentName,
     ...(name === 'llm-node-config' ? { LLMNodeConfig: 'LLMNodeConfig', defaultLLMNodeConfig: { model: 'llm' } } : {}),

--- a/frontend/components/chat/message.test.tsx
+++ b/frontend/components/chat/message.test.tsx
@@ -642,6 +642,8 @@ describe('message behavior', () => {
 
     const blocked = render(React.createElement(components.img, { src: 'javascript:alert(1)', alt: 'Blocked image' }))
     expect(blocked.textContent).toContain('Blocked image')
+    const vbscript = render(React.createElement(components.img, { src: 'vbscript:alert(1)', alt: 'Blocked vbscript image' }))
+    expect(vbscript.textContent).toContain('Blocked vbscript image')
     const external = render(React.createElement(components.img, { src: 'https://example.test/image.png', alt: 'External image' }))
     expect(external.querySelector('img')?.getAttribute('loading')).toBe('lazy')
   })

--- a/frontend/components/chat/message.tsx
+++ b/frontend/components/chat/message.tsx
@@ -1675,7 +1675,7 @@ function getAuthenticatedApiAssetUrl(src: string): string | null {
 
 function isBlockedImageSrc(src: string): boolean {
   const normalized = src.trim().toLowerCase()
-  return normalized.startsWith('javascript:') || normalized.startsWith('data:')
+  return normalized.startsWith('javascript:') || normalized.startsWith('data:') || normalized.startsWith('vbscript:')
 }
 
 type AuthenticatedMarkdownImageCacheEntry = {

--- a/frontend/components/knowledge-bases/retrieval-lab/index.tsx
+++ b/frontend/components/knowledge-bases/retrieval-lab/index.tsx
@@ -117,7 +117,8 @@ function AuthenticatedMarkdownImage({ src = '', alt = '' }: { src?: string; alt?
   React.useEffect(() => {
     let cancelled = false
     setFailed(false)
-    if (!src || src.startsWith('data:') || src.startsWith('javascript:')) {
+    const normalized = src.trim().toLowerCase()
+    if (!src || normalized.startsWith('data:') || normalized.startsWith('javascript:') || normalized.startsWith('vbscript:')) {
       setObjectUrl(null)
       setFailed(Boolean(src))
       return


### PR DESCRIPTION
Fixes CodeQL alerts #51–#57 found by the refreshed main-branch scan.\n\n- #51: remove the no-op Config-to-Config replacement in workflow config tests.\n- #52/#53: block vbscript: image sources (and normalize retrieval-lab scheme checks).\n- #54: validate document storage paths through the safe child-path resolver; reject traversal in local, logical, and S3 keys.\n- #55: replace MD5 filename derivation with SHA-256.\n- #56: assert the Feishu card URL structurally instead of substring matching.\n- #57: sanitize SSO redirects before persisting them and stop reflecting the raw login query redirect on early errors.\n\nVerification: backend full suite 6455 passed, 3 skipped, 97% coverage; frontend targeted suite 30 passed; frontend lint passed. The full frontend run emitted an existing large coverage report that exceeded the local tool capture limit; PR CI will run the complete frontend check.