### PR TITLE
feat: 限制 bash 工具为安全输出降噪 (YUN-125)

### DIFF
--- a/backend/app/core/i18n_legacy.py
+++ b/backend/app/core/i18n_legacy.py
@@ -244,6 +244,14 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "zh": "备份码已重新生成",
     },
     "bad_request": {"en": "Bad request", "zh": "错误请求"},
+    "bash_output_lines_omitted": {
+        "en": "... [{count} lines omitted] ...",
+        "zh": "... [已省略 {count} 行] ...",
+    },
+    "bash_output_repeated_lines": {
+        "en": "[repeated {count} times]",
+        "zh": "[重复 {count} 次]",
+    },
     "builtin_tool_artifact": {"en": "Create Download Link", "zh": "生成下载链接"},
     "builtin_tool_artifact_description": {
         "en": "Collect existing files or directories from /workspace and return fresh Markdown download links plus preview metadata. Call this only after verifying final user-facing files. If write, edit, or bash changes a collected file, call artifact again because earlier URLs are stale snapshots. Include the newest returned Markdown links in the final response body. Relative paths are interpreted from /workspace.",

--- a/backend/app/llm/tools/bash.py
+++ b/backend/app/llm/tools/bash.py
@@ -16,6 +16,7 @@ from app.services.sandbox.models import (
 )
 
 from .registry import ToolInfo, ToolParameter, tool_registry
+from .bash_output import denoise_output
 
 logger = logging.getLogger(__name__)
 
@@ -73,13 +74,20 @@ class BashSandboxTool:
                 timeout_seconds=timeout + 5,
             )
 
+            failed = not result.success
             return {
                 "success": result.success,
-                "stdout": self._restore_workspace_paths(
-                    result.stdout, runtime_workspace_root
+                "stdout": denoise_output(
+                    self._restore_workspace_paths(
+                        result.stdout, runtime_workspace_root
+                    ),
+                    failed=failed,
                 ),
-                "stderr": self._restore_workspace_paths(
-                    result.stderr, runtime_workspace_root
+                "stderr": denoise_output(
+                    self._restore_workspace_paths(
+                        result.stderr, runtime_workspace_root
+                    ),
+                    failed=failed,
                 ),
                 "exit_code": result.metadata.exit_code,
                 "timed_out": result.status == SandboxTaskStatus.FAILED

--- a/backend/app/llm/tools/bash_output.py
+++ b/backend/app/llm/tools/bash_output.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import json
 import re
 
+from app.core.i18n import t
+
 # ---------------------------------------------------------------------------
 # Tunables
 # ---------------------------------------------------------------------------
@@ -38,7 +40,7 @@ _COLLAPSE_THRESHOLD = 4
 #: OSC sequences (title-set, hyperlinks, etc.) terminated by BEL or ST.
 _ANSI_OSC_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
 #: CSI sequences (SGR colours, cursor moves, erase, etc.).
-_ANSI_CSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+_ANSI_CSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 #: Other two-byte escape sequences (single-char after ESC).
 _ANSI_OTHER_RE = re.compile(r"\x1b[@-_]")
 
@@ -58,9 +60,8 @@ def denoise_output(text: str | None, *, failed: bool = False) -> str | None:
     if not text:
         return text
 
-    structured = _looks_structured(text)
-
     cleaned = _strip_ansi(text)
+    structured = _looks_structured(cleaned)
     cleaned = _fold_progress_overwrites(cleaned)
     cleaned = _compress_blank_lines(cleaned)
 
@@ -149,7 +150,7 @@ def _collapse_repeated_lines(text: str) -> str:
         run_len = run_end - i
         if run_len > _COLLAPSE_THRESHOLD:
             result.append(lines[i])
-            result.append(f"[repeated {run_len} times]")
+            result.append(t("bash_output_repeated_lines", count=run_len))
         else:
             result.extend(lines[i:run_end])
         i = run_end
@@ -162,10 +163,10 @@ def _collapse_repeated_lines(text: str) -> str:
 
 
 def _failure_window(text: str) -> str:
-    lines = text.split("\n")
+    lines = text.splitlines()
     if len(lines) <= _MAX_LINES_BEFORE_WINDOW:
         return text
     head = lines[:_WINDOW_HEAD]
     tail = lines[-_WINDOW_TAIL:]
     omitted = len(lines) - _WINDOW_HEAD - _WINDOW_TAIL
-    return "\n".join([*head, f"... [{omitted} lines omitted] ...", *tail])
+    return "\n".join([*head, t("bash_output_lines_omitted", count=omitted), *tail])

--- a/backend/app/llm/tools/bash_output.py
+++ b/backend/app/llm/tools/bash_output.py
@@ -1,0 +1,171 @@
+"""Safe output denoising for the bash sandbox tool.
+
+Only general-purpose noise removal - never content editing. Editing
+responsibilities belong to a dedicated ``edit`` tool.
+
+Capabilities (in application order):
+
+1. ANSI cleanup          - strip colour/cursor escape sequences
+2. progress-overwrite    - fold ``\\r`` progress bars to final state
+3. blank-line compression - collapse runs of blank lines to one
+4. repeated-line collapse - collapse long runs of identical lines
+5. failure-diagnosis     - head+tail window on failed long output
+6. structured-output guard - skip destructive steps for JSON
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+#: Lines of output beyond which a failure-diagnosis window is applied.
+_MAX_LINES_BEFORE_WINDOW = 200
+#: Lines retained from the head when windowing.
+_WINDOW_HEAD = 20
+#: Lines retained from the tail when windowing.
+_WINDOW_TAIL = 40
+#: Runs of identical consecutive lines longer than this are collapsed.
+_COLLAPSE_THRESHOLD = 4
+
+# ---------------------------------------------------------------------------
+# Regexes
+# ---------------------------------------------------------------------------
+
+#: OSC sequences (title-set, hyperlinks, etc.) terminated by BEL or ST.
+_ANSI_OSC_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+#: CSI sequences (SGR colours, cursor moves, erase, etc.).
+_ANSI_CSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+#: Other two-byte escape sequences (single-char after ESC).
+_ANSI_OTHER_RE = re.compile(r"\x1b[@-_]")
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def denoise_output(text: str | None, *, failed: bool = False) -> str | None:
+    """Apply safe output denoising to a command output stream.
+
+    Non-destructive steps (ANSI cleanup, progress folding, blank-line
+    compression) always run. Destructive steps (repeated-line collapse,
+    failure-diagnosis windowing) are skipped when the output is structured
+    JSON so that array shape and element counts are preserved.
+    """
+    if not text:
+        return text
+
+    structured = _looks_structured(text)
+
+    cleaned = _strip_ansi(text)
+    cleaned = _fold_progress_overwrites(cleaned)
+    cleaned = _compress_blank_lines(cleaned)
+
+    if structured:
+        return cleaned
+
+    cleaned = _collapse_repeated_lines(cleaned)
+    if failed:
+        cleaned = _failure_window(cleaned)
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# Structured-output guard
+# ---------------------------------------------------------------------------
+
+
+def _looks_structured(text: str) -> bool:
+    """Return True when *text* is parseable JSON (array or object)."""
+    stripped = text.lstrip()
+    if not stripped or stripped[0] not in "{[":
+        return False
+    try:
+        json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# 1. ANSI cleanup
+# ---------------------------------------------------------------------------
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_OTHER_RE.sub("", _ANSI_CSI_RE.sub("", _ANSI_OSC_RE.sub("", text)))
+
+
+# ---------------------------------------------------------------------------
+# 2. progress-overwrite folding
+# ---------------------------------------------------------------------------
+
+
+def _fold_progress_overwrites(text: str) -> str:
+    # Normalise Windows line endings first so trailing \r before \n is
+    # not mistaken for a progress overwrite.
+    text = text.replace("\r\n", "\n")
+    if "\r" not in text:
+        return text
+    return "\n".join(line.split("\r")[-1] for line in text.split("\n"))
+
+
+# ---------------------------------------------------------------------------
+# 3. blank-line compression
+# ---------------------------------------------------------------------------
+
+
+def _compress_blank_lines(text: str) -> str:
+    lines = text.split("\n")
+    result: list[str] = []
+    prev_blank = False
+    for line in lines:
+        is_blank = line.strip() == ""
+        if is_blank and prev_blank:
+            continue
+        result.append(line)
+        prev_blank = is_blank
+    return "\n".join(result)
+
+
+# ---------------------------------------------------------------------------
+# 4. collapsing consecutive repeated lines
+# ---------------------------------------------------------------------------
+
+
+def _collapse_repeated_lines(text: str) -> str:
+    lines = text.split("\n")
+    if len(lines) <= _COLLAPSE_THRESHOLD:
+        return text
+    result: list[str] = []
+    i = 0
+    while i < len(lines):
+        run_end = i + 1
+        while run_end < len(lines) and lines[run_end] == lines[i]:
+            run_end += 1
+        run_len = run_end - i
+        if run_len > _COLLAPSE_THRESHOLD:
+            result.append(lines[i])
+            result.append(f"[repeated {run_len} times]")
+        else:
+            result.extend(lines[i:run_end])
+        i = run_end
+    return "\n".join(result)
+
+
+# ---------------------------------------------------------------------------
+# 5. failure-diagnosis window
+# ---------------------------------------------------------------------------
+
+
+def _failure_window(text: str) -> str:
+    lines = text.split("\n")
+    if len(lines) <= _MAX_LINES_BEFORE_WINDOW:
+        return text
+    head = lines[:_WINDOW_HEAD]
+    tail = lines[-_WINDOW_TAIL:]
+    omitted = len(lines) - _WINDOW_HEAD - _WINDOW_TAIL
+    return "\n".join([*head, f"... [{omitted} lines omitted] ...", *tail])

--- a/backend/app/locales/en/LC_MESSAGES/messages.po
+++ b/backend/app/locales/en/LC_MESSAGES/messages.po
@@ -570,6 +570,12 @@ msgstr "Backup codes regenerated successfully"
 msgid "bad_request"
 msgstr "Bad request"
 
+msgid "bash_output_lines_omitted"
+msgstr "... [{count} lines omitted] ..."
+
+msgid "bash_output_repeated_lines"
+msgstr "[repeated {count} times]"
+
 msgid "builtin_tool_artifact"
 msgstr "Create Download Link"
 

--- a/backend/app/locales/zh/LC_MESSAGES/messages.po
+++ b/backend/app/locales/zh/LC_MESSAGES/messages.po
@@ -570,6 +570,12 @@ msgstr "备份码已重新生成"
 msgid "bad_request"
 msgstr "错误请求"
 
+msgid "bash_output_lines_omitted"
+msgstr "... [已省略 {count} 行] ..."
+
+msgid "bash_output_repeated_lines"
+msgstr "[重复 {count} 次]"
+
 msgid "builtin_tool_artifact"
 msgstr "生成下载链接"
 

--- a/backend/tests/llm/test_bash_output.py
+++ b/backend/tests/llm/test_bash_output.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -19,6 +21,11 @@ from app.services.sandbox.models import SandboxResult, SandboxTaskStatus
 def test_strip_ansi_sgr_colour_codes():
     text = "\x1b[32mok\x1b[0m\n\x1b[1;31merror\x1b[0m"
     assert denoise_output(text) == "ok\nerror"
+
+
+def test_strip_ansi_colon_form_true_color():
+    text = "\x1b[38:2::255:0:0mred\x1b[0m\x1b[38;5;208morange\x1b[0m"
+    assert denoise_output(text) == "redorange"
 
 
 def test_strip_ansi_osc_title_and_hyperlink():
@@ -121,6 +128,12 @@ def test_failure_window_skipped_for_short_output():
     assert result == text
 
 
+def test_failure_window_boundary_200_lines_with_trailing_newline():
+    text = "\n".join(f"line {i}" for i in range(200)) + "\n"
+    result = denoise_output(text, failed=True)
+    assert result == text
+
+
 # ---------------------------------------------------------------------------
 # 6. structured-output guard
 # ---------------------------------------------------------------------------
@@ -141,6 +154,16 @@ def test_structured_json_object_keeps_repeated_values():
 def test_structured_json_with_ansi_still_cleaned():
     text = '\x1b[32m{"ok": true}\x1b[0m'
     assert denoise_output(text) == '{"ok": true}'
+
+
+def test_structured_ansi_wrapped_json_not_windowed_on_failure():
+    # ANSI-wrapped JSON exceeding 200 lines on failure must not be windowed
+    inner = ",\n".join('  {"v": 1}' for _ in range(250))
+    text = "\x1b[32m[\n" + inner + "\n]\x1b[0m"
+    result = denoise_output(text, failed=True)
+    parsed = json.loads(result)
+    assert isinstance(parsed, list)
+    assert len(parsed) == 250
 
 
 def test_non_json_starting_with_brace_not_protected():

--- a/backend/tests/llm/test_bash_output.py
+++ b/backend/tests/llm/test_bash_output.py
@@ -1,0 +1,202 @@
+"""Tests for the bash output denoising module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.llm.tools.bash import BashSandboxTool
+from app.llm.tools.bash_output import denoise_output
+from app.services.sandbox.models import SandboxResult, SandboxTaskStatus
+
+
+# ---------------------------------------------------------------------------
+# 1. ANSI cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_strip_ansi_sgr_colour_codes():
+    text = "\x1b[32mok\x1b[0m\n\x1b[1;31merror\x1b[0m"
+    assert denoise_output(text) == "ok\nerror"
+
+
+def test_strip_ansi_osc_title_and_hyperlink():
+    text = "\x1b]0;my title\x07visible\x1b]8;;https://x\x1b\\link\x1b]8;;\x1b\\"
+    assert denoise_output(text) == "visiblelink"
+
+
+def test_strip_ansi_cursor_and_single_char_escapes():
+    text = "\x1b[2J\x1b[Hcleared\x1bM"
+    assert denoise_output(text) == "cleared"
+
+
+# ---------------------------------------------------------------------------
+# 2. progress-overwrite folding
+# ---------------------------------------------------------------------------
+
+
+def test_fold_progress_overwrite_keeps_final_state():
+    text = "downloading 10%\rdownloading 50%\rdownloading 100%\ndone\n"
+    assert denoise_output(text) == "downloading 100%\ndone\n"
+
+
+def test_fold_preserves_windows_line_endings():
+    text = "line1\r\nline2\r\n"
+    assert denoise_output(text) == "line1\nline2\n"
+
+
+def test_fold_no_carriage_returns_unchanged():
+    text = "plain output\nno cr here"
+    assert denoise_output(text) == "plain output\nno cr here"
+
+
+# ---------------------------------------------------------------------------
+# 3. blank-line compression
+# ---------------------------------------------------------------------------
+
+
+def test_compress_blank_line_runs():
+    text = "a\n\n\n\nb\n\n\nc"
+    assert denoise_output(text) == "a\n\nb\n\nc"
+
+
+def test_compress_leading_and_trailing_blanks():
+    text = "\n\n\nhello\n\n"
+    assert denoise_output(text) == "\nhello\n"
+
+
+# ---------------------------------------------------------------------------
+# 4. collapsing consecutive repeated lines
+# ---------------------------------------------------------------------------
+
+
+def test_collapse_long_run_of_identical_lines():
+    text = "\n".join(["Downloading..."] * 10 + ["Done"])
+    result = denoise_output(text)
+    assert result == "Downloading...\n[repeated 10 times]\nDone"
+
+
+def test_collapse_short_run_unchanged():
+    text = "\n".join(["hi"] * 3 + ["bye"])
+    assert denoise_output(text) == "hi\nhi\nhi\nbye"
+
+
+def test_collapse_multiple_runs():
+    text = "\n".join(["a"] * 6 + ["b"] * 5 + ["c"])
+    result = denoise_output(text)
+    assert result == "a\n[repeated 6 times]\nb\n[repeated 5 times]\nc"
+
+
+def test_collapse_below_threshold_short_text_unchanged():
+    text = "\n".join(["x"] * 3)
+    assert denoise_output(text) == "x\nx\nx"
+
+
+# ---------------------------------------------------------------------------
+# 5. failure-diagnosis window
+# ---------------------------------------------------------------------------
+
+
+def test_failure_window_truncates_long_failed_output():
+    text = "\n".join(f"line {i}" for i in range(250))
+    result = denoise_output(text, failed=True)
+    lines = result.split("\n")
+    # 20 head + 1 marker + 40 tail = 61
+    assert len(lines) == 61
+    assert lines[20] == "... [190 lines omitted] ..."
+    assert lines[0] == "line 0"
+    assert lines[-1] == "line 249"
+
+
+def test_failure_window_skipped_on_success():
+    text = "\n".join(f"line {i}" for i in range(250))
+    result = denoise_output(text, failed=False)
+    assert result == text
+
+
+def test_failure_window_skipped_for_short_output():
+    text = "\n".join(f"line {i}" for i in range(100))
+    result = denoise_output(text, failed=True)
+    assert result == text
+
+
+# ---------------------------------------------------------------------------
+# 6. structured-output guard
+# ---------------------------------------------------------------------------
+
+
+def test_structured_json_array_not_collapsed_on_failure():
+    text = "[\n" + ",\n".join('  {"v": 1}' for _ in range(50)) + "\n]"
+    result = denoise_output(text, failed=True)
+    # JSON preserved - no windowing, no collapse
+    assert result == text
+
+
+def test_structured_json_object_keeps_repeated_values():
+    text = '{"a": 1, "b": 1, "c": 1}'
+    assert denoise_output(text) == text
+
+
+def test_structured_json_with_ansi_still_cleaned():
+    text = '\x1b[32m{"ok": true}\x1b[0m'
+    assert denoise_output(text) == '{"ok": true}'
+
+
+def test_non_json_starting_with_brace_not_protected():
+    # Looks like JSON but isn't - destructive steps still apply
+    text = "{not json}\n" * 10
+    result = denoise_output(text, failed=False)
+    assert "[repeated" in result
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_none_input_returns_none():
+    assert denoise_output(None) is None
+
+
+def test_empty_string_returns_empty():
+    assert denoise_output("") == ""
+
+
+def test_whitespace_only_compressed_to_single_blank():
+    assert denoise_output("   \n   \n   ") == "   "
+
+
+# ---------------------------------------------------------------------------
+# Integration with BashSandboxTool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_bash_tool_denoises_stdout_and_stderr():
+    from pathlib import Path
+
+    tool = BashSandboxTool(session_id="session-1", workspace_root="/workspace")
+    workspace = type("Workspace", (), {"root": Path("/tmp/sessions/abc")})()
+    fake_result = SandboxResult(
+        job_id="job-1",
+        success=False,
+        status=SandboxTaskStatus.FAILED,
+        stdout="\x1b[32mok\x1b[0m\n" + "\n".join(["step"] * 10),
+        stderr="\x1b[31merr\x1b[0m\nprogress\n",
+    )
+
+    with (
+        patch(
+            "app.llm.tools.bash.sandbox_gateway.get_session_workspace",
+            new=AsyncMock(return_value=workspace),
+        ),
+        patch(
+            "app.llm.tools.bash.sandbox_gateway.submit_and_wait",
+            new=AsyncMock(return_value=fake_result),
+        ),
+    ):
+        result = await tool.execute(command="test", cwd="/workspace")
+
+    assert result["stdout"] == "ok\nstep\n[repeated 10 times]"
+    assert result["stderr"] == "err\nprogress\n"


### PR DESCRIPTION
## 背景

YUN-125 要求将沙盒 bash 工具的输出处理限定为安全降噪，不承担内容编辑职责（编辑应由专用 `edit` 工具负责）。当前 bash 工具直接透传原始 stdout/stderr，缺少 ANSI 清理、进度条折叠等降噪能力，导致 Agent 上下文被噪声输出污染。

## 改动内容

新增 `backend/app/llm/tools/bash_output.py` 输出降噪模块，实现 6 项安全降噪能力：

1. **ANSI 清理** — 剥离 SGR 色彩、OSC 标题/超链接、光标控制等转义序列
2. **进度覆写折叠** — 将 `\r` 进度条折叠为最终状态（先归一化 `\r\n` 再折叠裸 `\r`）
3. **连续空行压缩** — 多个连续空行压缩为单行
4. **连续重复行折叠** — 超过阈值的连续相同行折叠为一行 + `[repeated N times]` 标记
5. **失败诊断窗口** — 命令失败且输出过长时保留头 20 行 + 尾 40 行 + 省略标记
6. **结构化输出保护** — JSON 输出跳过破坏性步骤（折叠/窗口），仅做 ANSI 清理

修改 `backend/app/llm/tools/bash.py`，在路径还原后对 stdout/stderr 应用 `denoise_output(failed=not result.success)`。

## 验证方式

- `uv run pytest tests/llm/test_bash_output.py tests/llm/test_bash_tool.py tests/llm/test_bash_sandbox_tool.py --no-cov -q` — 39 passed
- `uv run pytest -q && uv run python scripts/check_coverage.py` — 6568 passed, 行覆盖 97.56%, 分支覆盖 95.02%
- `bash_output.py` 覆盖率 100%
- 现有 bash 工具测试全部通过（降噪不改变无噪声输出的行为）

## 风险与影响

- **影响范围**：仅影响 bash 工具返回的 stdout/stderr 文本，不影响命令执行逻辑
- **行为变化**：带 ANSI/进度条的输出现在会被清理；失败时的超长输出会被窗口截断
- **结构化保护**：JSON 输出不受破坏性步骤影响，数组形状和元素计数保持不变
- **回滚**：删除 `bash_output.py` 并从 `bash.py` 移除 `denoise_output` 调用即可完全回退

## 关联信息

Closes #344


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bash command output readability by removing terminal formatting artifacts and consolidating progress updates.
  * Reduced excessive blank lines and repeated output.
  * Preserved parseable JSON output and retained the most relevant portions of lengthy failed-command output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->