### PR TITLE
fix(ci): base release notes on stable tags

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -132,7 +132,26 @@ jobs:
       - build-frontend
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Find previous stable tag
+        id: previous-tag
+        shell: bash
+        run: |
+          previous_tag=""
+          while IFS= read -r tag; do
+            if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && "$tag" != "$GITHUB_REF_NAME" ]]; then
+              previous_tag="$tag"
+              break
+            fi
+          done < <(git tag --merged "$GITHUB_SHA" --sort=-version:refname)
+          echo "tag=$previous_tag" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+          previous_tag: ${{ steps.previous-tag.outputs.tag }}


### PR DESCRIPTION
## Summary
- keep creating GitHub Releases for beta tags
- find the latest stable `vX.Y.Z` tag in the tagged commit history
- pass that tag as `previous_tag` so generated notes do not use a beta tag as the comparison base

## Verification
- parsed `.github/workflows/build-images.yml` successfully as YAML
- verified both `v0.3.0-beta.4` and `v0.3.0` select `v0.2.9` as the release-notes baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Improvements**
  * Release notes now include changes since the most recent stable version.
  * Release comparisons use the latest merged semantic-version tag for more accurate summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->