### PR TITLE
feat(deploy): support distributed uploads and Kubernetes installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,28 +178,20 @@ Supports 24+ providers out of the box, plus any OpenAI-compatible endpoint.
 ## Quick Start
 ### Prerequisites
 
-- Docker & Docker Compose
+- Docker and Docker Compose v2 for single-server deployment
+- `kubectl` and Helm 3 for Kubernetes deployment
 
 > For development from source, see the [Development Guide](docs/guide/getting-started/development.md).
 
-### 1. Configure Environment
+### 1. Run the Guided Installer
 
 ```bash
-# Copy the Docker deployment environment file
-cp deploy/.env.example deploy/.env
-
-# Edit deploy/.env with secure random values for:
-#   SECRET_KEY, POSTGRES_PASSWORD, REDIS_PASSWORD, QDRANT_API_KEY
+curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
 ```
 
-### 2. Start Clouisle
+Choose Docker Compose for a single server or Helm for Kubernetes. Docker mode interactively selects an installation directory, defaulting to `/opt/clouisle`. The installer generates required secrets and validates the selected deployment before starting it.
 
-```bash
-cd deploy
-docker compose --env-file .env up -d
-```
-
-### 3. Access the Application
+### 2. Access the Application
 
 - **Frontend**: http://localhost:3000
 - **API Documentation**: http://localhost:8000/docs

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Supports 24+ providers out of the box, plus any OpenAI-compatible endpoint.
 ### Prerequisites
 
 - Docker and Docker Compose v2 for single-server deployment
-- `kubectl` and Helm 3 for Kubernetes deployment
+- `kubectl` for Kubernetes deployment; Helm 3 only when using the Helm chart
 
 > For development from source, see the [Development Guide](docs/guide/getting-started/development.md).
 
@@ -189,7 +189,7 @@ Supports 24+ providers out of the box, plus any OpenAI-compatible endpoint.
 curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
 ```
 
-Choose Docker Compose for a single server or Helm for Kubernetes. Docker mode interactively selects an installation directory, defaulting to `/opt/clouisle`. The installer generates required secrets and validates the selected deployment before starting it.
+Choose Docker Compose for a single server, Helm for Kubernetes, or a generated single-file Kubernetes manifest. Docker mode interactively selects an installation directory, defaulting to `/opt/clouisle`. The manifest generator writes a separate secret-filled file for review and explicit `kubectl apply`; it does not modify the template or apply to a cluster.
 
 ### 2. Access the Application
 

--- a/backend/app/api/v1/endpoints/internal_uploads.py
+++ b/backend/app/api/v1/endpoints/internal_uploads.py
@@ -1,0 +1,123 @@
+"""Internal file endpoints for the upload gateway.
+
+The Celery worker (``UPLOAD_STORAGE_MODE=remote``) has no local uploads
+volume; every file operation it needs (read document bytes, save/delete
+extracted media assets, delete files) is an explicit HTTP call to these
+endpoints. The ``api`` process is the sole owner of the uploads directory.
+
+Security:
+- Every handler requires ``Authorization: Bearer {INTERNAL_API_TOKEN}``
+  (constant-time compare).
+- When ``INTERNAL_API_TOKEN`` is unset the router fails closed with 404 so the
+  endpoints behave as if they do not exist.
+- The router is mounted at ``/internal`` and must never be exposed publicly
+  (Ingress routes only ``/api`` and ``/``); the worker reaches it via the api
+  ClusterIP service directly.
+"""
+
+import hmac
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response
+
+from app.api.v1.endpoints.upload import UPLOAD_ROOT
+from app.core.config import settings
+from app.services.document_processor import document_processor
+from app.services.upload_storage import get_upload_storage_backend
+
+router = APIRouter()
+
+
+def _token_matches(token: str, authorization: str | None) -> bool:
+    if not authorization:
+        return False
+    scheme, _, credentials = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not credentials:
+        return False
+    return hmac.compare_digest(credentials, token)
+
+
+async def require_internal_token(
+    authorization: str | None = Header(default=None),
+) -> None:
+    token = settings.get_internal_api_token()
+    if not token:
+        # Fail closed: unconfigured gateway looks like it does not exist.
+        raise HTTPException(status_code=404, detail="Not Found")
+    if not _token_matches(token, authorization):
+        raise HTTPException(
+            status_code=401,
+            detail="Unauthorized",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+@router.get("/uploads/read")
+async def read_upload(
+    key: str = Query(...),
+    _: None = Depends(require_internal_token),
+) -> Response:
+    storage = await get_upload_storage_backend(UPLOAD_ROOT)
+    if not await storage.exists(key):
+        raise HTTPException(status_code=404, detail="Not Found")
+    return await storage.response(key)
+
+
+@router.put("/uploads/save")
+async def save_upload(
+    request: Request,
+    key: str = Query(...),
+    _: None = Depends(require_internal_token),
+) -> dict[str, str]:
+    content = await request.body()
+    storage = await get_upload_storage_backend(UPLOAD_ROOT)
+    storage_path = await storage.save(key, content)
+    return {"storage_path": storage_path}
+
+
+@router.head("/uploads/exists")
+async def exists_upload(
+    key: str = Query(...),
+    _: None = Depends(require_internal_token),
+) -> Response:
+    storage = await get_upload_storage_backend(UPLOAD_ROOT)
+    if not await storage.exists(key):
+        raise HTTPException(status_code=404, detail="Not Found")
+    return Response(status_code=200)
+
+
+@router.delete("/uploads/delete")
+async def delete_upload(
+    key: str = Query(...),
+    _: None = Depends(require_internal_token),
+) -> Response:
+    storage = await get_upload_storage_backend(UPLOAD_ROOT)
+    await storage.delete(key)
+    return Response(status_code=204)
+
+
+@router.put("/uploads/media/{kb_id}/{doc_id}")
+async def save_media_asset(
+    request: Request,
+    kb_id: UUID,
+    doc_id: UUID,
+    _: None = Depends(require_internal_token),
+) -> dict[str, object]:
+    content = await request.body()
+    content_type = request.headers.get("Content-Type", "application/octet-stream")
+    return await document_processor._save_media_asset(
+        kb_id=kb_id,
+        document_id=doc_id,
+        content_type=content_type,
+        content=content,
+    )
+
+
+@router.delete("/uploads/media/{kb_id}/{doc_id}")
+async def delete_media_assets(
+    kb_id: UUID,
+    doc_id: UUID,
+    _: None = Depends(require_internal_token),
+) -> Response:
+    await document_processor.delete_media_assets(kb_id, doc_id)
+    return Response(status_code=204)

--- a/backend/app/api/v1/endpoints/internal_uploads.py
+++ b/backend/app/api/v1/endpoints/internal_uploads.py
@@ -92,6 +92,8 @@ async def delete_upload(
     _: None = Depends(require_internal_token),
 ) -> Response:
     storage = await get_upload_storage_backend(UPLOAD_ROOT)
+    if not await storage.exists(key):
+        raise HTTPException(status_code=404, detail="Not Found")
     await storage.delete(key)
     return Response(status_code=204)
 

--- a/backend/app/api/v1/endpoints/knowledge_bases.py
+++ b/backend/app/api/v1/endpoints/knowledge_bases.py
@@ -3,7 +3,6 @@ Knowledge Base API endpoints.
 Provides CRUD operations for knowledge bases and documents.
 """
 
-import asyncio
 import logging
 import mimetypes
 from contextvars import ContextVar
@@ -11,7 +10,6 @@ from typing import Any, Optional
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, UploadFile, File, Body, Request
-from fastapi.responses import FileResponse
 from starlette.responses import Response as StarletteResponse
 from tortoise.expressions import F
 from tortoise.transactions import in_transaction
@@ -71,7 +69,7 @@ from app.services.lexical_store import (
     delete_document as delete_lexical_document,
     index_chunk as index_lexical_chunk,
 )
-from app.services.upload_storage import get_upload_storage_backend
+from app.services.upload_storage import LocalUploadStorage, get_upload_storage_backend
 from app.services.error_messages import is_safe_user_visible_error
 from app.services.audit_log import AuditLogService
 from app.services.vector_store import VectorStore, DimensionMismatchError
@@ -1054,7 +1052,7 @@ async def delete_document(
     await vector_store.delete_document_vectors(doc_id)
 
     # Delete extracted media assets if exists
-    await asyncio.to_thread(document_processor.delete_media_assets, kb.id, doc.id)
+    await document_processor.delete_media_assets(kb.id, doc.id)
 
     # Delete file if exists
     if doc.file_path:
@@ -1154,7 +1152,7 @@ async def get_document_media(
     doc_id: UUID,
     filename: str,
     current_user: User = Depends(require_kb_read),
-) -> FileResponse:
+) -> StarletteResponse:
     """
     Get extracted media from a processed document.
     """
@@ -1169,22 +1167,33 @@ async def get_document_media(
         )
 
     try:
-        file_path = document_processor.get_media_asset_path(kb_id, doc_id, filename)
+        safe_filename = document_processor._sanitize_filename(filename)
     except ValueError:
         raise BusinessError(
             code=ResponseCode.VALIDATION_ERROR,
             msg_key="file_not_found",
             status_code=404,
         ) from None
-    if not file_path.exists():
-        raise BusinessError(
-            code=ResponseCode.VALIDATION_ERROR,
-            msg_key="file_not_found",
-            status_code=404,
-        )
 
+    storage_key = f"documents/{kb_id}/media/{doc_id}/{safe_filename}"
+    root = document_processor._storage_root()
+    storage = await get_upload_storage_backend(root)
     media_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
-    return FileResponse(path=file_path, media_type=media_type)
+    if await storage.exists(storage_key):
+        return await storage.response(storage_key, content_type=media_type)
+
+    # Media assets created before this cutover were always local, including
+    # object-storage deployments. Keep them readable until migration/cleanup.
+    if not isinstance(storage, LocalUploadStorage):
+        legacy_storage = LocalUploadStorage(root)
+        if await legacy_storage.exists(storage_key):
+            return await legacy_storage.response(storage_key, content_type=media_type)
+
+    raise BusinessError(
+        code=ResponseCode.VALIDATION_ERROR,
+        msg_key="file_not_found",
+        status_code=404,
+    )
 
 
 @router.post(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from typing import Any
 
 from pydantic import ValidationInfo, field_validator
@@ -9,8 +10,9 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Clouisle"
     API_V1_STR: str = "/api/v1"
 
-    # Server URL (used for internal file access)
+    # Internal service URL; use PUBLIC_API_URL for browser-visible links.
     API_BASE_URL: str = "http://localhost:8000"
+    PUBLIC_API_URL: str | None = None
 
     # Frontend URL (used for SSO redirects)
     FRONTEND_URL: str = "http://localhost:3000"
@@ -117,6 +119,27 @@ class Settings(BaseSettings):
     SANDBOX_ARTIFACT_UPLOAD_API_KEY: str | None = None
     SANDBOX_ARTIFACT_MAX_FILE_SIZE_MB: float = 10.0
     SANDBOX_ARTIFACT_MAX_TOTAL_SIZE_MB: float = 10.0
+
+    # Internal upload gateway (worker -> api file access)
+    # UPLOAD_STORAGE_MODE: "local" (api process) | "remote" (worker process)
+    UPLOAD_STORAGE_MODE: str = "local"
+    API_INTERNAL_BASE_URL: str = ""
+    INTERNAL_API_TOKEN: str = ""
+    INTERNAL_API_TOKEN_FILE: str = ""
+
+    def get_internal_api_token(self) -> str:
+        if self.INTERNAL_API_TOKEN_FILE:
+            try:
+                token = (
+                    Path(self.INTERNAL_API_TOKEN_FILE)
+                    .read_text(encoding="utf-8")
+                    .strip()
+                )
+                if token:
+                    return token
+            except OSError:
+                pass
+        return self.INTERNAL_API_TOKEN
 
     model_config = SettingsConfigDict(
         case_sensitive=True,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.api.v1.api import api_router
 from app.core.config import settings
+from app.api.v1.endpoints.internal_uploads import router as internal_uploads_router
 from app.core.init_data import init_db
 from app.core.i18n import (
     set_language,
@@ -602,6 +603,10 @@ app.add_middleware(LoggingMiddleware)
 app.add_middleware(EmbedHeadersMiddleware)
 
 app.include_router(api_router, prefix=settings.API_V1_STR)
+# Internal upload gateway for worker -> api file access. Mounted outside
+# /api so the Ingress does not expose it publicly; authentication is
+# enforced by the dependency on every request.
+app.include_router(internal_uploads_router, prefix="/internal")
 
 
 @app.get("/")

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -3,7 +3,6 @@ Document processing service for knowledge base.
 Handles document parsing, text extraction, and chunking.
 """
 
-import asyncio
 import base64
 import binascii
 import hashlib
@@ -11,7 +10,6 @@ import logging
 import mimetypes
 import os
 import re
-import shutil
 import tempfile
 from datetime import datetime
 from pathlib import Path, PurePosixPath
@@ -22,11 +20,16 @@ from uuid import UUID
 from app.models.knowledge_base import (
     DocumentType,
 )
-from app.services.upload_storage import get_upload_storage_backend
+from app.services.upload_storage import LocalUploadStorage, get_upload_storage_backend
 from app.services.skill_package import resolve_child_path
 import bleach
+import httpx
 
 logger = logging.getLogger(__name__)
+
+
+class UploadGatewayError(RuntimeError):
+    """A transient failure while the worker is calling the api gateway."""
 
 
 MIME_TYPE_MAP: dict[str, str] = {
@@ -110,6 +113,28 @@ class DocumentProcessor:
 
     def _storage_root(self) -> Path:
         return Path(self.upload_dir).resolve().parent
+
+    # ---- Internal upload gateway (worker remote mode) ----
+    # In "remote" mode the worker process has no local uploads volume; every
+    # file operation is an explicit HTTP call to the api's /internal/uploads/*.
+    def _remote_mode(self) -> bool:
+        from app.core.config import settings
+
+        return settings.UPLOAD_STORAGE_MODE == "remote"
+
+    def _internal_client(self) -> httpx.AsyncClient:
+        from app.core.config import settings
+
+        return httpx.AsyncClient(
+            base_url=settings.API_INTERNAL_BASE_URL.rstrip("/"),
+            headers={"Authorization": f"Bearer {settings.get_internal_api_token()}"},
+            timeout=60.0,
+        )
+
+    def _media_storage_key(self, kb_id: UUID, document_id: UUID, filename: str) -> str:
+        return (
+            f"documents/{kb_id}/media/{document_id}/{self._sanitize_filename(filename)}"
+        )
 
     def _storage_key(self, path: str) -> str:
         if path.startswith("s3://"):
@@ -214,39 +239,77 @@ class DocumentProcessor:
         return len(content)
 
     async def read_file(self, path: str) -> bytes:
-        """
-        Read file content from disk.
-
-        Args:
-            path: File path
-
-        Returns:
-            File content bytes
-        """
+        """Read file content, streaming api gateway responses in remote mode."""
+        storage_key = self._storage_key(path)
+        if self._remote_mode():
+            try:
+                async with self._internal_client() as client:
+                    async with client.stream(
+                        "GET", "/internal/uploads/read", params={"key": storage_key}
+                    ) as resp:
+                        if resp.status_code == 404:
+                            raise FileNotFoundError(storage_key)
+                        resp.raise_for_status()
+                        content = bytearray()
+                        async for chunk in resp.aiter_bytes():
+                            content.extend(chunk)
+                        return bytes(content)
+            except FileNotFoundError:
+                raise
+            except httpx.HTTPError as exc:
+                raise UploadGatewayError(
+                    "Unable to read upload through api gateway"
+                ) from exc
         storage = await get_upload_storage_backend(self._storage_root())
-        return await storage.read(self._storage_key(path))
+        return await storage.read(storage_key)
 
     async def delete_file(self, path: str) -> bool:
-        """
-        Delete a file from upload storage.
-
-        Args:
-            path: File path or storage key
-
-        Returns:
-            True if deleted, False if not found
-        """
-        storage = await get_upload_storage_backend(self._storage_root())
+        """Delete a file from upload storage."""
         storage_key = self._storage_key(path)
+        if self._remote_mode():
+            try:
+                async with self._internal_client() as client:
+                    resp = await client.request(
+                        "DELETE",
+                        "/internal/uploads/delete",
+                        params={"key": storage_key},
+                    )
+                    resp.raise_for_status()
+                    return True
+            except httpx.HTTPError as exc:
+                raise UploadGatewayError(
+                    "Unable to delete upload through api gateway"
+                ) from exc
+        storage = await get_upload_storage_backend(self._storage_root())
         if not await storage.exists(storage_key):
             return False
         await storage.delete(storage_key)
         return True
 
-    def delete_media_assets(self, kb_id: UUID, document_id: UUID) -> None:
-        asset_dir = self._resolve_storage_path(str(kb_id), "media", str(document_id))
-        if asset_dir.exists():
-            shutil.rmtree(asset_dir, ignore_errors=True)
+    async def delete_media_assets(self, kb_id: UUID, document_id: UUID) -> None:
+        if self._remote_mode():
+            try:
+                async with self._internal_client() as client:
+                    resp = await client.delete(
+                        f"/internal/uploads/media/{kb_id}/{document_id}"
+                    )
+                    resp.raise_for_status()
+            except httpx.HTTPError as exc:
+                raise UploadGatewayError(
+                    "Unable to delete media through api gateway"
+                ) from exc
+            return
+
+        prefix = f"documents/{kb_id}/media/{document_id}/"
+        storage = await get_upload_storage_backend(self._storage_root())
+        for key in await storage.list(prefix):
+            await storage.delete(key)
+        # Before this cutover media was always local, even when documents used
+        # object storage. Clean that legacy location during the transition.
+        if not isinstance(storage, LocalUploadStorage):
+            legacy_storage = LocalUploadStorage(self._storage_root())
+            for key in await legacy_storage.list(prefix):
+                await legacy_storage.delete(key)
 
     def _get_media_asset_extension(self, content_type: str) -> str:
         return MEDIA_MIME_EXTENSIONS.get(
@@ -261,7 +324,7 @@ class DocumentProcessor:
             str(kb_id), "media", str(document_id), self._sanitize_filename(filename)
         )
 
-    def _save_media_asset(
+    async def _save_media_asset(
         self,
         *,
         kb_id: UUID,
@@ -272,28 +335,37 @@ class DocumentProcessor:
         digest = hashlib.sha256(content).hexdigest()[:16]
         extension = self._get_media_asset_extension(content_type)
         filename = self._sanitize_filename(f"{digest}{extension}")
-        file_path = self.get_media_asset_path(kb_id, document_id, filename)
-        os.makedirs(file_path.parent, exist_ok=True)
-        if not file_path.exists():
-            temp_file_path = file_path.with_name(f".tmp_{file_path.name}")
+        storage_key = self._media_storage_key(kb_id, document_id, filename)
+        if self._remote_mode():
             try:
-                temp_file_path.write_bytes(content)
-                temp_file_path.replace(file_path)
-            except Exception:
-                temp_file_path.unlink(missing_ok=True)
-                raise
+                async with self._internal_client() as client:
+                    resp = await client.put(
+                        f"/internal/uploads/media/{kb_id}/{document_id}",
+                        params={"filename": filename},
+                        content=content,
+                        headers={"Content-Type": content_type},
+                    )
+                    resp.raise_for_status()
+            except httpx.HTTPError as exc:
+                raise UploadGatewayError(
+                    "Unable to save media through api gateway"
+                ) from exc
+        else:
+            storage = await get_upload_storage_backend(self._storage_root())
+            if not await storage.exists(storage_key):
+                await storage.save(storage_key, content, content_type=content_type)
         url = (
             f"/api/v1/knowledge-bases/{kb_id}/documents/{document_id}/media/{filename}"
         )
         return {
-            "path": str(file_path),
+            "path": storage_key,
             "url": url,
             "filename": filename,
             "content_type": content_type,
             "size": len(content),
         }
 
-    def replace_embedded_media_data_uris(
+    async def replace_embedded_media_data_uris(
         self,
         text: str,
         *,
@@ -301,23 +373,27 @@ class DocumentProcessor:
         document_id: UUID,
     ) -> tuple[str, list[dict[str, Any]]]:
         assets: list[dict[str, Any]] = []
+        replacements: dict[str, str] = {}
 
-        def replace(match: re.Match[str]) -> str:
+        for match in DATA_URI_IMAGE_RE.finditer(text):
             content_type = match.group(1).lower()
             if content_type not in ALLOWED_MEDIA_MIME_TYPES:
-                return match.group(0)
+                continue
             try:
                 content = base64.b64decode(match.group(2), validate=True)
             except binascii.Error:
-                return match.group(0)
-            asset = self._save_media_asset(
+                continue
+            asset = await self._save_media_asset(
                 kb_id=kb_id,
                 document_id=document_id,
                 content_type=content_type,
                 content=content,
             )
             assets.append(asset)
-            return asset["url"]
+            replacements[match.group(0)] = asset["url"]
+
+        def replace(match: re.Match[str]) -> str:
+            return replacements.get(match.group(0), match.group(0))
 
         return DATA_URI_IMAGE_RE.sub(replace, text), assets
 
@@ -387,8 +463,7 @@ class DocumentProcessor:
 
         # Clean up text
         if kb_id is not None and document_id is not None:
-            text, media_assets = await asyncio.to_thread(
-                self.replace_embedded_media_data_uris,
+            text, media_assets = await self.replace_embedded_media_data_uris(
                 text,
                 kb_id=kb_id,
                 document_id=document_id,

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -20,16 +20,13 @@ from uuid import UUID
 from app.models.knowledge_base import (
     DocumentType,
 )
+from app.services import upload_gateway
 from app.services.upload_storage import LocalUploadStorage, get_upload_storage_backend
 from app.services.skill_package import resolve_child_path
 import bleach
 import httpx
 
 logger = logging.getLogger(__name__)
-
-
-class UploadGatewayError(RuntimeError):
-    """A transient failure while the worker is calling the api gateway."""
 
 
 MIME_TYPE_MAP: dict[str, str] = {
@@ -121,15 +118,6 @@ class DocumentProcessor:
         from app.core.config import settings
 
         return settings.UPLOAD_STORAGE_MODE == "remote"
-
-    def _internal_client(self) -> httpx.AsyncClient:
-        from app.core.config import settings
-
-        return httpx.AsyncClient(
-            base_url=settings.API_INTERNAL_BASE_URL.rstrip("/"),
-            headers={"Authorization": f"Bearer {settings.get_internal_api_token()}"},
-            timeout=60.0,
-        )
 
     def _media_storage_key(self, kb_id: UUID, document_id: UUID, filename: str) -> str:
         return (
@@ -242,24 +230,7 @@ class DocumentProcessor:
         """Read file content, streaming api gateway responses in remote mode."""
         storage_key = self._storage_key(path)
         if self._remote_mode():
-            try:
-                async with self._internal_client() as client:
-                    async with client.stream(
-                        "GET", "/internal/uploads/read", params={"key": storage_key}
-                    ) as resp:
-                        if resp.status_code == 404:
-                            raise FileNotFoundError(storage_key)
-                        resp.raise_for_status()
-                        content = bytearray()
-                        async for chunk in resp.aiter_bytes():
-                            content.extend(chunk)
-                        return bytes(content)
-            except FileNotFoundError:
-                raise
-            except httpx.HTTPError as exc:
-                raise UploadGatewayError(
-                    "Unable to read upload through api gateway"
-                ) from exc
+            return await upload_gateway.read(storage_key)
         storage = await get_upload_storage_backend(self._storage_root())
         return await storage.read(storage_key)
 
@@ -268,16 +239,18 @@ class DocumentProcessor:
         storage_key = self._storage_key(path)
         if self._remote_mode():
             try:
-                async with self._internal_client() as client:
+                async with upload_gateway.client() as client:
                     resp = await client.request(
                         "DELETE",
                         "/internal/uploads/delete",
                         params={"key": storage_key},
                     )
+                    if resp.status_code == 404:
+                        return False
                     resp.raise_for_status()
                     return True
             except httpx.HTTPError as exc:
-                raise UploadGatewayError(
+                raise upload_gateway.UploadGatewayError(
                     "Unable to delete upload through api gateway"
                 ) from exc
         storage = await get_upload_storage_backend(self._storage_root())
@@ -289,13 +262,13 @@ class DocumentProcessor:
     async def delete_media_assets(self, kb_id: UUID, document_id: UUID) -> None:
         if self._remote_mode():
             try:
-                async with self._internal_client() as client:
+                async with upload_gateway.client() as client:
                     resp = await client.delete(
                         f"/internal/uploads/media/{kb_id}/{document_id}"
                     )
                     resp.raise_for_status()
             except httpx.HTTPError as exc:
-                raise UploadGatewayError(
+                raise upload_gateway.UploadGatewayError(
                     "Unable to delete media through api gateway"
                 ) from exc
             return
@@ -338,7 +311,7 @@ class DocumentProcessor:
         storage_key = self._media_storage_key(kb_id, document_id, filename)
         if self._remote_mode():
             try:
-                async with self._internal_client() as client:
+                async with upload_gateway.client() as client:
                     resp = await client.put(
                         f"/internal/uploads/media/{kb_id}/{document_id}",
                         params={"filename": filename},
@@ -347,7 +320,7 @@ class DocumentProcessor:
                     )
                     resp.raise_for_status()
             except httpx.HTTPError as exc:
-                raise UploadGatewayError(
+                raise upload_gateway.UploadGatewayError(
                     "Unable to save media through api gateway"
                 ) from exc
         else:

--- a/backend/app/services/sandbox/manager.py
+++ b/backend/app/services/sandbox/manager.py
@@ -8,7 +8,6 @@ import json
 import os
 import shutil
 import time
-import httpx
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -19,6 +18,7 @@ from app.schemas.response import BusinessError, ResponseCode
 from app.core.i18n import t
 from app.llm.tools.sandbox import ExecutionResult as LegacyExecutionResult
 from app.services.error_messages import resolve_user_visible_error
+from app.services import upload_gateway
 
 from .artifacts import SandboxArtifactStore
 from .models import (
@@ -257,13 +257,14 @@ class SandboxManager:
                     user_id=user_id,
                 )
                 if settings.UPLOAD_STORAGE_MODE == "remote":
-                    content = await self._read_asset_from_gateway(asset.storage_key)
+                    content = await upload_gateway.read(asset.storage_key)
                     if (
                         len(content) != asset.size
                         or hashlib.sha256(content).hexdigest() != asset.checksum
                     ):
-                        raise RuntimeError(
-                            "Stored Asset content does not match its metadata"
+                        raise BusinessError(
+                            code=ResponseCode.VALIDATION_ERROR,
+                            msg_key="sandbox_input_checksum_mismatch",
                         )
                 else:
                     from app.api.v1.endpoints.upload import UPLOAD_ROOT
@@ -302,35 +303,6 @@ class SandboxManager:
                 partial.unlink(missing_ok=True)
             if input_file.mode is not None:
                 target.chmod(input_file.mode)
-
-    async def _read_asset_from_gateway(self, storage_key: str) -> bytes:
-        """Read an authorized attachment without relying on a local uploads mount."""
-        from app.services.document_processor import UploadGatewayError
-
-        try:
-            async with httpx.AsyncClient(
-                base_url=settings.API_INTERNAL_BASE_URL.rstrip("/"),
-                headers={
-                    "Authorization": f"Bearer {settings.get_internal_api_token()}"
-                },
-                timeout=60.0,
-            ) as client:
-                async with client.stream(
-                    "GET", "/internal/uploads/read", params={"key": storage_key}
-                ) as response:
-                    if response.status_code == 404:
-                        raise FileNotFoundError(storage_key)
-                    response.raise_for_status()
-                    content = bytearray()
-                    async for chunk in response.aiter_bytes():
-                        content.extend(chunk)
-                    return bytes(content)
-        except FileNotFoundError:
-            raise
-        except httpx.HTTPError as exc:
-            raise UploadGatewayError(
-                "Unable to read sandbox attachment through api gateway"
-            ) from exc
 
     def _prepare_snippet_execution(
         self,

--- a/backend/app/services/sandbox/manager.py
+++ b/backend/app/services/sandbox/manager.py
@@ -8,6 +8,7 @@ import json
 import os
 import shutil
 import time
+import httpx
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -248,17 +249,28 @@ class SandboxManager:
                     f"Sandbox input target already exists: {input_file.target_path}"
                 )
             if input_file.asset_id is not None:
-                from app.api.v1.endpoints.upload import UPLOAD_ROOT
                 from app.services.asset import asset_service
-                from app.services.upload_storage import get_upload_storage_backend
 
                 asset = await asset_service.get_authorized(
                     input_file.asset_id,
                     team_id=team_id,
                     user_id=user_id,
                 )
-                storage = await get_upload_storage_backend(UPLOAD_ROOT)
-                content = await asset_service.read(asset, storage=storage)
+                if settings.UPLOAD_STORAGE_MODE == "remote":
+                    content = await self._read_asset_from_gateway(asset.storage_key)
+                    if (
+                        len(content) != asset.size
+                        or hashlib.sha256(content).hexdigest() != asset.checksum
+                    ):
+                        raise RuntimeError(
+                            "Stored Asset content does not match its metadata"
+                        )
+                else:
+                    from app.api.v1.endpoints.upload import UPLOAD_ROOT
+                    from app.services.upload_storage import get_upload_storage_backend
+
+                    storage = await get_upload_storage_backend(UPLOAD_ROOT)
+                    content = await asset_service.read(asset, storage=storage)
             else:
                 assert input_file.content_base64 is not None
                 content = base64.b64decode(input_file.content_base64, validate=True)
@@ -290,6 +302,35 @@ class SandboxManager:
                 partial.unlink(missing_ok=True)
             if input_file.mode is not None:
                 target.chmod(input_file.mode)
+
+    async def _read_asset_from_gateway(self, storage_key: str) -> bytes:
+        """Read an authorized attachment without relying on a local uploads mount."""
+        from app.services.document_processor import UploadGatewayError
+
+        try:
+            async with httpx.AsyncClient(
+                base_url=settings.API_INTERNAL_BASE_URL.rstrip("/"),
+                headers={
+                    "Authorization": f"Bearer {settings.get_internal_api_token()}"
+                },
+                timeout=60.0,
+            ) as client:
+                async with client.stream(
+                    "GET", "/internal/uploads/read", params={"key": storage_key}
+                ) as response:
+                    if response.status_code == 404:
+                        raise FileNotFoundError(storage_key)
+                    response.raise_for_status()
+                    content = bytearray()
+                    async for chunk in response.aiter_bytes():
+                        content.extend(chunk)
+                    return bytes(content)
+        except FileNotFoundError:
+            raise
+        except httpx.HTTPError as exc:
+            raise UploadGatewayError(
+                "Unable to read sandbox attachment through api gateway"
+            ) from exc
 
     def _prepare_snippet_execution(
         self,

--- a/backend/app/services/upload_gateway.py
+++ b/backend/app/services/upload_gateway.py
@@ -1,0 +1,40 @@
+"""Authenticated client for the internal upload gateway."""
+
+from __future__ import annotations
+
+import httpx
+
+from app.core.config import settings
+
+
+class UploadGatewayError(RuntimeError):
+    """A transient failure while a worker calls the API upload gateway."""
+
+
+def client() -> httpx.AsyncClient:
+    """Create an authenticated client for the internal uploads API."""
+    return httpx.AsyncClient(
+        base_url=settings.API_INTERNAL_BASE_URL.rstrip("/"),
+        headers={"Authorization": f"Bearer {settings.get_internal_api_token()}"},
+        timeout=60.0,
+    )
+
+
+async def read(key: str) -> bytes:
+    """Stream an upload through the gateway, preserving missing-file semantics."""
+    try:
+        async with client() as gateway:
+            async with gateway.stream(
+                "GET", "/internal/uploads/read", params={"key": key}
+            ) as response:
+                if response.status_code == 404:
+                    raise FileNotFoundError(key)
+                response.raise_for_status()
+                content = bytearray()
+                async for chunk in response.aiter_bytes():
+                    content.extend(chunk)
+                return bytes(content)
+    except FileNotFoundError:
+        raise
+    except httpx.HTTPError as exc:
+        raise UploadGatewayError("Unable to read upload through api gateway") from exc

--- a/backend/app/services/upload_storage.py
+++ b/backend/app/services/upload_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -61,6 +62,10 @@ class UploadStorageBackend(ABC):
     async def delete(self, key: str) -> None:
         """Delete key if it exists."""
 
+    @abstractmethod
+    async def list(self, prefix: str) -> list[str]:
+        """List storage keys under a prefix (empty prefix lists everything)."""
+
     async def validate(self) -> None:
         return None
 
@@ -84,8 +89,16 @@ class LocalUploadStorage(UploadStorageBackend):
     ) -> str:
         path = self._path(key)
         os.makedirs(path.parent, exist_ok=True)
-        async with aiofiles.open(path, "wb") as f:
-            await f.write(content)
+        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        os.close(fd)
+        temporary_path = Path(temporary_name)
+        try:
+            async with aiofiles.open(temporary_path, "wb") as f:
+                await f.write(content)
+            os.replace(temporary_path, path)
+        except Exception:
+            temporary_path.unlink(missing_ok=True)
+            raise
         return str(path)
 
     async def exists(self, key: str) -> bool:
@@ -108,6 +121,19 @@ class LocalUploadStorage(UploadStorageBackend):
             self._path(key).unlink()
         except FileNotFoundError:
             return
+
+    async def list(self, prefix: str) -> list[str]:
+        base = self.root.joinpath(*prefix.split("/")).resolve()
+        if base != self.root and self.root not in base.parents:
+            return []
+        if not base.is_dir():
+            return []
+        keys = [
+            path.relative_to(self.root).as_posix()
+            for path in sorted(base.rglob("*"))
+            if path.is_file()
+        ]
+        return keys
 
 
 class ObjectUploadStorage(UploadStorageBackend):
@@ -238,6 +264,17 @@ class ObjectUploadStorage(UploadStorageBackend):
     async def delete(self, key: str) -> None:
         async with self._client() as client:
             await client.delete_object(Bucket=self.config.bucket, Key=key)
+
+    async def list(self, prefix: str) -> list[str]:
+        keys: list[str] = []
+        async with self._client() as client:
+            paginator = client.get_paginator("list_objects_v2")
+            async for page in paginator.paginate(
+                Bucket=self.config.bucket, Prefix=prefix
+            ):
+                for obj in page.get("Contents", []):
+                    keys.append(str(obj["Key"]))
+        return keys
 
 
 def _storage_defaults() -> dict[str, Any]:

--- a/backend/app/services/upload_storage.py
+++ b/backend/app/services/upload_storage.py
@@ -267,10 +267,11 @@ class ObjectUploadStorage(UploadStorageBackend):
 
     async def list(self, prefix: str) -> list[str]:
         keys: list[str] = []
+        normalized_prefix = f"{prefix.rstrip('/')}/" if prefix else ""
         async with self._client() as client:
             paginator = client.get_paginator("list_objects_v2")
             async for page in paginator.paginate(
-                Bucket=self.config.bucket, Prefix=prefix
+                Bucket=self.config.bucket, Prefix=normalized_prefix
             ):
                 for obj in page.get("Contents", []):
                     keys.append(str(obj["Key"]))

--- a/backend/app/services/workflow/executors/subworkflow.py
+++ b/backend/app/services/workflow/executors/subworkflow.py
@@ -398,7 +398,7 @@ class FileToURLNodeExecutor(NodeExecutor):
             try:
                 kb_id = UUID(key_path.parts[1])
             except ValueError:
-                pass
+                return ExecutionResult(error="not_found")
             else:
                 from app.models.knowledge_base import KnowledgeBase
                 from app.models.workflow import Workflow

--- a/backend/app/services/workflow/executors/subworkflow.py
+++ b/backend/app/services/workflow/executors/subworkflow.py
@@ -4,10 +4,11 @@ Sub-workflow node executor.
 Handles nested workflow execution with depth tracking.
 """
 
-from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 import logging
+import mimetypes
+import os
 
 from ..executor import NodeExecutor, NodeExecutorRegistry, ExecutionResult
 from ..types import NodeOutputDecl, TypeSpec, WorkflowValue
@@ -255,97 +256,188 @@ class FileToURLNodeExecutor(NodeExecutor):
         context: "ExecutionContext",
         run: "WorkflowRun",
     ) -> ExecutionResult:
-        """Execute file to URL conversion."""
-        import os
+        """Execute file to URL conversion.
+
+        Workflow file parameters are uploaded when the run starts; the
+        variable value is already the upload URL (frontend stores
+        ``result.url``, a list of URLs for multi-file parameters). This node
+        therefore never reads file bytes — it resolves the file variable(s)
+        and returns their URL(s), optionally absolutized. No local filesystem
+        access, so it runs on any worker without the uploads volume.
+        """
         import base64
         import mimetypes
+        from urllib.parse import urlparse
+
         from app.core.config import settings
 
         node_data = node.get("data", {})
-        config = node_data.get("config", {})
+        legacy_config = node_data.get("config", {})
+        config = node_data.get("fileToUrlConfig", legacy_config)
 
-        input_var = config.get("inputVariable", "")
-        input_type = config.get("inputType", "path")
-        output_type = config.get("outputType", "url")
-        config.get("expiresIn", 3600)
-
-        # Get input value
-        input_value = await context.resolve_variable_ref(input_var)
-        if not input_value:
-            return ExecutionResult(error="validation_error")
+        inputs = config.get("inputs", [])
+        ensure_absolute = bool(config.get("ensureAbsolute", True))
+        input_var = config.get("inputVariable", "") or legacy_config.get(
+            "inputVariable", ""
+        )
+        input_type = config.get("inputType", "path") or legacy_config.get(
+            "inputType", "path"
+        )
+        output_type = config.get("outputType", "url") or legacy_config.get(
+            "outputType", "url"
+        )
 
         try:
-            if input_type == "path":
-                # Input is a file path
-                file_path = str(input_value)
-
-                if not os.path.exists(file_path):
-                    return ExecutionResult(error="file_not_found")
-
-                filename = os.path.basename(file_path)
-                mime_type, _ = mimetypes.guess_type(file_path)
-                file_size = os.path.getsize(file_path)
-
-                if output_type == "base64":
-                    with open(file_path, "rb") as f:
-                        content = base64.b64encode(f.read()).decode()
-                    return ExecutionResult(
-                        outputs={
-                            "content": content,
-                            "filename": filename,
-                            "mimeType": mime_type or "application/octet-stream",
-                            "size": file_size,
-                        }
+            if inputs:
+                outputs: dict[str, WorkflowValue] = {}
+                for item in inputs:
+                    name = item.get("name", "")
+                    ref = item.get("sourceVariable", "")
+                    if not name or not ref:
+                        continue
+                    value = await context.resolve_variable_ref(ref)
+                    if not self._has_file_value(value):
+                        return ExecutionResult(error="validation_error")
+                    outputs[name] = self._normalize_urls(
+                        value, ensure_absolute, settings
                     )
-                else:
-                    # Generate URL (simplified - in production use signed URLs)
-                    uploads_root = Path(
-                        "/Users/yunhai/Documents/CodeData/Project/Clouisle/uploads"
-                    )
-                    relative_path = Path(file_path).resolve().relative_to(uploads_root)
-                    url = (
-                        f"{str(settings.API_BASE_URL).rstrip('/')}/uploads/"
-                        f"{relative_path.as_posix()}"
-                    )
+                if not outputs:
+                    return ExecutionResult(error="validation_error")
+                return ExecutionResult(outputs=outputs)
 
-                    return ExecutionResult(
-                        outputs={
-                            "url": url,
-                            "filename": filename,
-                            "mimeType": mime_type or "application/octet-stream",
-                            "size": file_size,
-                        }
-                    )
-
-            elif input_type == "base64":
-                # Input is base64 content
-                content = str(input_value)
-
-                # Decode to get size
+            # Legacy base64/content modes — pure string handling, no filesystem.
+            if input_type == "content":
+                return ExecutionResult(error="validation_error")
+            if input_type == "base64":
+                value = await context.resolve_variable_ref(input_var or "")
+                if value is None:
+                    return ExecutionResult(error="validation_error")
+                content = str(value)
                 try:
                     decoded = base64.b64decode(content)
                     file_size = len(decoded)
                 except Exception:
                     file_size = len(content)
-
                 if output_type == "base64":
                     return ExecutionResult(
-                        outputs={
-                            "content": content,
-                            "size": file_size,
-                        }
+                        outputs={"content": content, "size": file_size}
                     )
-                else:
-                    # Would need to save to storage and generate URL
-                    # This is a simplified implementation
-                    return ExecutionResult(error="workflow_execution_error")
+                return ExecutionResult(error="workflow_execution_error")
 
-            else:
+            if not input_var:
                 return ExecutionResult(error="validation_error")
 
+            value = await context.resolve_variable_ref(input_var)
+            if not self._has_file_value(value):
+                return ExecutionResult(error="validation_error")
+
+            if input_type == "path" and output_type == "base64":
+                return await self._legacy_path_to_base64(value, settings)
+
+            converted = self._normalize_urls(value, ensure_absolute, settings)
+            if isinstance(converted, list):
+                first = converted[0] if converted else ""
+                filename = os.path.basename(urlparse(first).path) or "file"
+                mime_type, _ = mimetypes.guess_type(filename)
+                return ExecutionResult(
+                    outputs={
+                        "urls": converted,
+                        "filename": filename,
+                        "mimeType": mime_type or "application/octet-stream",
+                    }
+                )
+            filename = os.path.basename(urlparse(converted).path) or "file"
+            mime_type, _ = mimetypes.guess_type(filename)
+            return ExecutionResult(
+                outputs={
+                    "url": converted,
+                    "filename": filename,
+                    "mimeType": mime_type or "application/octet-stream",
+                    "size": 0,
+                }
+            )
         except Exception as e:
             logger.exception(f"File conversion error: {e}")
             return ExecutionResult(error=translate_public_workflow_error(e))
+
+    @staticmethod
+    def _has_file_value(value: WorkflowValue) -> bool:
+        if isinstance(value, list):
+            return bool(value) and all(
+                isinstance(item, str) and item.strip() for item in value
+            )
+        return isinstance(value, str) and bool(value.strip())
+
+    @staticmethod
+    async def _legacy_path_to_base64(
+        value: WorkflowValue, settings: Any
+    ) -> ExecutionResult:
+        """Read a legacy uploaded path through api, never from worker disk."""
+        import base64
+        import httpx
+        from pathlib import PurePosixPath
+        from urllib.parse import unquote, urlsplit
+
+        if not isinstance(value, str):
+            return ExecutionResult(error="validation_error")
+        raw_path = unquote(urlsplit(value).path or value)
+        marker = "/api/v1/upload/files/"
+        if marker in raw_path:
+            storage_key = raw_path.split(marker, 1)[1]
+        elif "/uploads/" in raw_path:
+            storage_key = raw_path.split("/uploads/", 1)[1]
+        elif raw_path.startswith("documents/"):
+            storage_key = raw_path
+        else:
+            return ExecutionResult(error="workflow_execution_error")
+        key_path = PurePosixPath(storage_key)
+        if key_path.is_absolute() or not key_path.parts or ".." in key_path.parts:
+            return ExecutionResult(error="validation_error")
+
+        async with httpx.AsyncClient(
+            base_url=settings.API_INTERNAL_BASE_URL.rstrip("/"),
+            headers={"Authorization": f"Bearer {settings.get_internal_api_token()}"},
+            timeout=60.0,
+        ) as client:
+            async with client.stream(
+                "GET", "/internal/uploads/read", params={"key": key_path.as_posix()}
+            ) as response:
+                response.raise_for_status()
+                content = bytearray()
+                async for chunk in response.aiter_bytes():
+                    content.extend(chunk)
+
+        filename = os.path.basename(raw_path) or "file"
+        mime_type, _ = mimetypes.guess_type(filename)
+        return ExecutionResult(
+            outputs={
+                "content": base64.b64encode(content).decode("ascii"),
+                "filename": filename,
+                "mimeType": mime_type or "application/octet-stream",
+                "size": len(content),
+            }
+        )
+
+    @staticmethod
+    def _normalize_urls(
+        value: WorkflowValue, ensure_absolute: bool, settings: Any
+    ) -> str | list[str]:
+        """Normalize a file variable value (URL or URL list) without reading files."""
+
+        def _absolutize(url: str) -> str:
+            url = url.strip()
+            if not ensure_absolute or url.startswith(("http://", "https://")):
+                return url
+            base = str(getattr(settings, "PUBLIC_API_URL", "") or "").rstrip("/")
+            if not base:
+                return url
+            return f"{base}{url if url.startswith('/') else '/' + url}"
+
+        if isinstance(value, list):
+            return [_absolutize(v) for v in value if isinstance(v, str) and v.strip()]
+        if isinstance(value, str) and value.strip():
+            return _absolutize(value)
+        return _absolutize(str(value))
 
     def get_output_variables(self, config: dict) -> list[dict]:
         """Get output variables."""

--- a/backend/app/services/workflow/executors/subworkflow.py
+++ b/backend/app/services/workflow/executors/subworkflow.py
@@ -10,6 +10,7 @@ import logging
 import mimetypes
 import os
 
+from app.services import upload_gateway
 from ..executor import NodeExecutor, NodeExecutorRegistry, ExecutionResult
 from ..types import NodeOutputDecl, TypeSpec, WorkflowValue
 from ..errors import MaxDepthExceededError
@@ -332,7 +333,7 @@ class FileToURLNodeExecutor(NodeExecutor):
                 return ExecutionResult(error="validation_error")
 
             if input_type == "path" and output_type == "base64":
-                return await self._legacy_path_to_base64(value, settings)
+                return await self._legacy_path_to_base64(value, run)
 
             converted = self._normalize_urls(value, ensure_absolute, settings)
             if isinstance(converted, list):
@@ -370,11 +371,10 @@ class FileToURLNodeExecutor(NodeExecutor):
 
     @staticmethod
     async def _legacy_path_to_base64(
-        value: WorkflowValue, settings: Any
+        value: WorkflowValue, run: "WorkflowRun"
     ) -> ExecutionResult:
         """Read a legacy uploaded path through api, never from worker disk."""
         import base64
-        import httpx
         from pathlib import PurePosixPath
         from urllib.parse import unquote, urlsplit
 
@@ -394,18 +394,26 @@ class FileToURLNodeExecutor(NodeExecutor):
         if key_path.is_absolute() or not key_path.parts or ".." in key_path.parts:
             return ExecutionResult(error="validation_error")
 
-        async with httpx.AsyncClient(
-            base_url=settings.API_INTERNAL_BASE_URL.rstrip("/"),
-            headers={"Authorization": f"Bearer {settings.get_internal_api_token()}"},
-            timeout=60.0,
-        ) as client:
-            async with client.stream(
-                "GET", "/internal/uploads/read", params={"key": key_path.as_posix()}
-            ) as response:
-                response.raise_for_status()
-                content = bytearray()
-                async for chunk in response.aiter_bytes():
-                    content.extend(chunk)
+        if len(key_path.parts) > 1 and key_path.parts[0] == "documents":
+            try:
+                kb_id = UUID(key_path.parts[1])
+            except ValueError:
+                pass
+            else:
+                from app.models.knowledge_base import KnowledgeBase
+                from app.models.workflow import Workflow
+
+                workflow_id = getattr(run, "workflow_id", None)
+                workflow = await Workflow.filter(id=workflow_id).only("team_id").first()
+                if not workflow:
+                    return ExecutionResult(error="not_found")
+                kb = await KnowledgeBase.filter(
+                    id=kb_id, team_id=workflow.team_id
+                ).first()
+                if not kb:
+                    return ExecutionResult(error="not_found")
+
+        content = await upload_gateway.read(key_path.as_posix())
 
         filename = os.path.basename(raw_path) or "file"
         mime_type, _ = mimetypes.guess_type(filename)
@@ -439,26 +447,50 @@ class FileToURLNodeExecutor(NodeExecutor):
             return _absolutize(value)
         return _absolutize(str(value))
 
+    @staticmethod
+    def _configured_input_names(config: dict) -> list[str]:
+        inputs = config.get("inputs", [])
+        if not isinstance(inputs, list):
+            return []
+        return [
+            name
+            for item in inputs
+            if isinstance(item, dict)
+            and isinstance((name := item.get("name")), str)
+            and name
+        ]
+
     def get_output_variables(self, config: dict) -> list[dict]:
         """Get output variables."""
+        input_names = self._configured_input_names(config)
+        if input_names:
+            return [{"name": name, "type": "any"} for name in input_names]
+
         output_type = config.get("outputType", "url")
         if output_type == "url":
             return [
                 {"name": "url", "type": "string"},
+                {"name": "urls", "type": "array"},
                 {"name": "filename", "type": "string"},
                 {"name": "mimeType", "type": "string"},
                 {"name": "size", "type": "number"},
             ]
-        else:
-            return [
-                {"name": "content", "type": "string"},
-                {"name": "filename", "type": "string"},
-                {"name": "mimeType", "type": "string"},
-                {"name": "size", "type": "number"},
-            ]
+        return [
+            {"name": "content", "type": "string"},
+            {"name": "filename", "type": "string"},
+            {"name": "mimeType", "type": "string"},
+            {"name": "size", "type": "number"},
+        ]
 
     def get_output_specs(self, config: dict) -> list["NodeOutputDecl"]:
         """Get output specs with TypeSpec for type inference."""
+        input_names = self._configured_input_names(config)
+        if input_names:
+            return [
+                NodeOutputDecl(name=name, type=TypeSpec(kind="any"))
+                for name in input_names
+            ]
+
         output_type = config.get("outputType", "url")
         specs = [
             NodeOutputDecl(name="filename", type=TypeSpec(kind="string")),
@@ -467,6 +499,16 @@ class FileToURLNodeExecutor(NodeExecutor):
         ]
         if output_type == "url":
             specs.insert(0, NodeOutputDecl(name="url", type=TypeSpec(kind="string")))
+            specs.insert(
+                1,
+                NodeOutputDecl(
+                    name="urls",
+                    type=TypeSpec(
+                        kind="array",
+                        item=TypeSpec(kind="string"),
+                    ),
+                ),
+            )
         else:
             specs.insert(
                 0, NodeOutputDecl(name="content", type=TypeSpec(kind="string"))

--- a/backend/app/tasks/knowledge_base.py
+++ b/backend/app/tasks/knowledge_base.py
@@ -19,7 +19,7 @@ from app.models.knowledge_base import (
 )
 from app.models.notification import AutoNotificationType
 from app.services.auto_notification import AutoNotificationService
-from app.services.document_processor import document_processor
+from app.services.document_processor import UploadGatewayError, document_processor
 from app.services.lexical_store import LexicalStore, chunk_document, index_document
 from app.services.vector_store import (
     VectorStore,
@@ -372,7 +372,7 @@ async def _process_document(document_id: str, task_id: str | None) -> dict[str, 
         clean_text_setting = doc_meta.get("clean_text", True)
 
         if document.file_path:
-            document_processor.delete_media_assets(kb.id, document.id)
+            await document_processor.delete_media_assets(kb.id, document.id)
             text, metadata = await document_processor.extract_text(
                 document.file_path,
                 document.doc_type,
@@ -562,6 +562,10 @@ async def _process_document(document_id: str, task_id: str | None) -> dict[str, 
             "error_type": "dimension_mismatch",
         }
 
+    except UploadGatewayError:
+        # The api gateway can be briefly unavailable during startup or rollout.
+        # Let the bound Celery task retry instead of terminally failing the document.
+        raise
     except Exception as e:
         logger.exception(f"Error processing document {document_id}: {e}")
 
@@ -609,7 +613,10 @@ def process_document_task(self, document_id: str) -> dict:
     """
 
     task_id = getattr(self.request, "id", None)
-    return _run_async(_process_document(document_id, task_id))
+    try:
+        return _run_async(_process_document(document_id, task_id))
+    except UploadGatewayError as exc:
+        raise self.retry(exc=exc) from exc
 
 
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
@@ -670,13 +677,16 @@ def reprocess_document_task(self, document_id: str) -> dict:
 
         return {"status": "pending", "deleted_chunks": deleted_count}
 
-    result = _run_async(_reprocess())
+    try:
+        result = _run_async(_reprocess())
 
-    if result.get("status") == "pending":
-        task_id = getattr(self.request, "id", None)
-        return _run_async(_process_document(document_id, task_id))
+        if result.get("status") == "pending":
+            task_id = getattr(self.request, "id", None)
+            return _run_async(_process_document(document_id, task_id))
 
-    return result
+        return result
+    except UploadGatewayError as exc:
+        raise self.retry(exc=exc) from exc
 
 
 @shared_task
@@ -778,7 +788,7 @@ def rechunk_document_task(self, document_id: str) -> dict:
 
             # Extract text
             if document.file_path:
-                document_processor.delete_media_assets(kb.id, document.id)
+                await document_processor.delete_media_assets(kb.id, document.id)
                 text, _ = await document_processor.extract_text(
                     document.file_path,
                     document.doc_type,
@@ -916,6 +926,8 @@ def rechunk_document_task(self, document_id: str) -> dict:
                 "error_type": "dimension_mismatch",
             }
 
+        except UploadGatewayError:
+            raise
         except Exception as e:
             logger.exception(f"Error rechunking document {document_id}: {e}")
 
@@ -942,7 +954,10 @@ def rechunk_document_task(self, document_id: str) -> dict:
                 "message": document.error_message,
             }
 
-    return _run_async(_rechunk())
+    try:
+        return _run_async(_rechunk())
+    except UploadGatewayError as exc:
+        raise self.retry(exc=exc) from exc
 
 
 async def _embed_existing_document_chunks(

--- a/backend/app/tasks/knowledge_base.py
+++ b/backend/app/tasks/knowledge_base.py
@@ -19,7 +19,8 @@ from app.models.knowledge_base import (
 )
 from app.models.notification import AutoNotificationType
 from app.services.auto_notification import AutoNotificationService
-from app.services.document_processor import UploadGatewayError, document_processor
+from app.services.document_processor import document_processor
+from app.services.upload_gateway import UploadGatewayError
 from app.services.lexical_store import LexicalStore, chunk_document, index_document
 from app.services.vector_store import (
     VectorStore,
@@ -211,6 +212,68 @@ async def _finish_already_finished_task(
         "document_id": str(document.id),
         "document_status": document.status,
     }
+
+
+async def _finish_upload_gateway_retry_exhaustion(
+    document_id: str,
+    task_id: str | None,
+    error: UploadGatewayError,
+) -> dict[str, Any]:
+    """Mark a document terminally failed after gateway retries are exhausted."""
+    document = (
+        await Document.filter(id=UUID(document_id))
+        .prefetch_related("knowledge_base", "uploaded_by")
+        .first()
+    )
+    if not document:
+        logger.error("Document %s not found after upload gateway retries", document_id)
+        default_lang = await get_default_language()
+        return {
+            "status": "error",
+            "message": t("document_not_found", lang=default_lang),
+        }
+    if _is_stale_task(document, task_id):
+        return await _finish_stale_task(document, task_id)
+    if _is_finished_task(document, task_id):
+        return await _finish_already_finished_task(document, task_id)
+
+    kb = document.knowledge_base
+    user_locale = (
+        getattr(document.uploaded_by, "locale", "en") if document.uploaded_by else "en"
+    )
+    logger.error(
+        "Upload gateway retries exhausted for document %s: %s", document_id, error
+    )
+    document.status = DocumentStatus.ERROR.value
+    _clear_task_metadata(document)
+    document.error_message = _get_generic_processing_error(document, user_locale)[:500]
+    await document.save()
+    await _send_doc_failed_notification(
+        document=document,
+        kb_name=kb.name,
+        team_id=kb.team_id,
+        error=document.error_message,
+        user_locale=user_locale,
+    )
+    return {
+        "status": "error",
+        "document_id": document_id,
+        "message": document.error_message,
+    }
+
+
+def _retry_upload_gateway_or_mark_document_failed(
+    task: Any,
+    document_id: str,
+    task_id: str | None,
+    error: UploadGatewayError,
+) -> dict[str, Any]:
+    # Celery re-raises the supplied error at the retry limit, so check first.
+    if getattr(task.request, "retries", 0) >= task.max_retries:
+        return _run_async(
+            _finish_upload_gateway_retry_exhaustion(document_id, task_id, error)
+        )
+    raise task.retry(exc=error) from error
 
 
 async def _send_doc_indexed_notification(
@@ -616,7 +679,12 @@ def process_document_task(self, document_id: str) -> dict:
     try:
         return _run_async(_process_document(document_id, task_id))
     except UploadGatewayError as exc:
-        raise self.retry(exc=exc) from exc
+        return _retry_upload_gateway_or_mark_document_failed(
+            self,
+            document_id,
+            task_id,
+            exc,
+        )
 
 
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
@@ -686,7 +754,12 @@ def reprocess_document_task(self, document_id: str) -> dict:
 
         return result
     except UploadGatewayError as exc:
-        raise self.retry(exc=exc) from exc
+        return _retry_upload_gateway_or_mark_document_failed(
+            self,
+            document_id,
+            getattr(self.request, "id", None),
+            exc,
+        )
 
 
 @shared_task
@@ -957,7 +1030,12 @@ def rechunk_document_task(self, document_id: str) -> dict:
     try:
         return _run_async(_rechunk())
     except UploadGatewayError as exc:
-        raise self.retry(exc=exc) from exc
+        return _retry_upload_gateway_or_mark_document_failed(
+            self,
+            document_id,
+            getattr(self.request, "id", None),
+            exc,
+        )
 
 
 async def _embed_existing_document_chunks(

--- a/backend/tests/api/test_knowledge_base_lifecycle_issue255.py
+++ b/backend/tests/api/test_knowledge_base_lifecycle_issue255.py
@@ -273,7 +273,11 @@ async def test_delete_document_cleans_task_vectors_media_file_and_stats(
         patch.object(knowledge_bases, "check_kb_access", AsyncMock(return_value=kb)),
         patch.object(knowledge_bases.Document, "filter", return_value=Query(first=doc)),
         patch.object(knowledge_bases, "VectorStore", return_value=vector_store),
-        patch.object(knowledge_bases.asyncio, "to_thread", AsyncMock()) as media_delete,
+        patch.object(
+            knowledge_bases.document_processor,
+            "delete_media_assets",
+            AsyncMock(),
+        ) as media_delete,
         patch.object(
             knowledge_bases.document_processor, "delete_file", AsyncMock()
         ) as file_delete,
@@ -288,7 +292,7 @@ async def test_delete_document_cleans_task_vectors_media_file_and_stats(
     celery_app.control.revoke.assert_called_once_with("task-1", terminate=True)
     lexical_store_calls.document.assert_not_awaited()
     vector_store.delete_document_vectors.assert_awaited_once_with(doc_id)
-    media_delete.assert_awaited_once()
+    media_delete.assert_awaited_once_with(kb_id, doc_id)
     file_delete.assert_awaited_once_with("uploads/report.pdf")
     assert (kb.document_count, kb.total_chunks, kb.total_tokens) == (0, 0, 0)
     kb.save.assert_awaited_once()

--- a/backend/tests/api/test_knowledge_bases_deep_residual_issue255.py
+++ b/backend/tests/api/test_knowledge_bases_deep_residual_issue255.py
@@ -1,5 +1,4 @@
 import importlib
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
@@ -250,10 +249,11 @@ async def test_download_and_media_reject_invalid_storage_paths(monkeypatch):
         await knowledge_bases.download_document(kb_id, doc_id, SimpleNamespace())
     assert caught.value.msg_key == "file_not_found"
 
+    storage = SimpleNamespace(exists=AsyncMock(return_value=False))
     monkeypatch.setattr(
-        knowledge_bases.document_processor,
-        "get_media_asset_path",
-        lambda *_args: Path("/definitely/missing/image.png"),
+        knowledge_bases,
+        "get_upload_storage_backend",
+        AsyncMock(return_value=storage),
     )
     with pytest.raises(BusinessError) as caught:
         await knowledge_bases.get_document_media(

--- a/backend/tests/api/test_knowledge_bases_document_chunk_lifecycle_issue255.py
+++ b/backend/tests/api/test_knowledge_bases_document_chunk_lifecycle_issue255.py
@@ -121,7 +121,7 @@ async def test_delete_document_cleans_task_vectors_media_file_and_stats(
     )
     monkeypatch.setattr(knowledge_bases, "VectorStore", lambda: vectors)
     monkeypatch.setattr(
-        knowledge_bases.document_processor, "delete_media_assets", Mock()
+        knowledge_bases.document_processor, "delete_media_assets", AsyncMock()
     )
     monkeypatch.setattr(knowledge_bases.document_processor, "delete_file", AsyncMock())
     monkeypatch.setattr(knowledge_bases.AuditLogService, "log", AsyncMock())
@@ -133,7 +133,7 @@ async def test_delete_document_cleans_task_vectors_media_file_and_stats(
     celery_app.control.revoke.assert_called_once_with("old-task", terminate=True)
     lexical_store_calls.document.assert_not_awaited()
     vectors.delete_document_vectors.assert_awaited_once_with(doc_id)
-    knowledge_bases.document_processor.delete_media_assets.assert_called_once_with(
+    knowledge_bases.document_processor.delete_media_assets.assert_awaited_once_with(
         kb_id, doc_id
     )
     knowledge_bases.document_processor.delete_file.assert_awaited_once_with(

--- a/backend/tests/api/test_knowledge_bases_lifecycle_issue255.py
+++ b/backend/tests/api/test_knowledge_bases_lifecycle_issue255.py
@@ -246,7 +246,9 @@ async def test_delete_document_cleans_storage_vectors_and_statistics(monkeypatch
     )
     store = SimpleNamespace(delete_document_vectors=AsyncMock())
     monkeypatch.setattr(knowledge_bases, "VectorStore", lambda: store)
-    monkeypatch.setattr(knowledge_bases.asyncio, "to_thread", AsyncMock())
+    monkeypatch.setattr(
+        knowledge_bases.document_processor, "delete_media_assets", AsyncMock()
+    )
     monkeypatch.setattr(knowledge_bases.document_processor, "delete_file", AsyncMock())
     monkeypatch.setattr(knowledge_bases.AuditLogService, "log", AsyncMock())
     from app.core.celery import celery_app

--- a/backend/tests/api/test_knowledge_bases_remaining_branches_issue255.py
+++ b/backend/tests/api/test_knowledge_bases_remaining_branches_issue255.py
@@ -245,7 +245,7 @@ async def test_delete_document_without_task_or_file(monkeypatch, status):
     monkeypatch.setattr(endpoint, "check_kb_access", AsyncMock(return_value=kb))
     monkeypatch.setattr(endpoint.Document, "filter", lambda **_kwargs: Query(first=doc))
     monkeypatch.setattr(endpoint, "VectorStore", lambda: vector_store)
-    monkeypatch.setattr(endpoint.asyncio, "to_thread", AsyncMock())
+    monkeypatch.setattr(endpoint.document_processor, "delete_media_assets", AsyncMock())
     monkeypatch.setattr(endpoint.AuditLogService, "log", AsyncMock())
 
     await endpoint.delete_document(
@@ -256,26 +256,71 @@ async def test_delete_document_without_task_or_file(monkeypatch, status):
     )
 
     vector_store.delete_document_vectors.assert_awaited_once_with(doc.id)
+    endpoint.document_processor.delete_media_assets.assert_awaited_once_with(
+        kb.id, doc.id
+    )
     doc.delete.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_document_media_returns_existing_asset(monkeypatch, tmp_path):
     doc = document()
-    asset = tmp_path / "image.png"
-    asset.write_bytes(b"png")
+    kb_id = uuid4()
+    storage = SimpleNamespace(
+        exists=AsyncMock(return_value=True),
+        response=AsyncMock(
+            return_value=SimpleNamespace(path="asset", media_type="image/png")
+        ),
+    )
     monkeypatch.setattr(endpoint, "check_kb_access", AsyncMock())
     monkeypatch.setattr(endpoint.Document, "filter", lambda **_kwargs: Query(first=doc))
     monkeypatch.setattr(
-        endpoint.document_processor,
-        "get_media_asset_path",
-        lambda *_args: asset,
+        endpoint, "get_upload_storage_backend", AsyncMock(return_value=storage)
     )
 
-    response = await endpoint.get_document_media(uuid4(), doc.id, "image.png", user())
+    response = await endpoint.get_document_media(kb_id, doc.id, "image.png", user())
 
-    assert response.path == asset
-    assert response.media_type == "image/png"
+    assert response.path == "asset"
+    storage.exists.assert_awaited_once_with(
+        f"documents/{kb_id}/media/{doc.id}/image.png"
+    )
+    storage.response.assert_awaited_once_with(
+        f"documents/{kb_id}/media/{doc.id}/image.png", content_type="image/png"
+    )
+
+
+@pytest.mark.asyncio
+async def test_document_media_falls_back_to_legacy_local_asset(monkeypatch):
+    doc = document()
+    kb_id = uuid4()
+    key = f"documents/{kb_id}/media/{doc.id}/image.png"
+    object_storage = SimpleNamespace(
+        exists=AsyncMock(return_value=False), response=AsyncMock()
+    )
+
+    class LegacyStorage:
+        instances = []
+
+        def __init__(self, _root):
+            self.exists = AsyncMock(return_value=True)
+            self.response = AsyncMock(
+                return_value=SimpleNamespace(path="legacy", media_type="image/png")
+            )
+            self.instances.append(self)
+
+    monkeypatch.setattr(endpoint, "check_kb_access", AsyncMock())
+    monkeypatch.setattr(endpoint.Document, "filter", lambda **_kwargs: Query(first=doc))
+    monkeypatch.setattr(
+        endpoint, "get_upload_storage_backend", AsyncMock(return_value=object_storage)
+    )
+    monkeypatch.setattr(endpoint, "LocalUploadStorage", LegacyStorage)
+    response = await endpoint.get_document_media(kb_id, doc.id, "image.png", user())
+
+    assert response.path == "legacy"
+    legacy_storage = LegacyStorage.instances[-1]
+    object_storage.exists.assert_awaited_once_with(key)
+    legacy_storage.exists.assert_awaited_once_with(key)
+    legacy_storage.response.assert_awaited_once_with(key, content_type="image/png")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_knowledge_bases_residual_companion2_issue255.py
+++ b/backend/tests/api/test_knowledge_bases_residual_companion2_issue255.py
@@ -218,7 +218,7 @@ async def test_delete_document_cleans_processing_task_file_vectors_and_stats(
     monkeypatch.setattr(kb_endpoint, "VectorStore", lambda: vector_store)
     monkeypatch.setattr(kb_endpoint.document_processor, "delete_file", AsyncMock())
     monkeypatch.setattr(
-        kb_endpoint.document_processor, "delete_media_assets", lambda *_args: None
+        kb_endpoint.document_processor, "delete_media_assets", AsyncMock()
     )
     monkeypatch.setattr(kb_endpoint.AuditLogService, "log", AsyncMock())
 

--- a/backend/tests/api/test_knowledge_bases_residual_issue255.py
+++ b/backend/tests/api/test_knowledge_bases_residual_issue255.py
@@ -487,10 +487,10 @@ async def test_delete_document_ignores_cleanup_failures_and_updates_counts(
 
     monkeypatch.setattr(kb_api, "VectorStore", lambda: VectorStore())
 
-    async def to_thread(*_args, **_kwargs):
-        return None
-
-    monkeypatch.setattr(kb_api.asyncio, "to_thread", to_thread)
+    delete_media_assets = AsyncMock()
+    monkeypatch.setattr(
+        kb_api.document_processor, "delete_media_assets", delete_media_assets
+    )
 
     async def delete_file(path):
         assert path == doc.file_path
@@ -500,6 +500,7 @@ async def test_delete_document_ignores_cleanup_failures_and_updates_counts(
     result = await kb_api.delete_document(kb.id, doc.id, fake_request, user)
 
     assert result["data"] == {"id": str(doc.id)}
+    delete_media_assets.assert_awaited_once_with(kb.id, doc.id)
     assert doc.deleted is True
     assert kb.document_count == 0
     assert kb.total_chunks == 0

--- a/backend/tests/services/test_document_processor_branches.py
+++ b/backend/tests/services/test_document_processor_branches.py
@@ -32,9 +32,21 @@ def test_document_type_detection(processor, filename, content_type, expected):
     assert processor.get_document_type(filename, content_type) == expected
 
 
-def test_paths_and_media_resource_cleanup(processor):
+@pytest.mark.asyncio
+async def test_paths_and_media_resource_cleanup(processor, monkeypatch):
     kb_id = uuid4()
     document_id = uuid4()
+
+    async def local_storage(root):
+        from app.services import upload_storage
+
+        return upload_storage.LocalUploadStorage(root)
+
+    monkeypatch.setattr(
+        document_processor_module,
+        "get_upload_storage_backend",
+        local_storage,
+    )
 
     short_path = processor.get_storage_path(kb_id, "../report.txt")
     long_path = processor.get_storage_path(kb_id, f"{'x' * 60}.pdf")
@@ -60,29 +72,32 @@ def test_paths_and_media_resource_cleanup(processor):
         with pytest.raises(ValueError, match="validation_error"):
             processor._sanitize_filename(invalid)
 
-    asset = processor._save_media_asset(
+    asset = await processor._save_media_asset(
         kb_id=kb_id,
         document_id=document_id,
         content_type="image/x-custom",
         content=b"asset",
     )
     assert asset["filename"].endswith(".bin")
-    processor._save_media_asset(
+    await processor._save_media_asset(
         kb_id=kb_id,
         document_id=document_id,
         content_type="image/x-custom",
         content=b"asset",
     )
-    processor.delete_media_assets(kb_id, document_id)
-    assert not Path(asset["path"]).exists()
+    media_path = processor.get_media_asset_path(kb_id, document_id, asset["filename"])
+    assert media_path.exists()
+    await processor.delete_media_assets(kb_id, document_id)
+    assert not media_path.exists()
 
 
-def test_media_replacement_ignores_unsupported_and_invalid_data(processor):
+@pytest.mark.asyncio
+async def test_media_replacement_ignores_unsupported_and_invalid_data(processor):
     invalid = "data:image/png;base64,not-valid=="
     unsupported = "data:image/bmp;base64," + base64.b64encode(b"bmp").decode()
     text = f"{invalid} {unsupported}"
 
-    assert processor.replace_embedded_media_data_uris(
+    assert await processor.replace_embedded_media_data_uris(
         text, kb_id=uuid4(), document_id=uuid4()
     ) == (text, [])
 
@@ -212,6 +227,26 @@ async def test_fetch_url_content_with_markitdown(processor, monkeypatch):
         "format": "markdown",
         "title": "Page",
         "char_count": 7,
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_content_markitdown_without_title(processor, monkeypatch):
+    class FakeMarkItDown:
+        def convert(self, url):
+            return SimpleNamespace(text_content="body", title=None)
+
+    monkeypatch.setitem(
+        sys.modules, "markitdown", SimpleNamespace(MarkItDown=FakeMarkItDown)
+    )
+
+    text, metadata = await processor.fetch_url_content("https://example.test")
+
+    assert text == "body"
+    assert metadata == {
+        "source_url": "https://example.test",
+        "format": "markdown",
+        "char_count": 4,
     }
 
 

--- a/backend/tests/services/test_document_processor_media_assets.py
+++ b/backend/tests/services/test_document_processor_media_assets.py
@@ -3,6 +3,8 @@ import importlib
 import io
 import zipfile
 from uuid import uuid4
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -14,7 +16,8 @@ from app.services.document_processor import DocumentProcessor
 document_processor_module = importlib.import_module("app.services.document_processor")
 
 
-def test_replace_embedded_media_data_uris_saves_assets(tmp_path):
+@pytest.mark.asyncio
+async def test_replace_embedded_media_data_uris_saves_assets(tmp_path):
     processor = DocumentProcessor(upload_dir=str(tmp_path / "documents"))
     kb_id = uuid4()
     document_id = uuid4()
@@ -23,11 +26,20 @@ def test_replace_embedded_media_data_uris_saves_assets(tmp_path):
         "ascii"
     )
 
-    text, assets = processor.replace_embedded_media_data_uris(
-        f"before ![sample]({data_uri}) after",
-        kb_id=kb_id,
-        document_id=document_id,
-    )
+    async def local_storage(root):
+        return upload_storage.LocalUploadStorage(root)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            document_processor_module,
+            "get_upload_storage_backend",
+            local_storage,
+        )
+        text, assets = await processor.replace_embedded_media_data_uris(
+            f"before ![sample]({data_uri}) after",
+            kb_id=kb_id,
+            document_id=document_id,
+        )
 
     assert data_uri not in text
     assert f"/api/v1/knowledge-bases/{kb_id}/documents/{document_id}/media/" in text
@@ -77,6 +89,65 @@ async def test_extract_text_resourceizes_markdown_data_uri_when_context_is_provi
     assert data_uri not in text
     assert metadata["media_assets"][0]["content_type"] == "image/png"
     assert metadata["media_assets"][0]["size"] == len(image_content)
+
+
+@pytest.mark.asyncio
+async def test_extract_text_without_data_uris_records_no_media_assets(tmp_path):
+    processor = DocumentProcessor(upload_dir=str(tmp_path / "documents"))
+    kb_id = uuid4()
+    document_id = uuid4()
+    markdown_path = processor.get_storage_path(kb_id, "plain.md")
+
+    async def local_storage(root):
+        return upload_storage.LocalUploadStorage(root)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            document_processor_module,
+            "get_upload_storage_backend",
+            local_storage,
+        )
+        await processor.save_file(b"# No images here", markdown_path)
+        text, metadata = await processor.extract_text(
+            markdown_path,
+            DocumentType.MD.value,
+            kb_id=kb_id,
+            document_id=document_id,
+        )
+
+    assert text == "# No images here"
+    assert "media_assets" not in metadata
+
+
+@pytest.mark.asyncio
+async def test_delete_media_assets_cleans_object_and_legacy_local_files(
+    tmp_path, monkeypatch
+):
+    processor = DocumentProcessor(upload_dir=str(tmp_path / "documents"))
+    kb_id = uuid4()
+    document_id = uuid4()
+    key = f"documents/{kb_id}/media/{document_id}/legacy.png"
+    legacy_path = tmp_path / key
+    legacy_path.parent.mkdir(parents=True)
+    legacy_path.write_bytes(b"legacy")
+    object_storage = SimpleNamespace(
+        list=AsyncMock(return_value=[key]),
+        delete=AsyncMock(),
+    )
+
+    monkeypatch.setattr(
+        document_processor_module,
+        "get_upload_storage_backend",
+        AsyncMock(return_value=object_storage),
+    )
+
+    await processor.delete_media_assets(kb_id, document_id)
+
+    object_storage.list.assert_awaited_once_with(
+        f"documents/{kb_id}/media/{document_id}/"
+    )
+    object_storage.delete.assert_awaited_once_with(key)
+    assert not legacy_path.exists()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_internal_uploads_gateway.py
+++ b/backend/tests/services/test_internal_uploads_gateway.py
@@ -17,7 +17,8 @@ import app.services  # noqa: F401  # Initialize service exports before the endpo
 from app.api.v1.endpoints.internal_uploads import router as internal_router
 from app.core.config import settings
 from app.services import upload_storage
-from app.services.document_processor import DocumentProcessor, UploadGatewayError
+from app.services.document_processor import DocumentProcessor
+from app.services.upload_gateway import UploadGatewayError
 
 
 @pytest.fixture
@@ -173,6 +174,7 @@ def test_save_and_delete_and_exists(gateway_client, monkeypatch):
     )
     assert missing.status_code == 404
 
+    storage.exists.return_value = True
     delete = gateway_client.delete(
         "/internal/uploads/delete",
         params={"key": "documents/kb/doc.pdf"},
@@ -180,6 +182,16 @@ def test_save_and_delete_and_exists(gateway_client, monkeypatch):
     )
     assert delete.status_code == 204
     storage.delete.assert_awaited_once_with("documents/kb/doc.pdf")
+
+    storage.delete.reset_mock()
+    storage.exists.return_value = False
+    missing_delete = gateway_client.delete(
+        "/internal/uploads/delete",
+        params={"key": "documents/missing.pdf"},
+        headers=headers,
+    )
+    assert missing_delete.status_code == 404
+    storage.delete.assert_not_awaited()
 
 
 def test_media_save_and_delete_delegate_to_document_processor(
@@ -230,10 +242,13 @@ def remote_processor(tmp_path, monkeypatch):
     return DocumentProcessor(upload_dir=str(tmp_path / "uploads" / "documents"))
 
 
-def _patch_http_client(monkeypatch, *, status_code=200, stream_error=None):
+def _patch_http_client(
+    monkeypatch, *, status_code=200, request_status_code=200, stream_error=None
+):
     import importlib
 
     module = importlib.import_module("app.services.document_processor")
+    gateway_module = importlib.import_module("app.services.upload_gateway")
 
     async def aiter_bytes():
         if stream_error is not None:
@@ -254,7 +269,10 @@ def _patch_http_client(monkeypatch, *, status_code=200, stream_error=None):
         async def __aexit__(self, *_args):
             return None
 
-    fake_resp = SimpleNamespace(status_code=200, raise_for_status=Mock())
+    fake_resp = SimpleNamespace(
+        status_code=request_status_code,
+        raise_for_status=Mock(),
+    )
     fake_client = AsyncMock()
     fake_client.put = AsyncMock(return_value=fake_resp)
     fake_client.delete = AsyncMock(return_value=fake_resp)
@@ -267,6 +285,7 @@ def _patch_http_client(monkeypatch, *, status_code=200, stream_error=None):
         AsyncClient=Mock(return_value=fake_client), HTTPError=httpx.HTTPError
     )
     monkeypatch.setattr(module, "httpx", fake_httpx)
+    monkeypatch.setattr(gateway_module, "httpx", fake_httpx)
     return fake_client
 
 
@@ -315,8 +334,7 @@ async def test_remote_processor_reads_through_internal_gateway_app(
     processor = DocumentProcessor(upload_dir=str(tmp_path / "uploads" / "documents"))
     transport = httpx.ASGITransport(app=gateway_app)
     monkeypatch.setattr(
-        processor,
-        "_internal_client",
+        "app.services.upload_gateway.client",
         lambda: httpx.AsyncClient(
             transport=transport,
             base_url="http://gateway",
@@ -339,6 +357,20 @@ async def test_remote_delete_file_calls_internal_endpoint(
         "DELETE",
         "/internal/uploads/delete",
         params={"key": "documents/kb/doc.pdf"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_delete_file_returns_false_for_missing(
+    remote_processor, monkeypatch
+):
+    fake_client = _patch_http_client(monkeypatch, request_status_code=404)
+
+    assert await remote_processor.delete_file("documents/kb/missing.pdf") is False
+    fake_client.request.assert_awaited_once_with(
+        "DELETE",
+        "/internal/uploads/delete",
+        params={"key": "documents/kb/missing.pdf"},
     )
 
 
@@ -399,8 +431,16 @@ async def test_local_storage_list_empty_prefix_lists_all(tmp_path):
     assert await storage.list("") == ["a.txt", "sub/b.txt"]
 
 
+@pytest.mark.parametrize(
+    ("prefix", "expected_prefix"),
+    [
+        ("", ""),
+        ("documents/kb", "documents/kb/"),
+        ("documents/kb/", "documents/kb/"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_object_storage_list_paginates(monkeypatch):
+async def test_object_storage_list_paginates(monkeypatch, prefix, expected_prefix):
     first_page = {
         "Contents": [{"Key": "documents/kb/a.png"}, {"Key": "documents/kb/b.png"}]
     }
@@ -433,7 +473,8 @@ async def test_object_storage_list_paginates(monkeypatch):
         )
     )
 
-    keys = await storage.list("documents/kb/")
+    keys = await storage.list(prefix)
 
     assert keys == ["documents/kb/a.png", "documents/kb/b.png", "documents/kb/c.png"]
     client.get_paginator.assert_called_once_with("list_objects_v2")
+    paginator.paginate.assert_called_once_with(Bucket="uploads", Prefix=expected_prefix)

--- a/backend/tests/services/test_internal_uploads_gateway.py
+++ b/backend/tests/services/test_internal_uploads_gateway.py
@@ -1,0 +1,439 @@
+"""Tests for the worker -> api internal upload gateway.
+
+Covers: token auth (fail-closed), the /internal/uploads/* endpoints, the
+document_processor remote-mode branches (explicit HTTP calls), and the
+UploadStorageBackend.list() capability added for media asset deletion.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import FastAPI, Response
+from fastapi.testclient import TestClient
+
+import app.services  # noqa: F401  # Initialize service exports before the endpoints.
+
+from app.api.v1.endpoints.internal_uploads import router as internal_router
+from app.core.config import settings
+from app.services import upload_storage
+from app.services.document_processor import DocumentProcessor, UploadGatewayError
+
+
+@pytest.fixture
+def gateway_app():
+    app = FastAPI()
+    app.include_router(internal_router, prefix="/internal")
+    return app
+
+
+@pytest.fixture
+def gateway_client(gateway_app):
+    return TestClient(gateway_app)
+
+
+def _mock_storage(monkeypatch):
+    storage = Mock()
+    storage.response = AsyncMock(return_value=Response(content=b"bytes"))
+    storage.save = AsyncMock(return_value="/tmp/uploads/key.bin")
+    storage.exists = AsyncMock(return_value=True)
+    storage.delete = AsyncMock()
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.internal_uploads.get_upload_storage_backend",
+        AsyncMock(return_value=storage),
+    )
+    return storage
+
+
+# ── Auth ──────────────────────────────────────────────────────────
+
+
+def test_gateway_fails_closed_when_token_unset(gateway_client, monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "")
+    resp = gateway_client.get("/internal/uploads/read", params={"key": "documents/x"})
+    assert resp.status_code == 404
+
+
+def test_gateway_rejects_missing_and_wrong_token(gateway_client, monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "secret-token")
+    resp = gateway_client.get("/internal/uploads/read", params={"key": "documents/x"})
+    assert resp.status_code == 401
+
+    resp = gateway_client.get(
+        "/internal/uploads/read",
+        params={"key": "documents/x"},
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert resp.status_code == 401
+
+    resp = gateway_client.get(
+        "/internal/uploads/read",
+        params={"key": "documents/x"},
+        headers={"Authorization": "Token secret-token"},
+    )
+    assert resp.status_code == 401
+
+
+def test_gateway_reads_token_from_rotating_secret_file(
+    gateway_client, monkeypatch, tmp_path
+):
+    token_file = tmp_path / "internal-api-token"
+    token_file.write_text("first-token", encoding="utf-8")
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "")
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN_FILE", str(token_file))
+    _mock_storage(monkeypatch)
+
+    first = gateway_client.get(
+        "/internal/uploads/read",
+        params={"key": "documents/kb/doc.pdf"},
+        headers={"Authorization": "Bearer first-token"},
+    )
+    assert first.status_code == 200
+
+    token_file.write_text("rotated-token", encoding="utf-8")
+    rotated = gateway_client.get(
+        "/internal/uploads/read",
+        params={"key": "documents/kb/doc.pdf"},
+        headers={"Authorization": "Bearer rotated-token"},
+    )
+    assert rotated.status_code == 200
+
+
+def test_token_file_falls_back_to_environment_token(monkeypatch, tmp_path):
+    token_file = tmp_path / "internal-api-token"
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "environment-token")
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN_FILE", str(token_file))
+
+    assert settings.get_internal_api_token() == "environment-token"
+
+    token_file.write_text("\n", encoding="utf-8")
+    assert settings.get_internal_api_token() == "environment-token"
+
+
+# ── Endpoints ─────────────────────────────────────────────────────
+
+
+def test_read_streams_storage_response(gateway_client, monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "secret-token")
+    storage = _mock_storage(monkeypatch)
+
+    resp = gateway_client.get(
+        "/internal/uploads/read",
+        params={"key": "documents/kb/doc.pdf"},
+        headers={"Authorization": "Bearer secret-token"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.content == b"bytes"
+    storage.exists.assert_awaited_once_with("documents/kb/doc.pdf")
+    storage.response.assert_awaited_once_with("documents/kb/doc.pdf")
+
+
+def test_read_404_when_missing(gateway_client, monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "secret-token")
+    storage = _mock_storage(monkeypatch)
+    storage.exists.return_value = False
+
+    resp = gateway_client.get(
+        "/internal/uploads/read",
+        params={"key": "documents/missing.pdf"},
+        headers={"Authorization": "Bearer secret-token"},
+    )
+
+    assert resp.status_code == 404
+
+
+def test_save_and_delete_and_exists(gateway_client, monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "secret-token")
+    storage = _mock_storage(monkeypatch)
+    headers = {"Authorization": "Bearer secret-token"}
+
+    save = gateway_client.put(
+        "/internal/uploads/save",
+        params={"key": "documents/kb/doc.pdf"},
+        content=b"pdf",
+        headers=headers,
+    )
+    assert save.status_code == 200
+    assert save.json() == {"storage_path": "/tmp/uploads/key.bin"}
+    storage.save.assert_awaited_once_with("documents/kb/doc.pdf", b"pdf")
+
+    exists = gateway_client.head(
+        "/internal/uploads/exists",
+        params={"key": "documents/kb/doc.pdf"},
+        headers=headers,
+    )
+    assert exists.status_code == 200
+
+    storage.exists.return_value = False
+    missing = gateway_client.head(
+        "/internal/uploads/exists",
+        params={"key": "documents/missing.pdf"},
+        headers=headers,
+    )
+    assert missing.status_code == 404
+
+    delete = gateway_client.delete(
+        "/internal/uploads/delete",
+        params={"key": "documents/kb/doc.pdf"},
+        headers=headers,
+    )
+    assert delete.status_code == 204
+    storage.delete.assert_awaited_once_with("documents/kb/doc.pdf")
+
+
+def test_media_save_and_delete_delegate_to_document_processor(
+    gateway_client, monkeypatch
+):
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "secret-token")
+    headers = {"Authorization": "Bearer secret-token"}
+    save_asset = AsyncMock(
+        return_value={
+            "path": "documents/kb/media/doc/a.png",
+            "url": "/api/v1/knowledge-bases/kb/documents/doc/media/a.png",
+            "filename": "a.png",
+            "content_type": "image/png",
+            "size": 3,
+        }
+    )
+    delete_assets = AsyncMock()
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.internal_uploads.document_processor",
+        Mock(_save_media_asset=save_asset, delete_media_assets=delete_assets),
+    )
+
+    save = gateway_client.put(
+        "/internal/uploads/media/11111111-1111-1111-1111-111111111111/"
+        "22222222-2222-2222-2222-222222222222",
+        content=b"png",
+        headers={**headers, "Content-Type": "image/png"},
+    )
+    assert save.status_code == 200
+    assert save.json()["filename"] == "a.png"
+    save_asset.assert_awaited_once()
+
+    delete = gateway_client.delete(
+        "/internal/uploads/media/11111111-1111-1111-1111-111111111111/"
+        "22222222-2222-2222-2222-222222222222",
+        headers=headers,
+    )
+    assert delete.status_code == 204
+    delete_assets.assert_awaited_once()
+
+
+@pytest.fixture
+def remote_processor(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "UPLOAD_STORAGE_MODE", "remote")
+    monkeypatch.setattr(settings, "API_INTERNAL_BASE_URL", "http://api:8000")
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "secret-token")
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN_FILE", "")
+    return DocumentProcessor(upload_dir=str(tmp_path / "uploads" / "documents"))
+
+
+def _patch_http_client(monkeypatch, *, status_code=200, stream_error=None):
+    import importlib
+
+    module = importlib.import_module("app.services.document_processor")
+
+    async def aiter_bytes():
+        if stream_error is not None:
+            raise stream_error
+        yield b"by"
+        yield b"tes"
+
+    stream_response = SimpleNamespace(
+        status_code=status_code,
+        raise_for_status=Mock(),
+        aiter_bytes=aiter_bytes,
+    )
+
+    class StreamContext:
+        async def __aenter__(self):
+            return stream_response
+
+        async def __aexit__(self, *_args):
+            return None
+
+    fake_resp = SimpleNamespace(status_code=200, raise_for_status=Mock())
+    fake_client = AsyncMock()
+    fake_client.put = AsyncMock(return_value=fake_resp)
+    fake_client.delete = AsyncMock(return_value=fake_resp)
+    fake_client.request = AsyncMock(return_value=fake_resp)
+    fake_client.stream = Mock(return_value=StreamContext())
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    import httpx
+
+    fake_httpx = SimpleNamespace(
+        AsyncClient=Mock(return_value=fake_client), HTTPError=httpx.HTTPError
+    )
+    monkeypatch.setattr(module, "httpx", fake_httpx)
+    return fake_client
+
+
+@pytest.mark.asyncio
+async def test_remote_read_file_streams_internal_endpoint(
+    remote_processor, monkeypatch
+):
+    fake_client = _patch_http_client(monkeypatch)
+
+    content = await remote_processor.read_file("documents/kb/doc.pdf")
+
+    assert content == b"bytes"
+    fake_client.stream.assert_called_once_with(
+        "GET", "/internal/uploads/read", params={"key": "documents/kb/doc.pdf"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_read_file_preserves_missing_error(remote_processor, monkeypatch):
+    _patch_http_client(monkeypatch, status_code=404)
+
+    with pytest.raises(FileNotFoundError, match="documents/kb/doc.pdf"):
+        await remote_processor.read_file("documents/kb/doc.pdf")
+
+
+@pytest.mark.asyncio
+async def test_remote_read_file_wraps_network_error(remote_processor, monkeypatch):
+    import httpx
+
+    _patch_http_client(monkeypatch, stream_error=httpx.ReadError("connection reset"))
+
+    with pytest.raises(UploadGatewayError, match="api gateway"):
+        await remote_processor.read_file("documents/kb/doc.pdf")
+
+
+@pytest.mark.asyncio
+async def test_remote_processor_reads_through_internal_gateway_app(
+    gateway_app, monkeypatch, tmp_path
+):
+    import httpx
+
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "gateway-token")
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN_FILE", "")
+    monkeypatch.setattr(settings, "UPLOAD_STORAGE_MODE", "remote")
+    storage = _mock_storage(monkeypatch)
+    processor = DocumentProcessor(upload_dir=str(tmp_path / "uploads" / "documents"))
+    transport = httpx.ASGITransport(app=gateway_app)
+    monkeypatch.setattr(
+        processor,
+        "_internal_client",
+        lambda: httpx.AsyncClient(
+            transport=transport,
+            base_url="http://gateway",
+            headers={"Authorization": "Bearer gateway-token"},
+        ),
+    )
+
+    assert await processor.read_file("documents/kb/doc.pdf") == b"bytes"
+    storage.response.assert_awaited_once_with("documents/kb/doc.pdf")
+
+
+@pytest.mark.asyncio
+async def test_remote_delete_file_calls_internal_endpoint(
+    remote_processor, monkeypatch
+):
+    fake_client = _patch_http_client(monkeypatch)
+
+    assert await remote_processor.delete_file("documents/kb/doc.pdf") is True
+    fake_client.request.assert_awaited_once_with(
+        "DELETE",
+        "/internal/uploads/delete",
+        params={"key": "documents/kb/doc.pdf"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_media_save_and_delete_use_gateway(remote_processor, monkeypatch):
+    fake_client = _patch_http_client(monkeypatch)
+    kb_id, doc_id = __import__("uuid").uuid4(), __import__("uuid").uuid4()
+
+    asset = await remote_processor._save_media_asset(
+        kb_id=kb_id,
+        document_id=doc_id,
+        content_type="image/png",
+        content=b"png",
+    )
+
+    assert asset["filename"].endswith(".png")
+    assert asset["url"] == (
+        f"/api/v1/knowledge-bases/{kb_id}/documents/{doc_id}/media/{asset['filename']}"
+    )
+    fake_client.put.assert_awaited_once()
+
+    await remote_processor.delete_media_assets(kb_id, doc_id)
+    fake_client.delete.assert_awaited_once_with(
+        f"/internal/uploads/media/{kb_id}/{doc_id}"
+    )
+
+
+# ── UploadStorageBackend.list ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_local_storage_list_returns_relative_keys(tmp_path):
+    root = tmp_path / "uploads"
+    (root / "documents" / "kb1" / "media" / "doc1").mkdir(parents=True)
+    (root / "documents" / "kb1" / "media" / "doc1" / "a.png").write_bytes(b"a")
+    (root / "documents" / "kb1" / "media" / "doc1" / "b.png").write_bytes(b"b")
+    storage = upload_storage.LocalUploadStorage(root)
+
+    keys = await storage.list("documents/kb1/media/doc1/")
+
+    assert keys == [
+        "documents/kb1/media/doc1/a.png",
+        "documents/kb1/media/doc1/b.png",
+    ]
+    assert await storage.list("documents/kb1/media/missing/") == []
+    assert await storage.list("../../escape") == []
+
+
+@pytest.mark.asyncio
+async def test_local_storage_list_empty_prefix_lists_all(tmp_path):
+    root = tmp_path / "uploads"
+    root.mkdir()
+    (root / "a.txt").write_bytes(b"a")
+    (root / "sub").mkdir()
+    (root / "sub" / "b.txt").write_bytes(b"b")
+    storage = upload_storage.LocalUploadStorage(root)
+
+    assert await storage.list("") == ["a.txt", "sub/b.txt"]
+
+
+@pytest.mark.asyncio
+async def test_object_storage_list_paginates(monkeypatch):
+    first_page = {
+        "Contents": [{"Key": "documents/kb/a.png"}, {"Key": "documents/kb/b.png"}]
+    }
+    second_page = {"Contents": [{"Key": "documents/kb/c.png"}]}
+
+    async def _pages():
+        yield first_page
+        yield second_page
+
+    paginator = Mock()
+    paginator.paginate = Mock(return_value=_pages())
+    client = Mock()
+    client.get_paginator = Mock(return_value=paginator)
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    session = Mock()
+    session.create_client = Mock(return_value=ctx)
+    monkeypatch.setattr(upload_storage, "get_session", lambda: session)
+
+    storage = upload_storage.ObjectUploadStorage(
+        upload_storage.ObjectStorageConfig(
+            endpoint="minio:9000",
+            bucket="uploads",
+            region=None,
+            access_key="a",
+            secret_key="s",
+            secure=False,
+            force_path_style=True,
+        )
+    )
+
+    keys = await storage.list("documents/kb/")
+
+    assert keys == ["documents/kb/a.png", "documents/kb/b.png", "documents/kb/c.png"]
+    client.get_paginator.assert_called_once_with("list_objects_v2")

--- a/backend/tests/services/test_sandbox_manager.py
+++ b/backend/tests/services/test_sandbox_manager.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import pytest
 from app.core.config import settings
 from app.schemas.response import BusinessError, ResponseCode
-from app.services.document_processor import UploadGatewayError
+from app.services.upload_gateway import UploadGatewayError, read as read_upload
 
 from app.services.sandbox.manager import SandboxManager
 from app.services.sandbox.models import (
@@ -843,7 +843,7 @@ class TestSandboxManager:
         client = Client()
         async_client = Mock(return_value=client)
         monkeypatch.setattr(
-            "app.services.sandbox.manager.httpx.AsyncClient", async_client
+            "app.services.upload_gateway.httpx.AsyncClient", async_client
         )
         job = SandboxJob(
             command=["python3"],
@@ -875,15 +875,52 @@ class TestSandboxManager:
         )
 
     @pytest.mark.anyio
-    async def test_read_asset_gateway_preserves_missing_and_wraps_network_error(
+    async def test_stage_asset_input_maps_remote_asset_integrity_failure(
         self, tmp_path: Path, monkeypatch
+    ):
+        workspace_manager = SandboxWorkspaceManager(root=str(tmp_path))
+        workspace = workspace_manager.prepare("job-1")
+        manager = SandboxManager(
+            workspace_manager=workspace_manager,
+            cleanup_workspaces=False,
+            result_store=InMemoryResultStore(),
+        )
+        content = b"remote asset content"
+        asset = SimpleNamespace(
+            storage_key="files/input.bin",
+            size=len(content),
+            checksum="invalid-checksum",
+        )
+        authorize = AsyncMock(return_value=asset)
+        read = AsyncMock(return_value=content)
+        monkeypatch.setattr(
+            "app.services.asset.asset_service.get_authorized", authorize
+        )
+        monkeypatch.setattr("app.services.sandbox.manager.upload_gateway.read", read)
+        monkeypatch.setattr(settings, "UPLOAD_STORAGE_MODE", "remote")
+        job = SandboxJob(
+            command=["python3"],
+            input_files=[
+                SandboxInputFileSpec(
+                    target_path="/workspace/input/data.bin",
+                    asset_id="c3f74d2b-255d-49bc-8895-89a7f088ea86",
+                )
+            ],
+        )
+
+        with pytest.raises(BusinessError) as exc_info:
+            await manager._stage_input_files(job, workspace)
+
+        assert exc_info.value.code == ResponseCode.VALIDATION_ERROR
+        assert exc_info.value.msg_key == "sandbox_input_checksum_mismatch"
+        read.assert_awaited_once_with(asset.storage_key)
+
+    @pytest.mark.anyio
+    async def test_upload_gateway_preserves_missing_and_wraps_network_error(
+        self, monkeypatch
     ):
         import httpx
 
-        manager = SandboxManager(
-            workspace_manager=SandboxWorkspaceManager(root=str(tmp_path)),
-            result_store=InMemoryResultStore(),
-        )
         monkeypatch.setattr(settings, "API_INTERNAL_BASE_URL", "http://api:8000")
         monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "gateway-token")
         monkeypatch.setattr(settings, "INTERNAL_API_TOKEN_FILE", "")
@@ -910,18 +947,18 @@ class TestSandboxManager:
                 return None
 
         monkeypatch.setattr(
-            "app.services.sandbox.manager.httpx.AsyncClient",
+            "app.services.upload_gateway.httpx.AsyncClient",
             Mock(return_value=Client()),
         )
         with pytest.raises(FileNotFoundError, match="files/missing.bin"):
-            await manager._read_asset_from_gateway("files/missing.bin")
+            await read_upload("files/missing.bin")
 
         monkeypatch.setattr(
-            "app.services.sandbox.manager.httpx.AsyncClient",
+            "app.services.upload_gateway.httpx.AsyncClient",
             Mock(side_effect=httpx.ConnectError("connection reset")),
         )
         with pytest.raises(UploadGatewayError, match="api gateway"):
-            await manager._read_asset_from_gateway("files/missing.bin")
+            await read_upload("files/missing.bin")
 
     def test_parse_snippet_result_handles_timeout_and_plain_output(
         self, tmp_path: Path

--- a/backend/tests/services/test_sandbox_manager.py
+++ b/backend/tests/services/test_sandbox_manager.py
@@ -4,11 +4,13 @@ import json
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 from uuid import uuid4
 
 import pytest
+from app.core.config import settings
 from app.schemas.response import BusinessError, ResponseCode
+from app.services.document_processor import UploadGatewayError
 
 from app.services.sandbox.manager import SandboxManager
 from app.services.sandbox.models import (
@@ -746,6 +748,7 @@ class TestSandboxManager:
             "app.services.asset.asset_service.get_authorized", authorize
         )
         monkeypatch.setattr("app.services.asset.asset_service.read", read)
+        monkeypatch.setattr(settings, "UPLOAD_STORAGE_MODE", "local")
         monkeypatch.setattr(
             "app.services.upload_storage.get_upload_storage_backend",
             AsyncMock(return_value=storage),
@@ -786,6 +789,139 @@ class TestSandboxManager:
         assert exc_info.value.code == ResponseCode.VALIDATION_ERROR
         assert exc_info.value.msg_key == "sandbox_input_size_mismatch"
         assert not (workspace.root / "input/.data.bin.partial").exists()
+
+    @pytest.mark.anyio
+    async def test_stage_asset_input_reads_through_internal_gateway(
+        self, tmp_path: Path, monkeypatch
+    ):
+        workspace_manager = SandboxWorkspaceManager(root=str(tmp_path))
+        workspace = workspace_manager.prepare("job-1")
+        manager = SandboxManager(
+            workspace_manager=workspace_manager,
+            cleanup_workspaces=False,
+            result_store=InMemoryResultStore(),
+        )
+        content = b"remote asset content"
+        checksum = hashlib.sha256(content).hexdigest()
+        asset = SimpleNamespace(
+            storage_key="files/input.bin", size=len(content), checksum=checksum
+        )
+        authorize = AsyncMock(return_value=asset)
+        monkeypatch.setattr(
+            "app.services.asset.asset_service.get_authorized", authorize
+        )
+        monkeypatch.setattr(settings, "UPLOAD_STORAGE_MODE", "remote")
+        monkeypatch.setattr(settings, "API_INTERNAL_BASE_URL", "http://api:8000")
+        monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "gateway-token")
+        monkeypatch.setattr(settings, "INTERNAL_API_TOKEN_FILE", "")
+
+        async def aiter_bytes():
+            yield b"remote "
+            yield b"asset content"
+
+        response = SimpleNamespace(
+            status_code=200, raise_for_status=Mock(), aiter_bytes=aiter_bytes
+        )
+
+        class StreamContext:
+            async def __aenter__(self):
+                return response
+
+            async def __aexit__(self, *_args):
+                return None
+
+        class Client:
+            def __init__(self):
+                self.stream = Mock(return_value=StreamContext())
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+        client = Client()
+        async_client = Mock(return_value=client)
+        monkeypatch.setattr(
+            "app.services.sandbox.manager.httpx.AsyncClient", async_client
+        )
+        job = SandboxJob(
+            command=["python3"],
+            input_files=[
+                SandboxInputFileSpec(
+                    target_path="/workspace/input/data.bin",
+                    asset_id="c3f74d2b-255d-49bc-8895-89a7f088ea86",
+                    expected_size=len(content),
+                    expected_checksum=checksum,
+                )
+            ],
+        )
+
+        await manager._stage_input_files(job, workspace)
+
+        assert (workspace.root / "input/data.bin").read_bytes() == content
+        async_client.assert_called_once_with(
+            base_url="http://api:8000",
+            headers={"Authorization": "Bearer gateway-token"},
+            timeout=60.0,
+        )
+        client.stream.assert_called_once_with(
+            "GET", "/internal/uploads/read", params={"key": asset.storage_key}
+        )
+        authorize.assert_awaited_once_with(
+            job.input_files[0].asset_id,
+            team_id=None,
+            user_id=None,
+        )
+
+    @pytest.mark.anyio
+    async def test_read_asset_gateway_preserves_missing_and_wraps_network_error(
+        self, tmp_path: Path, monkeypatch
+    ):
+        import httpx
+
+        manager = SandboxManager(
+            workspace_manager=SandboxWorkspaceManager(root=str(tmp_path)),
+            result_store=InMemoryResultStore(),
+        )
+        monkeypatch.setattr(settings, "API_INTERNAL_BASE_URL", "http://api:8000")
+        monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "gateway-token")
+        monkeypatch.setattr(settings, "INTERNAL_API_TOKEN_FILE", "")
+
+        response = SimpleNamespace(
+            status_code=404, raise_for_status=Mock(), aiter_bytes=None
+        )
+
+        class StreamContext:
+            async def __aenter__(self):
+                return response
+
+            async def __aexit__(self, *_args):
+                return None
+
+        class Client:
+            def stream(self, *_args, **_kwargs):
+                return StreamContext()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+        monkeypatch.setattr(
+            "app.services.sandbox.manager.httpx.AsyncClient",
+            Mock(return_value=Client()),
+        )
+        with pytest.raises(FileNotFoundError, match="files/missing.bin"):
+            await manager._read_asset_from_gateway("files/missing.bin")
+
+        monkeypatch.setattr(
+            "app.services.sandbox.manager.httpx.AsyncClient",
+            Mock(side_effect=httpx.ConnectError("connection reset")),
+        )
+        with pytest.raises(UploadGatewayError, match="api gateway"):
+            await manager._read_asset_from_gateway("files/missing.bin")
 
     def test_parse_snippet_result_handles_timeout_and_plain_output(
         self, tmp_path: Path

--- a/backend/tests/services/test_upload_storage.py
+++ b/backend/tests/services/test_upload_storage.py
@@ -34,6 +34,36 @@ async def test_local_upload_storage_save_read_delete(tmp_path: Path):
 
 
 @pytest.mark.anyio
+async def test_local_upload_storage_save_keeps_existing_file_on_write_failure(
+    monkeypatch, tmp_path: Path
+):
+    storage = LocalUploadStorage(tmp_path)
+    target = tmp_path / "documents" / "file.txt"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"complete-old-content")
+
+    class FailingWriter:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def write(self, _content):
+            raise OSError("disk full")
+
+    monkeypatch.setattr(
+        upload_storage.aiofiles, "open", lambda *_args, **_kwargs: FailingWriter()
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        await storage.save("documents/file.txt", b"partial")
+
+    assert target.read_bytes() == b"complete-old-content"
+    assert not list(target.parent.glob(".file.txt.*"))
+
+
+@pytest.mark.anyio
 async def test_local_upload_storage_read_response_and_traversal(tmp_path: Path):
     storage = LocalUploadStorage(tmp_path)
     await storage.save("file.txt", b"contents")

--- a/backend/tests/services/workflow/test_file_to_url_executor_edges_issue255.py
+++ b/backend/tests/services/workflow/test_file_to_url_executor_edges_issue255.py
@@ -92,7 +92,11 @@ def test_remaining_output_metadata_modes():
     ] == ["content", "filename", "mimeType", "size"]
     assert [item.name for item in executor.get_output_specs({})] == [
         "url",
+        "urls",
         "filename",
         "mimeType",
         "size",
     ]
+    urls_spec = executor.get_output_specs({})[1].type
+    assert urls_spec.kind == "array"
+    assert urls_spec.item is not None and urls_spec.item.kind == "string"

--- a/backend/tests/services/workflow/test_file_to_url_executor_edges_issue255.py
+++ b/backend/tests/services/workflow/test_file_to_url_executor_edges_issue255.py
@@ -11,16 +11,14 @@ def node(**config):
 
 
 @pytest.mark.asyncio
-async def test_path_reports_missing_file(tmp_path):
-    context = SimpleNamespace(
-        resolve_variable_ref=AsyncMock(return_value=str(tmp_path / "missing.txt"))
-    )
+async def test_empty_input_value_is_rejected():
+    context = SimpleNamespace(resolve_variable_ref=AsyncMock(return_value=""))
 
     result = await FileToURLNodeExecutor().execute(
-        node(inputType="path"), context, SimpleNamespace()
+        node(inputVariable="file"), context, SimpleNamespace()
     )
 
-    assert result.error == "file_not_found"
+    assert result.error == "validation_error"
 
 
 @pytest.mark.asyncio
@@ -35,26 +33,55 @@ async def test_invalid_base64_uses_encoded_length():
 
 
 @pytest.mark.asyncio
-async def test_file_read_error_is_translated(tmp_path):
-    file_path = tmp_path / "file.txt"
-    file_path.write_text("content")
+async def test_resolve_error_is_translated():
     context = SimpleNamespace(
-        resolve_variable_ref=AsyncMock(return_value=str(file_path))
+        resolve_variable_ref=AsyncMock(side_effect=OSError("private detail"))
     )
 
     with (
-        patch("os.path.getsize", side_effect=OSError("private detail")),
         patch(
             "app.services.workflow.executors.subworkflow.translate_public_workflow_error",
             return_value="public_error",
         ) as translate,
     ):
         result = await FileToURLNodeExecutor().execute(
-            node(inputType="path"), context, SimpleNamespace()
+            node(inputVariable="file"), context, SimpleNamespace()
         )
 
     assert result.error == "public_error"
     translate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_absolute_urls_are_passed_through_unchanged():
+    context = SimpleNamespace(
+        resolve_variable_ref=AsyncMock(
+            return_value="https://cdn.example.com/files/a.pdf"
+        )
+    )
+
+    result = await FileToURLNodeExecutor().execute(
+        node(inputVariable="file", ensureAbsolute=True),
+        context,
+        SimpleNamespace(),
+    )
+
+    assert result.outputs["url"] == "https://cdn.example.com/files/a.pdf"
+
+
+@pytest.mark.asyncio
+async def test_http_absolute_url_is_not_rebaselined():
+    context = SimpleNamespace(
+        resolve_variable_ref=AsyncMock(return_value="http://cdn.example.com/a.pdf")
+    )
+
+    result = await FileToURLNodeExecutor().execute(
+        node(inputVariable="file", ensureAbsolute=True),
+        context,
+        SimpleNamespace(),
+    )
+
+    assert result.outputs["url"] == "http://cdn.example.com/a.pdf"
 
 
 def test_remaining_output_metadata_modes():

--- a/backend/tests/services/workflow/test_file_to_url_executor_issue255.py
+++ b/backend/tests/services/workflow/test_file_to_url_executor_issue255.py
@@ -2,6 +2,7 @@ import base64
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
+from uuid import uuid4
 import pytest
 
 from app.services.workflow.executors.subworkflow import FileToURLNodeExecutor
@@ -118,7 +119,11 @@ async def test_legacy_path_to_base64_streams_internal_upload(monkeypatch):
         yield b"hel"
         yield b"lo"
 
-    stream_response = SimpleNamespace(raise_for_status=Mock(), aiter_bytes=aiter_bytes)
+    stream_response = SimpleNamespace(
+        status_code=200,
+        raise_for_status=Mock(),
+        aiter_bytes=aiter_bytes,
+    )
 
     class StreamContext:
         async def __aenter__(self):
@@ -161,6 +166,105 @@ async def test_legacy_path_to_base64_streams_internal_upload(monkeypatch):
         "/internal/uploads/read",
         params={"key": "documents/2026/08/report.txt"},
     )
+
+
+@pytest.mark.asyncio
+async def test_legacy_document_path_requires_workflow_team_access(monkeypatch):
+    from app.models.knowledge_base import KnowledgeBase
+    from app.models.workflow import Workflow
+    from app.services import upload_gateway
+
+    kb_id, workflow_id, team_id = uuid4(), uuid4(), uuid4()
+    workflow_filter = Mock()
+    workflow_filter.return_value.only.return_value.first = AsyncMock(
+        return_value=SimpleNamespace(team_id=team_id)
+    )
+    kb_filter = Mock()
+    kb_filter.return_value.first = AsyncMock(return_value=SimpleNamespace(id=kb_id))
+    read = AsyncMock(return_value=b"hello")
+    monkeypatch.setattr(Workflow, "filter", workflow_filter)
+    monkeypatch.setattr(KnowledgeBase, "filter", kb_filter)
+    monkeypatch.setattr(upload_gateway, "read", read)
+
+    context = SimpleNamespace(
+        resolve_variable_ref=AsyncMock(
+            return_value=f"/api/v1/upload/files/documents/{kb_id}/2026/08/report.txt"
+        )
+    )
+    result = await FileToURLNodeExecutor().execute(
+        node(inputVariable="file", inputType="path", outputType="base64"),
+        context,
+        SimpleNamespace(workflow_id=workflow_id),
+    )
+
+    assert result.outputs["content"] == base64.b64encode(b"hello").decode()
+    workflow_filter.assert_called_once_with(id=workflow_id)
+    kb_filter.assert_called_once_with(id=kb_id, team_id=team_id)
+    read.assert_awaited_once_with(f"documents/{kb_id}/2026/08/report.txt")
+
+
+@pytest.mark.asyncio
+async def test_legacy_document_path_rejects_missing_workflow(monkeypatch):
+    from app.models.knowledge_base import KnowledgeBase
+    from app.models.workflow import Workflow
+    from app.services import upload_gateway
+
+    workflow_filter = Mock()
+    workflow_filter.return_value.only.return_value.first = AsyncMock(return_value=None)
+    kb_filter = Mock()
+    read = AsyncMock(return_value=b"should not be read")
+    monkeypatch.setattr(Workflow, "filter", workflow_filter)
+    monkeypatch.setattr(KnowledgeBase, "filter", kb_filter)
+    monkeypatch.setattr(upload_gateway, "read", read)
+
+    context = SimpleNamespace(
+        resolve_variable_ref=AsyncMock(
+            return_value=f"documents/{uuid4()}/2026/08/report.txt"
+        )
+    )
+    result = await FileToURLNodeExecutor().execute(
+        node(inputVariable="file", inputType="path", outputType="base64"),
+        context,
+        SimpleNamespace(),
+    )
+
+    assert result.error == "not_found"
+    kb_filter.assert_not_called()
+    read.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_legacy_document_path_rejects_knowledge_base_from_other_team(monkeypatch):
+    from app.models.knowledge_base import KnowledgeBase
+    from app.models.workflow import Workflow
+    from app.services import upload_gateway
+
+    kb_id, workflow_id, team_id = uuid4(), uuid4(), uuid4()
+    workflow_filter = Mock()
+    workflow_filter.return_value.only.return_value.first = AsyncMock(
+        return_value=SimpleNamespace(team_id=team_id)
+    )
+    kb_filter = Mock()
+    kb_filter.return_value.first = AsyncMock(return_value=None)
+    read = AsyncMock(return_value=b"should not be read")
+    monkeypatch.setattr(Workflow, "filter", workflow_filter)
+    monkeypatch.setattr(KnowledgeBase, "filter", kb_filter)
+    monkeypatch.setattr(upload_gateway, "read", read)
+
+    context = SimpleNamespace(
+        resolve_variable_ref=AsyncMock(
+            return_value=f"documents/{kb_id}/2026/08/report.txt"
+        )
+    )
+    result = await FileToURLNodeExecutor().execute(
+        node(inputVariable="file", inputType="path", outputType="base64"),
+        context,
+        SimpleNamespace(workflow_id=workflow_id),
+    )
+
+    assert result.error == "not_found"
+    kb_filter.assert_called_once_with(id=kb_id, team_id=team_id)
+    read.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -280,6 +384,7 @@ def test_output_metadata_matches_requested_mode():
 
     assert [item["name"] for item in executor.get_output_variables({})] == [
         "url",
+        "urls",
         "filename",
         "mimeType",
         "size",
@@ -292,3 +397,21 @@ def test_output_metadata_matches_requested_mode():
         "mimeType",
         "size",
     ]
+
+
+def test_dynamic_input_output_metadata_uses_any_for_string_or_list_values():
+    executor = FileToURLNodeExecutor()
+    config = {
+        "inputs": [
+            {"name": "document_url", "sourceVariable": "{{start.document}}"},
+            {"name": "image_urls", "sourceVariable": "{{start.images}}"},
+        ]
+    }
+
+    assert executor.get_output_variables(config) == [
+        {"name": "document_url", "type": "any"},
+        {"name": "image_urls", "type": "any"},
+    ]
+    specs = executor.get_output_specs(config)
+    assert [spec.name for spec in specs] == ["document_url", "image_urls"]
+    assert [spec.type.kind for spec in specs] == ["any", "any"]

--- a/backend/tests/services/workflow/test_file_to_url_executor_issue255.py
+++ b/backend/tests/services/workflow/test_file_to_url_executor_issue255.py
@@ -1,6 +1,6 @@
 import base64
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -52,40 +52,227 @@ async def test_returns_existing_base64_content_and_decoded_size():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("output_type", ["base64", "url"])
-async def test_converts_existing_file_to_content_or_upload_url(tmp_path, output_type):
-    uploads_root = tmp_path / "uploads"
-    file_path = uploads_root / "reports" / "result.txt"
-    file_path.parent.mkdir(parents=True)
-    file_path.write_text("hello")
+async def test_legacy_input_variable_returns_upload_url_without_reading_file():
+    """Workflow file parameter values are upload URLs; no filesystem access."""
     context = SimpleNamespace(
-        resolve_variable_ref=AsyncMock(return_value=str(file_path))
+        resolve_variable_ref=AsyncMock(
+            return_value="/api/v1/upload/files/documents/2026/08/a.pdf"
+        )
     )
 
-    if output_type == "url":
-        import app.services.workflow.executors.subworkflow as module
+    result = await FileToURLNodeExecutor().execute(
+        node(inputVariable="file", ensureAbsolute=False),
+        context,
+        SimpleNamespace(),
+    )
 
-        original_path = module.Path
-        module.Path = lambda value: (
-            uploads_root if value.startswith("/Users/") else original_path(value)
-        )
-    try:
+    assert result.outputs["url"] == ("/api/v1/upload/files/documents/2026/08/a.pdf")
+    assert result.outputs["filename"] == "a.pdf"
+    assert result.outputs["mimeType"] == "application/pdf"
+
+
+@pytest.mark.asyncio
+async def test_ensure_absolute_uses_public_api_url_when_configured():
+    context = SimpleNamespace(
+        resolve_variable_ref=AsyncMock(return_value="/files/report.txt")
+    )
+    from app.core.config import settings
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(settings, "PUBLIC_API_URL", "http://public.example:8000")
         result = await FileToURLNodeExecutor().execute(
-            node(inputVariable="file", inputType="path", outputType=output_type),
+            node(inputVariable="file", ensureAbsolute=True),
             context,
             SimpleNamespace(),
         )
-    finally:
-        if output_type == "url":
-            module.Path = original_path
 
-    assert result.outputs["filename"] == "result.txt"
-    assert result.outputs["mimeType"] == "text/plain"
+    assert result.outputs["url"] == "http://public.example:8000/files/report.txt"
+    assert result.outputs["filename"] == "report.txt"
+
+
+@pytest.mark.asyncio
+async def test_ensure_absolute_preserves_relative_url_without_public_origin():
+    from app.core.config import settings
+
+    context = SimpleNamespace(
+        resolve_variable_ref=AsyncMock(return_value="/files/report.txt")
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(settings, "PUBLIC_API_URL", "")
+        monkeypatch.setattr(settings, "API_BASE_URL", "http://internal-api:8000")
+        result = await FileToURLNodeExecutor().execute(
+            node(inputVariable="file", ensureAbsolute=True),
+            context,
+            SimpleNamespace(),
+        )
+
+    assert result.outputs["url"] == "/files/report.txt"
+
+
+@pytest.mark.asyncio
+async def test_legacy_path_to_base64_streams_internal_upload(monkeypatch):
+    import httpx
+    from app.core.config import settings
+
+    async def aiter_bytes():
+        yield b"hel"
+        yield b"lo"
+
+    stream_response = SimpleNamespace(raise_for_status=Mock(), aiter_bytes=aiter_bytes)
+
+    class StreamContext:
+        async def __aenter__(self):
+            return stream_response
+
+        async def __aexit__(self, *_args):
+            return None
+
+    class Client:
+        def __init__(self):
+            self.stream = Mock(return_value=StreamContext())
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    client = Client()
+    monkeypatch.setattr(httpx, "AsyncClient", Mock(return_value=client))
+    monkeypatch.setattr(settings, "API_INTERNAL_BASE_URL", "http://api:8000")
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN", "internal-token")
+    monkeypatch.setattr(settings, "INTERNAL_API_TOKEN_FILE", "")
+    context = SimpleNamespace(
+        resolve_variable_ref=AsyncMock(
+            return_value="/api/v1/upload/files/documents/2026/08/report.txt"
+        )
+    )
+
+    result = await FileToURLNodeExecutor().execute(
+        node(inputVariable="file", inputType="path", outputType="base64"),
+        context,
+        SimpleNamespace(),
+    )
+
+    assert result.outputs["content"] == base64.b64encode(b"hello").decode()
     assert result.outputs["size"] == 5
-    if output_type == "base64":
-        assert base64.b64decode(result.outputs["content"]) == b"hello"
-    else:
-        assert result.outputs["url"].endswith("/uploads/reports/result.txt")
+    client.stream.assert_called_once_with(
+        "GET",
+        "/internal/uploads/read",
+        params={"key": "documents/2026/08/report.txt"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_path_to_base64_rejects_absolute_storage_key():
+    context = SimpleNamespace(
+        resolve_variable_ref=AsyncMock(return_value="/uploads//etc/passwd")
+    )
+
+    result = await FileToURLNodeExecutor().execute(
+        node(inputVariable="file", inputType="path", outputType="base64"),
+        context,
+        SimpleNamespace(),
+    )
+
+    assert result.error == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_file_to_url_config_inputs_map_multiple_urls():
+    config = {
+        "ensureAbsolute": False,
+        "inputs": [
+            {"name": "doc_url", "sourceVariable": "{{start.document}}"},
+            {"name": "image_url", "sourceVariable": "{{start.image}}"},
+        ],
+    }
+    context = SimpleNamespace(
+        resolve_variable_ref=AsyncMock(side_effect=["/files/a.pdf", "/files/b.png"])
+    )
+
+    result = await FileToURLNodeExecutor().execute(
+        {"data": {"fileToUrlConfig": config}}, context, SimpleNamespace()
+    )
+
+    assert result.outputs == {
+        "doc_url": "/files/a.pdf",
+        "image_url": "/files/b.png",
+    }
+
+
+@pytest.mark.asyncio
+async def test_multi_file_value_produces_url_list():
+    context = SimpleNamespace(
+        resolve_variable_ref=AsyncMock(return_value=["/files/a.png", "/files/b.png"])
+    )
+
+    result = await FileToURLNodeExecutor().execute(
+        node(inputVariable="images", ensureAbsolute=False),
+        context,
+        SimpleNamespace(),
+    )
+
+    assert result.outputs["urls"] == ["/files/a.png", "/files/b.png"]
+    assert result.outputs["filename"] == "a.png"
+
+
+@pytest.mark.asyncio
+async def test_file_to_url_config_skips_empty_input_entries():
+    config = {
+        "ensureAbsolute": False,
+        "inputs": [
+            {"name": "", "sourceVariable": "{{start.a}}"},
+            {"name": "url", "sourceVariable": ""},
+        ],
+    }
+    context = SimpleNamespace(resolve_variable_ref=AsyncMock(return_value=None))
+
+    result = await FileToURLNodeExecutor().execute(
+        {"data": {"fileToUrlConfig": config}}, context, SimpleNamespace()
+    )
+
+    assert result.error == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_file_to_url_config_rejects_resolved_none_value():
+    config = {
+        "ensureAbsolute": False,
+        "inputs": [{"name": "url", "sourceVariable": "{{start.missing}}"}],
+    }
+    context = SimpleNamespace(resolve_variable_ref=AsyncMock(return_value=None))
+
+    result = await FileToURLNodeExecutor().execute(
+        {"data": {"fileToUrlConfig": config}}, context, SimpleNamespace()
+    )
+
+    assert result.error == "validation_error"
+    context.resolve_variable_ref.assert_awaited_once_with("{{start.missing}}")
+
+
+@pytest.mark.asyncio
+async def test_legacy_node_without_input_variable_is_rejected():
+    context = SimpleNamespace(resolve_variable_ref=AsyncMock(return_value="x"))
+
+    result = await FileToURLNodeExecutor().execute(
+        node(inputType="path"), context, SimpleNamespace()
+    )
+
+    assert result.error == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_non_string_file_value_is_rejected():
+    context = SimpleNamespace(resolve_variable_ref=AsyncMock(return_value=123))
+
+    result = await FileToURLNodeExecutor().execute(
+        node(inputVariable="file", ensureAbsolute=False),
+        context,
+        SimpleNamespace(),
+    )
+
+    assert result.error == "validation_error"
 
 
 def test_output_metadata_matches_requested_mode():

--- a/backend/tests/services/workflow/test_file_to_url_executor_issue255.py
+++ b/backend/tests/services/workflow/test_file_to_url_executor_issue255.py
@@ -149,7 +149,7 @@ async def test_legacy_path_to_base64_streams_internal_upload(monkeypatch):
     monkeypatch.setattr(settings, "INTERNAL_API_TOKEN_FILE", "")
     context = SimpleNamespace(
         resolve_variable_ref=AsyncMock(
-            return_value="/api/v1/upload/files/documents/2026/08/report.txt"
+            return_value="/api/v1/upload/files/sandbox-artifacts/2026/08/report.txt"
         )
     )
 
@@ -164,8 +164,30 @@ async def test_legacy_path_to_base64_streams_internal_upload(monkeypatch):
     client.stream.assert_called_once_with(
         "GET",
         "/internal/uploads/read",
-        params={"key": "documents/2026/08/report.txt"},
+        params={"key": "sandbox-artifacts/2026/08/report.txt"},
     )
+
+
+@pytest.mark.asyncio
+async def test_legacy_document_path_rejects_non_uuid_knowledge_base(monkeypatch):
+    from app.services import upload_gateway
+
+    read = AsyncMock(return_value=b"should not be read")
+    monkeypatch.setattr(upload_gateway, "read", read)
+    context = SimpleNamespace(
+        resolve_variable_ref=AsyncMock(
+            return_value="documents/not-a-uuid/2026/08/report.txt"
+        )
+    )
+
+    result = await FileToURLNodeExecutor().execute(
+        node(inputVariable="file", inputType="path", outputType="base64"),
+        context,
+        SimpleNamespace(),
+    )
+
+    assert result.error == "not_found"
+    read.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/tasks/test_knowledge_base_task_behavior.py
+++ b/backend/tests/tasks/test_knowledge_base_task_behavior.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -5,7 +7,7 @@ from uuid import uuid4
 import pytest
 
 from app.models.knowledge_base import DocumentStatus
-from app.services.document_processor import UploadGatewayError
+from app.services.upload_gateway import UploadGatewayError
 from app.services.vector_store import DimensionMismatchError
 from app.tasks import knowledge_base as kb_tasks
 
@@ -174,6 +176,131 @@ def test_process_document_retries_transient_upload_gateway_failure():
         kb_tasks.process_document_task.run(str(uuid4()))
 
     retry.assert_called_once_with(exc=gateway_error)
+
+
+def test_reprocess_document_retries_transient_upload_gateway_failure():
+    gateway_error = UploadGatewayError("api unavailable")
+    retry_signal = RuntimeError("retry queued")
+
+    def raise_gateway(coroutine):
+        coroutine.close()
+        raise gateway_error
+
+    with (
+        patch.object(kb_tasks, "_run_async", side_effect=raise_gateway),
+        patch.object(
+            kb_tasks.reprocess_document_task, "retry", side_effect=retry_signal
+        ) as retry,
+        pytest.raises(RuntimeError, match="retry queued"),
+    ):
+        kb_tasks.reprocess_document_task.run(str(uuid4()))
+
+    retry.assert_called_once_with(exc=gateway_error)
+
+
+@pytest.mark.asyncio
+async def test_upload_gateway_retry_exhaustion_marks_document_failed():
+    document = make_document(
+        status=DocumentStatus.PROCESSING.value,
+        metadata={
+            "task_id": "current",
+            "embed_progress": {"embedded": 1},
+            "task_name": "process_document_task",
+            "task_args": ["document"],
+            "keep": True,
+        },
+    )
+    notify = AsyncMock()
+    with (
+        patch.object(kb_tasks.Document, "filter", return_value=Query(first=document)),
+        patch.object(
+            kb_tasks,
+            "_get_generic_processing_error",
+            return_value="gateway unavailable",
+        ),
+        patch.object(kb_tasks, "_send_doc_failed_notification", new=notify),
+    ):
+        result = await kb_tasks._finish_upload_gateway_retry_exhaustion(
+            str(document.id),
+            "current",
+            UploadGatewayError("api unavailable"),
+        )
+
+    assert result == {
+        "status": "error",
+        "document_id": str(document.id),
+        "message": "gateway unavailable",
+    }
+    assert document.status == DocumentStatus.ERROR.value
+    assert document.metadata == {"task_id": "current", "keep": True}
+    document.save.assert_awaited_once()
+    notify.assert_awaited_once_with(
+        document=document,
+        kb_name=document.knowledge_base.name,
+        team_id=document.knowledge_base.team_id,
+        error="gateway unavailable",
+        user_locale="zh",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "metadata", "task_id", "expected_status"),
+    [
+        (DocumentStatus.PROCESSING.value, {"task_id": "new"}, "old", "stale"),
+        (
+            DocumentStatus.ERROR.value,
+            {"task_id": "current"},
+            "current",
+            "already_finished",
+        ),
+    ],
+)
+async def test_upload_gateway_retry_exhaustion_preserves_newer_or_finished_task(
+    status, metadata, task_id, expected_status
+):
+    document = make_document(status=status, metadata=metadata)
+    notify = AsyncMock()
+    with (
+        patch.object(kb_tasks.Document, "filter", return_value=Query(first=document)),
+        patch.object(kb_tasks, "_send_doc_failed_notification", new=notify),
+    ):
+        result = await kb_tasks._finish_upload_gateway_retry_exhaustion(
+            str(document.id),
+            task_id,
+            UploadGatewayError("api unavailable"),
+        )
+
+    assert result["status"] == expected_status
+    document.save.assert_not_awaited()
+    notify.assert_not_awaited()
+
+
+def test_upload_gateway_retry_exhaustion_does_not_queue_another_retry():
+    error = UploadGatewayError("api unavailable")
+    task = SimpleNamespace(
+        request=SimpleNamespace(retries=3),
+        max_retries=3,
+        retry=MagicMock(),
+    )
+    finish = AsyncMock(return_value={"status": "error"})
+
+    with (
+        patch.object(kb_tasks, "_finish_upload_gateway_retry_exhaustion", new=finish),
+        patch.object(
+            kb_tasks, "_run_async", side_effect=lambda coro: asyncio.run(coro)
+        ),
+    ):
+        result = kb_tasks._retry_upload_gateway_or_mark_document_failed(
+            task,
+            "document-id",
+            "task-id",
+            error,
+        )
+
+    assert result == {"status": "error"}
+    finish.assert_awaited_once_with("document-id", "task-id", error)
+    task.retry.assert_not_called()
 
 
 def test_rechunk_document_retries_transient_upload_gateway_failure():

--- a/backend/tests/tasks/test_knowledge_base_task_behavior.py
+++ b/backend/tests/tasks/test_knowledge_base_task_behavior.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 
 from app.models.knowledge_base import DocumentStatus
+from app.services.document_processor import UploadGatewayError
 from app.services.vector_store import DimensionMismatchError
 from app.tasks import knowledge_base as kb_tasks
 
@@ -155,6 +156,46 @@ def test_process_document_returns_localized_not_found_error():
     assert result == {"status": "error", "message": "document_not_found:zh"}
 
 
+def test_process_document_retries_transient_upload_gateway_failure():
+    gateway_error = UploadGatewayError("api unavailable")
+    retry_signal = RuntimeError("retry queued")
+
+    def raise_gateway(coroutine):
+        coroutine.close()
+        raise gateway_error
+
+    with (
+        patch.object(kb_tasks, "_run_async", side_effect=raise_gateway),
+        patch.object(
+            kb_tasks.process_document_task, "retry", side_effect=retry_signal
+        ) as retry,
+        pytest.raises(RuntimeError, match="retry queued"),
+    ):
+        kb_tasks.process_document_task.run(str(uuid4()))
+
+    retry.assert_called_once_with(exc=gateway_error)
+
+
+def test_rechunk_document_retries_transient_upload_gateway_failure():
+    gateway_error = UploadGatewayError("api unavailable")
+    retry_signal = RuntimeError("retry queued")
+
+    def raise_gateway(coroutine):
+        coroutine.close()
+        raise gateway_error
+
+    with (
+        patch.object(kb_tasks, "_run_async", side_effect=raise_gateway),
+        patch.object(
+            kb_tasks.rechunk_document_task, "retry", side_effect=retry_signal
+        ) as retry,
+        pytest.raises(RuntimeError, match="retry queued"),
+    ):
+        kb_tasks.rechunk_document_task.run(str(uuid4()))
+
+    retry.assert_called_once_with(exc=gateway_error)
+
+
 def test_process_document_success_updates_document_and_kb():
     document = make_document(metadata={"clean_text": False, "task_name": "queued"})
     chunks = [make_chunk(tokens=3), make_chunk(tokens=5)]
@@ -166,6 +207,11 @@ def test_process_document_success_updates_document_and_kb():
     with (
         patch.object(kb_tasks.Document, "filter", return_value=Query(first=document)),
         patch.object(kb_tasks.DocumentChunk, "filter", return_value=Query(count=0)),
+        patch.object(
+            kb_tasks.document_processor,
+            "delete_media_assets",
+            new=AsyncMock(),
+        ),
         patch.object(
             kb_tasks.document_processor,
             "extract_text",
@@ -265,6 +311,11 @@ def test_process_document_dimension_mismatch_is_specific_and_cleans_metadata():
     with (
         patch.object(kb_tasks.Document, "filter", return_value=Query(first=document)),
         patch.object(kb_tasks.DocumentChunk, "filter", return_value=Query(count=0)),
+        patch.object(
+            kb_tasks.document_processor,
+            "delete_media_assets",
+            new=AsyncMock(),
+        ),
         patch.object(
             kb_tasks.document_processor,
             "extract_text",

--- a/backend/tests/tasks/test_knowledge_base_task_remaining_issue255.py
+++ b/backend/tests/tasks/test_knowledge_base_task_remaining_issue255.py
@@ -79,6 +79,11 @@ def test_process_document_all_failed_records_progress_and_error(monkeypatch, doc
     )
     monkeypatch.setattr(
         knowledge_base.document_processor,
+        "delete_media_assets",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        knowledge_base.document_processor,
         "extract_text",
         AsyncMock(return_value=("text", {})),
     )

--- a/backend/tests/test_deploy_install_script.py
+++ b/backend/tests/test_deploy_install_script.py
@@ -72,6 +72,8 @@ def test_k8s_installer_generates_a_secret_manifest_and_preserves_output(tmp_path
         template_secret["data"]["SECRET_KEY"]
         == "Y2hhbmdldGhpcy10by1hLXNlY3VyZS1yYW5kb20tc2VjcmV0LWtleQ=="
     )
+    assert template_secret["data"]["INTERNAL_API_TOKEN"] == ""
+    assert template_secret["data"]["SANDBOX_ARTIFACT_UPLOAD_API_KEY"] == ""
 
     deployments = {
         document["metadata"]["name"]: document

--- a/backend/tests/test_deploy_install_script.py
+++ b/backend/tests/test_deploy_install_script.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import base64
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = PROJECT_ROOT / "deploy" / "install.sh"
+REQUIRED_SECRET_KEYS = (
+    "SECRET_KEY",
+    "POSTGRES_PASSWORD",
+    "REDIS_PASSWORD",
+    "QDRANT_API_KEY",
+    "SANDBOX_ARTIFACT_UPLOAD_API_KEY",
+    "INTERNAL_API_TOKEN",
+)
+BACKEND_WORKLOADS = ("api", "worker", "sandbox-worker", "beat")
+
+
+def _run_manifest_generator(output_path: Path) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "CLOUISLE_DEPLOYMENT": "k8s",
+        "CLOUISLE_K8S_MANIFEST": str(output_path),
+        "CLOUISLE_SOURCE_DIR": str(PROJECT_ROOT),
+        "CLOUISLE_YES": "1",
+    }
+    return subprocess.run(
+        ["bash", str(INSTALL_SCRIPT)],
+        cwd=output_path.parent.parent,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _generated_documents(output_path: Path) -> list[dict]:
+    return list(yaml.safe_load_all(output_path.read_text(encoding="utf-8")))
+
+
+def test_k8s_installer_generates_a_secret_manifest_and_preserves_output(tmp_path: Path):
+    output_path = tmp_path / "generated" / "clouisle-k8s.yaml"
+
+    result = _run_manifest_generator(output_path)
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.stat().st_mode & 0o777 == 0o600
+    assert f"kubectl apply -f {output_path}" in result.stdout
+
+    documents = _generated_documents(output_path)
+    secret = next(document for document in documents if document["kind"] == "Secret")
+    decoded = {
+        key: base64.b64decode(secret["data"][key]).decode("ascii")
+        for key in REQUIRED_SECRET_KEYS
+    }
+    assert set(decoded) == set(REQUIRED_SECRET_KEYS)
+    assert len(set(decoded.values())) == len(REQUIRED_SECRET_KEYS)
+    assert all(len(value) == 64 for value in decoded.values())
+
+    template_documents = _generated_documents(
+        PROJECT_ROOT / "deploy" / "k8s" / "clouisle.yaml"
+    )
+    template_secret = next(
+        document for document in template_documents if document["kind"] == "Secret"
+    )
+    assert (
+        template_secret["data"]["SECRET_KEY"]
+        == "Y2hhbmdldGhpcy10by1hLXNlY3VyZS1yYW5kb20tc2VjcmV0LWtleQ=="
+    )
+
+    deployments = {
+        document["metadata"]["name"]: document
+        for document in documents
+        if document["kind"] == "Deployment"
+    }
+    for name in BACKEND_WORKLOADS:
+        pod_spec = deployments[name]["spec"]["template"]["spec"]
+        wait_container = next(
+            container
+            for container in pod_spec["initContainers"]
+            if container["name"] == "wait-for-postgres"
+        )
+        assert wait_container["image"].startswith(
+            "registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-postgres-pg-search:"
+        )
+        assert "pg_isready" in wait_container["command"][-1]
+        assert {item["name"] for item in wait_container["env"]} == {
+            "POSTGRES_SERVER",
+            "POSTGRES_PORT",
+            "POSTGRES_USER",
+            "POSTGRES_DB",
+        }
+
+    existing = _run_manifest_generator(output_path)
+    assert existing.returncode != 0
+    assert "Refusing to overwrite existing Kubernetes manifest" in existing.stderr

--- a/backend/tests/test_main_sandbox_worker.py
+++ b/backend/tests/test_main_sandbox_worker.py
@@ -93,6 +93,7 @@ def test_start_sandbox_worker_container_runs_without_bind_mounts(
     mock_build.assert_called_once_with(no_cache=False, image_tag="sandbox:test")
     cmd = mock_run.call_args.args[0]
     assert cmd[:3] == ["docker", "run", "--rm"]
+    assert ["--add-host", "host.docker.internal:host-gateway"] == cmd[3:5]
     assert "-v" not in cmd
     assert "--volume" not in cmd
     assert "--mount" not in cmd

--- a/backend/tests/test_main_sandbox_worker.py
+++ b/backend/tests/test_main_sandbox_worker.py
@@ -99,6 +99,7 @@ def test_start_sandbox_worker_container_runs_without_bind_mounts(
     assert ["python", "main.py", "sandbox-worker", "-c", "3"] == cmd[-5:]
     assert "-e" in cmd
     assert "REDIS_HOST=redis.local" in cmd
+    assert "UPLOAD_STORAGE_MODE=remote" in cmd
     mock_run.assert_called_once_with(cmd, cwd=PROJECT_ROOT, check=True)
 
 
@@ -108,6 +109,7 @@ def test_start_sandbox_worker_container_reads_root_env(
     env_file = tmp_path / ".env"
     env_file.write_text(
         "REDIS_PASSWORD=secret\nPOSTGRES_USER=postgres\nREDIS_HOST=redis.local\n"
+        "API_INTERNAL_BASE_URL=http://localhost:8000\nINTERNAL_API_TOKEN=token\n"
     )
     monkeypatch.setattr("main.PROJECT_ROOT", str(tmp_path))
     monkeypatch.delenv("REDIS_PASSWORD", raising=False)
@@ -124,6 +126,8 @@ def test_start_sandbox_worker_container_reads_root_env(
     assert "REDIS_PASSWORD=secret" in cmd
     assert "POSTGRES_USER=postgres" in cmd
     assert "REDIS_HOST=redis.local" in cmd
+    assert "API_INTERNAL_BASE_URL=http://host.docker.internal:8000" in cmd
+    assert "INTERNAL_API_TOKEN=token" in cmd
 
 
 def test_start_sandbox_worker_container_maps_localhost_env_to_host_gateway(
@@ -135,6 +139,7 @@ def test_start_sandbox_worker_container_maps_localhost_env_to_host_gateway(
         "POSTGRES_SERVER=127.0.0.1\n"
         "QDRANT_URL=http://localhost:6333\n"
         "API_BASE_URL=http://localhost:8000\n"
+        "API_INTERNAL_BASE_URL=http://localhost:8000\n"
         "SANDBOX_ARTIFACT_UPLOAD_BASE_URL=http://127.0.0.1:9000\n"
     )
     monkeypatch.setattr("main.PROJECT_ROOT", str(tmp_path))
@@ -143,6 +148,7 @@ def test_start_sandbox_worker_container_maps_localhost_env_to_host_gateway(
     monkeypatch.delenv("QDRANT_URL", raising=False)
     monkeypatch.delenv("API_BASE_URL", raising=False)
     monkeypatch.delenv("SANDBOX_ARTIFACT_UPLOAD_BASE_URL", raising=False)
+    monkeypatch.delenv("API_INTERNAL_BASE_URL", raising=False)
 
     with (
         patch("main.build_sandbox_worker_image"),
@@ -156,6 +162,7 @@ def test_start_sandbox_worker_container_maps_localhost_env_to_host_gateway(
     assert "QDRANT_URL=http://host.docker.internal:6333" in cmd
     assert "API_BASE_URL=http://host.docker.internal:8000" in cmd
     assert "SANDBOX_ARTIFACT_UPLOAD_BASE_URL=http://host.docker.internal:9000" in cmd
+    assert "API_INTERNAL_BASE_URL=http://host.docker.internal:8000" in cmd
 
 
 def test_start_sandbox_worker_container_defaults_host_service_env(
@@ -177,6 +184,7 @@ def test_start_sandbox_worker_container_defaults_host_service_env(
     assert "REDIS_HOST=host.docker.internal" in cmd
     assert "POSTGRES_SERVER=host.docker.internal" in cmd
     assert "QDRANT_URL=http://host.docker.internal:6333" in cmd
+    assert "API_INTERNAL_BASE_URL=http://host.docker.internal:8000" in cmd
 
 
 def test_sandbox_worker_local_dev_cli_dispatches_container_mode(

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,6 +1,6 @@
 # =============================================================================
 # Clouisle Docker Deployment Environment Variables
-# Copy this file to .env inside deploy/ before running docker compose.
+# Keep this file as .env next to docker-compose.yml.
 # =============================================================================
 
 # ---- General ----

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -11,12 +11,18 @@ TIMEZONE=Asia/Shanghai
 # ---- URLs ----
 # Internal API address used by containers. Put public domains in FRONTEND_URL/CORS.
 API_BASE_URL=http://api:8000
+PUBLIC_API_URL=
+API_INTERNAL_BASE_URL=http://api:8000
 FRONTEND_URL=http://localhost:3000
 BACKEND_CORS_ORIGINS=["http://localhost:3000"]
 
 # Sandbox workers upload artifacts to this internal API address.
 SANDBOX_ARTIFACT_UPLOAD_BASE_URL=http://api:8000
 SANDBOX_ARTIFACT_UPLOAD_API_KEY=
+
+# Worker -> api internal file gateway (worker has no uploads volume).
+# INTERNAL_API_TOKEN must be shared by api and worker; keep it secret.
+INTERNAL_API_TOKEN=
 
 # ---- PostgreSQL ----
 POSTGRES_SERVER=db

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -3,12 +3,6 @@
 # Copy this file to .env inside deploy/ before running docker compose.
 # =============================================================================
 
-# ---- Images ----
-# For a registry, use a repository prefix such as:
-# IMAGE_REGISTRY=registry.cn-hangzhou.aliyuncs.com/your-namespace/clouisle
-IMAGE_REGISTRY=clouisle
-IMAGE_TAG=latest
-
 # ---- General ----
 PROJECT_NAME=Clouisle
 SECRET_KEY=changethis-to-a-secure-random-secret-key

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -74,6 +74,11 @@ The installer offers Docker Compose, Kubernetes with Helm, or secure single-file
 ```bash
 cd deploy
 cp .env.example .env
+# Generate the shared API-to-worker gateway token before starting Compose.
+internal_api_token="$(openssl rand -hex 32)"
+sed -i.bak "s/^INTERNAL_API_TOKEN=.*/INTERNAL_API_TOKEN=${internal_api_token}/" .env
+rm .env.bak
+unset internal_api_token
 # Edit .env when custom domains or external API keys are required.
 docker compose pull
 docker compose up -d
@@ -157,10 +162,13 @@ docker compose down -v
 ### Option A: Helm Chart (recommended)
 
 ```bash
-helm lint deploy/helm/clouisle
+helm lint deploy/helm/clouisle \
+  --set-string secrets.values.INTERNAL_API_TOKEN=lint-only-token
 helm upgrade --install clouisle deploy/helm/clouisle \
   --namespace clouisle \
-  --create-namespace
+  --create-namespace \
+  --set-string secrets.values.INTERNAL_API_TOKEN="$(openssl rand -hex 32)"
+
 ```
 
 For production, create a Secret and use `values-production.yaml`:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -61,19 +61,25 @@ docker build -f deploy/dockerfiles/frontend.Dockerfile -t clouisle-frontend .
 
 ## Docker Compose Deployment
 
-### Quick Start
+### Guided One-Command Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
+```
+
+The installer asks whether to deploy with Docker Compose or Kubernetes with Helm. Docker mode prompts for an installation directory (`/opt/clouisle` by default), downloads the deployment files, generates strong secrets, validates the Compose configuration, pulls the published images, and starts the services. Existing `.env` files are preserved during upgrades.
+
+### Manual Docker Compose Install
 
 ```bash
 cd deploy
 cp .env.example .env
-# Edit .env and set strong values for SECRET_KEY, POSTGRES_PASSWORD, REDIS_PASSWORD,
-# and QDRANT_API_KEY.
-
+# Edit .env when custom domains or external API keys are required.
 docker compose pull
 docker compose up -d
 ```
 
-Compose pulls the published `latest` images listed above by default. Use `docker compose up -d --build` only when intentionally rebuilding them from local source.
+Compose pulls the published `latest` images listed above by default.
 
 ### Services
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -67,7 +67,7 @@ docker build -f deploy/dockerfiles/frontend.Dockerfile -t clouisle-frontend .
 curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
 ```
 
-The installer asks whether to deploy with Docker Compose or Kubernetes with Helm. Docker mode prompts for an installation directory (`/opt/clouisle` by default), downloads the deployment files, generates strong secrets, validates the Compose configuration, pulls the published images, and starts the services. Existing `.env` files are preserved during upgrades.
+The installer offers Docker Compose, Kubernetes with Helm, or secure single-file Kubernetes manifest generation. Docker mode prompts for an installation directory (`/opt/clouisle` by default), downloads deployment files, generates strong secrets, validates the Compose configuration, pulls published images, and starts services. Existing `.env` files are preserved during upgrades.
 
 ### Manual Docker Compose Install
 
@@ -148,11 +148,11 @@ docker compose down -v
 ### Prerequisites
 
 - Kubernetes cluster 1.25+
-- `kubectl` configured
-- Helm 3.x installed
+- `kubectl` configured to apply either Kubernetes option
+- Helm 3.x only for the Helm chart option
 - Ingress controller, such as ingress-nginx
 - Container images pushed to a registry accessible by the cluster
-- A `ReadWriteMany` capable StorageClass for multi-replica uploads, or single-replica application deployments
+- A `ReadWriteMany` capable StorageClass for multiple API replicas using local upload storage; otherwise use one API replica or object storage
 
 ### Option A: Helm Chart (recommended)
 
@@ -171,7 +171,9 @@ kubectl -n clouisle create secret generic clouisle-secret \
   --from-literal=SECRET_KEY='replace-with-strong-random-key' \
   --from-literal=POSTGRES_PASSWORD='replace-with-postgres-password' \
   --from-literal=REDIS_PASSWORD='replace-with-redis-password' \
-  --from-literal=QDRANT_API_KEY='replace-with-qdrant-api-key'
+  --from-literal=QDRANT_API_KEY='replace-with-qdrant-api-key' \
+  --from-literal=SANDBOX_ARTIFACT_UPLOAD_API_KEY='replace-with-sandbox-artifact-key' \
+  --from-literal=INTERNAL_API_TOKEN='replace-with-internal-upload-gateway-token'
 
 helm upgrade --install clouisle deploy/helm/clouisle \
   --namespace clouisle \
@@ -181,18 +183,40 @@ helm upgrade --install clouisle deploy/helm/clouisle \
 
 See `deploy/helm/clouisle/README.md` for external PostgreSQL, Redis, and Qdrant examples.
 
-### Option B: Single-file manifest
+### Option B: Generated single-file manifest
 
-The plain manifest is still available at `deploy/k8s/clouisle.yaml` for debugging or environments that do not use Helm.
+Generate a separate manifest with strong values for all required application secrets. The source
+template is not changed, the output is mode `0600`, and the installer does **not** apply it.
 
 ```bash
-# 1. Edit the manifest: replace base64 secret placeholders and set image/domain/storage values.
+curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | \
+  CLOUISLE_DEPLOYMENT=k8s \
+  CLOUISLE_K8S_MANIFEST="$PWD/clouisle-k8s.yaml" \
+  CLOUISLE_YES=1 bash
+
+# Review image, domain, and storage settings before applying.
+kubectl apply -f ./clouisle-k8s.yaml
+```
+
+The generated document contains base64-encoded secrets; store it securely and do not commit it.
+It contains `SECRET_KEY`, `POSTGRES_PASSWORD`, `REDIS_PASSWORD`, `QDRANT_API_KEY`,
+`SANDBOX_ARTIFACT_UPLOAD_API_KEY`, and `INTERNAL_API_TOKEN`. The raw backend workloads wait in
+their `wait-for-postgres` init containers until PostgreSQL accepts connections, preventing a
+database startup race from turning into application restart loops.
+
+### Option C: Manual single-file template
+
+`deploy/k8s/clouisle.yaml` remains available for debugging or environments that need a manually
+edited template.
+
+```bash
+# 1. Replace base64 Secret placeholders and set image/domain/storage values.
 vi deploy/k8s/clouisle.yaml
 
-# 2. Apply everything
+# 2. Apply everything. Backend workloads wait for PostgreSQL automatically.
 kubectl apply -f deploy/k8s/clouisle.yaml
 
-# 3. Wait for infrastructure
+# 3. Observe infrastructure readiness when diagnosing a cluster deployment.
 kubectl -n clouisle wait --for=condition=ready pod -l app=postgres --timeout=120s
 kubectl -n clouisle wait --for=condition=ready pod -l app=redis --timeout=120s
 kubectl -n clouisle wait --for=condition=ready pod -l app=qdrant --timeout=120s
@@ -226,7 +250,7 @@ kubectl -n clouisle scale deployment api --replicas=3
 
 Keep `beat` at exactly one replica.
 
-If `uploads-data` uses `ReadWriteMany`, API/worker/sandbox-worker replicas can share uploaded files and sandbox artifacts. If your cluster does not support RWX storage, keep those deployments single-replica or move uploads/artifacts to object storage before scaling.
+`uploads-data` is mounted only by `api`; workers and sandbox-worker read authorized attachments/documents through the authenticated internal upload gateway, while sandbox artifacts are uploaded through the API. Local upload storage needs `ReadWriteMany` only when scaling `api` beyond one replica. With `ReadWriteOnce`, keep `api` at one replica; worker and sandbox-worker replicas remain independently scalable.
 
 ### Logs
 
@@ -246,6 +270,7 @@ kubectl -n clouisle logs -f deployment/frontend
 |----------|----------|-----------------|-------------|
 | `SECRET_KEY` | Yes | placeholder | JWT signing key and default sandbox upload signing basis |
 | `API_BASE_URL` | Yes | `http://api:8000` | Internal API URL for containers |
+| `PUBLIC_API_URL` | No | empty | Public API origin used when workflow file URLs must be absolute |
 | `SANDBOX_ARTIFACT_UPLOAD_BASE_URL` | Yes for sandbox | `http://api:8000` | Internal API URL used by sandbox artifact upload |
 | `FRONTEND_URL` | Yes | `http://localhost:3000` | Public frontend URL |
 | `BACKEND_CORS_ORIGINS` | Yes | `["http://localhost:3000"]` | JSON array of allowed frontend origins |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -39,9 +39,9 @@ git push origin v0.1.0
 Images are pushed to:
 
 ```text
-<ACR_REGISTRY>/<ACR_NAMESPACE>/clouisle-backend:<version>
-<ACR_REGISTRY>/<ACR_NAMESPACE>/clouisle-sandbox-worker:<version>
-<ACR_REGISTRY>/<ACR_NAMESPACE>/clouisle-frontend:<version>
+registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest
+registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-sandbox-worker:latest
+registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-frontend:latest
 ```
 
 Required GitHub Secrets: `ACR_REGISTRY`, `ACR_NAMESPACE`, `ACR_USERNAME`, `ACR_PASSWORD`.
@@ -69,15 +69,11 @@ cp .env.example .env
 # Edit .env and set strong values for SECRET_KEY, POSTGRES_PASSWORD, REDIS_PASSWORD,
 # and QDRANT_API_KEY.
 
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
 
-Compose reads `deploy/.env`. The default image prefix is `clouisle`; set these when using registry images:
-
-```env
-IMAGE_REGISTRY=registry.cn-hangzhou.aliyuncs.com/your-namespace/clouisle
-IMAGE_TAG=0.1.0
-```
+Compose pulls the published `latest` images listed above by default. Use `docker compose up -d --build` only when intentionally rebuilding them from local source.
 
 ### Services
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -62,7 +62,7 @@ services:
   # Application
   # ---------------------------------------------------------------------------
   api:
-    image: ${IMAGE_REGISTRY:-clouisle}-backend:${IMAGE_TAG:-latest}
+    image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest
     build:
       context: ..
       dockerfile: deploy/dockerfiles/backend.Dockerfile
@@ -88,7 +88,7 @@ services:
         condition: service_healthy
 
   worker:
-    image: ${IMAGE_REGISTRY:-clouisle}-backend:${IMAGE_TAG:-latest}
+    image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest
     build:
       context: ..
       dockerfile: deploy/dockerfiles/backend.Dockerfile
@@ -114,7 +114,7 @@ services:
         condition: service_started
 
   sandbox-worker:
-    image: ${IMAGE_REGISTRY:-clouisle}-sandbox-worker:${IMAGE_TAG:-latest}
+    image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-sandbox-worker:latest
     build:
       context: ..
       dockerfile: deploy/dockerfiles/sandbox-worker.Dockerfile
@@ -145,7 +145,7 @@ services:
         condition: service_started
 
   beat:
-    image: ${IMAGE_REGISTRY:-clouisle}-backend:${IMAGE_TAG:-latest}
+    image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest
     build:
       context: ..
       dockerfile: deploy/dockerfiles/backend.Dockerfile
@@ -167,7 +167,7 @@ services:
         condition: service_started
 
   frontend:
-    image: ${IMAGE_REGISTRY:-clouisle}-frontend:${IMAGE_TAG:-latest}
+    image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-frontend:latest
     build:
       context: ..
       dockerfile: deploy/dockerfiles/frontend.Dockerfile

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -63,9 +63,6 @@ services:
   # ---------------------------------------------------------------------------
   api:
     image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest
-    build:
-      context: ..
-      dockerfile: deploy/dockerfiles/backend.Dockerfile
     restart: unless-stopped
     command: ["python", "main.py", "server", "-H", "0.0.0.0", "-w", "4", "--no-reload"]
     env_file: .env
@@ -89,9 +86,6 @@ services:
 
   worker:
     image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest
-    build:
-      context: ..
-      dockerfile: deploy/dockerfiles/backend.Dockerfile
     restart: unless-stopped
     command: ["python", "main.py", "worker", "-c", "4", "-Q", "default,knowledge,workflow"]
     env_file: .env
@@ -115,9 +109,6 @@ services:
 
   sandbox-worker:
     image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-sandbox-worker:latest
-    build:
-      context: ..
-      dockerfile: deploy/dockerfiles/sandbox-worker.Dockerfile
     restart: unless-stopped
     command: ["python", "main.py", "sandbox-worker", "-c", "${SANDBOX_WORKER_CONCURRENCY:-1}"]
     env_file: .env
@@ -146,9 +137,6 @@ services:
 
   beat:
     image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest
-    build:
-      context: ..
-      dockerfile: deploy/dockerfiles/backend.Dockerfile
     restart: unless-stopped
     command: ["python", "main.py", "beat"]
     env_file: .env
@@ -168,13 +156,6 @@ services:
 
   frontend:
     image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-frontend:latest
-    build:
-      context: ..
-      dockerfile: deploy/dockerfiles/frontend.Dockerfile
-      args:
-        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-/api/v1}
-        NEXT_PUBLIC_APP_VERSION: ${NEXT_PUBLIC_APP_VERSION:-0.0.0-dev}
-        NEXT_PUBLIC_BUILD_DATE: ${NEXT_PUBLIC_BUILD_DATE:-unknown}
     restart: unless-stopped
     environment:
       BACKEND_INTERNAL_URL: ${BACKEND_INTERNAL_URL:-http://api:8000}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -72,6 +72,12 @@ services:
       POSTGRES_SERVER: db
       REDIS_HOST: redis
       QDRANT_URL: http://qdrant:6333
+      INTERNAL_API_TOKEN: ${INTERNAL_API_TOKEN:?INTERNAL_API_TOKEN is required}
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
     ports:
       - "8000:8000"
     volumes:
@@ -95,8 +101,9 @@ services:
       POSTGRES_SERVER: db
       REDIS_HOST: redis
       QDRANT_URL: http://qdrant:6333
-    volumes:
-      - uploads_data:/app/uploads
+      UPLOAD_STORAGE_MODE: remote
+      API_INTERNAL_BASE_URL: ${API_INTERNAL_BASE_URL:-http://api:8000}
+      INTERNAL_API_TOKEN: ${INTERNAL_API_TOKEN:?INTERNAL_API_TOKEN is required}
     depends_on:
       db:
         condition: service_healthy
@@ -105,7 +112,7 @@ services:
       qdrant:
         condition: service_healthy
       api:
-        condition: service_started
+        condition: service_healthy
 
   sandbox-worker:
     image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-sandbox-worker:latest
@@ -123,8 +130,9 @@ services:
       POSTGRES_SERVER: db
       REDIS_HOST: redis
       QDRANT_URL: http://qdrant:6333
-    volumes:
-      - uploads_data:/app/uploads
+      UPLOAD_STORAGE_MODE: remote
+      API_INTERNAL_BASE_URL: ${API_INTERNAL_BASE_URL:-http://api:8000}
+      INTERNAL_API_TOKEN: ${INTERNAL_API_TOKEN:?INTERNAL_API_TOKEN is required}
     depends_on:
       db:
         condition: service_healthy
@@ -133,7 +141,7 @@ services:
       qdrant:
         condition: service_healthy
       api:
-        condition: service_started
+        condition: service_healthy
 
   beat:
     image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest

--- a/deploy/helm/clouisle/README.md
+++ b/deploy/helm/clouisle/README.md
@@ -71,9 +71,9 @@ helm upgrade --install clouisle deploy/helm/clouisle \
 
 | Value | Default | Description |
 |-------|---------|-------------|
-| `images.backend.repository` | `clouisle-backend` | API, worker, and beat image |
-| `images.sandboxWorker.repository` | `clouisle-sandbox-worker` | Sandbox worker image |
-| `images.frontend.repository` | `clouisle-frontend` | Frontend image |
+| `images.backend.repository` | `registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend` | API, worker, and beat image |
+| `images.sandboxWorker.repository` | `registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-sandbox-worker` | Sandbox worker image |
+| `images.frontend.repository` | `registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-frontend` | Frontend image |
 | `config.API_BASE_URL` | `http://api:8000` | Internal API URL |
 | `config.SANDBOX_ARTIFACT_UPLOAD_BASE_URL` | `http://api:8000` | Internal artifact upload API URL |
 | `secrets.create` | `true` | Create a Secret from values |

--- a/deploy/helm/clouisle/README.md
+++ b/deploy/helm/clouisle/README.md
@@ -12,10 +12,12 @@ This chart deploys Clouisle on Kubernetes with the current service model:
 ## Quick Start
 
 ```bash
-helm lint deploy/helm/clouisle
+INTERNAL_API_TOKEN="$(openssl rand -base64 32)"
 helm upgrade --install clouisle deploy/helm/clouisle \
   --namespace clouisle \
-  --create-namespace
+  --create-namespace \
+  --set-string secrets.values.INTERNAL_API_TOKEN="$INTERNAL_API_TOKEN"
+unset INTERNAL_API_TOKEN
 ```
 
 Check status:
@@ -37,7 +39,8 @@ kubectl -n clouisle create secret generic clouisle-secret \
   --from-literal=SECRET_KEY='replace-with-strong-random-key' \
   --from-literal=POSTGRES_PASSWORD='replace-with-postgres-password' \
   --from-literal=REDIS_PASSWORD='replace-with-redis-password' \
-  --from-literal=QDRANT_API_KEY='replace-with-qdrant-api-key'
+  --from-literal=QDRANT_API_KEY='replace-with-qdrant-api-key' \
+  --from-literal=INTERNAL_API_TOKEN="$(openssl rand -base64 32)"
 ```
 
 Install with production values:
@@ -79,7 +82,7 @@ helm upgrade --install clouisle deploy/helm/clouisle \
 | `config.SANDBOX_ARTIFACT_UPLOAD_BASE_URL` | `http://api:8000` | Internal artifact upload API URL |
 | `secrets.create` | `true` | Create a Secret from values |
 | `secrets.existingSecret` | empty | Existing Secret for production |
-| `secrets.values.INTERNAL_API_TOKEN` | `changeme` | Shared token for the internal upload gateway |
+| `secrets.values.INTERNAL_API_TOKEN` | required | Shared token for the internal upload gateway; set a unique value when chart-managed Secrets are enabled |
 | `uploads.accessModes` | `ReadWriteMany` | Shared uploads PVC mode |
 | `postgresql.enabled` | `true` | Deploy built-in ParadeDB PostgreSQL 17 with pg_search 0.24.3 |
 | `postgresql.external.host` | empty | External PG17+ host with pg_search 0.24.3 preloaded when built-in mode is disabled |
@@ -105,11 +108,16 @@ Local upload storage needs a `ReadWriteMany` capable StorageClass, such as NFS, 
 ## Validation
 
 ```bash
-helm lint deploy/helm/clouisle
-helm template clouisle deploy/helm/clouisle --namespace clouisle --create-namespace
+helm lint deploy/helm/clouisle \
+  --set-string secrets.values.INTERNAL_API_TOKEN=lint-only-token
+helm template clouisle deploy/helm/clouisle --namespace clouisle --create-namespace \
+  --set-string secrets.values.INTERNAL_API_TOKEN=lint-only-token
 helm template clouisle deploy/helm/clouisle --namespace clouisle --create-namespace \
   -f deploy/helm/clouisle/values-production.yaml
 helm template clouisle deploy/helm/clouisle --namespace clouisle --create-namespace \
+  --set secrets.create=false --set secrets.existingSecret=clouisle-secret
+helm template clouisle deploy/helm/clouisle --namespace clouisle --create-namespace \
+  --set secrets.create=false --set secrets.existingSecret=clouisle-secret \
   | kubectl apply --dry-run=client -f -
 ```
 

--- a/deploy/helm/clouisle/README.md
+++ b/deploy/helm/clouisle/README.md
@@ -75,9 +75,11 @@ helm upgrade --install clouisle deploy/helm/clouisle \
 | `images.sandboxWorker.repository` | `registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-sandbox-worker` | Sandbox worker image |
 | `images.frontend.repository` | `registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-frontend` | Frontend image |
 | `config.API_BASE_URL` | `http://api:8000` | Internal API URL |
+| `config.API_INTERNAL_BASE_URL` | `http://api:8000` | Worker-to-API internal upload gateway URL |
 | `config.SANDBOX_ARTIFACT_UPLOAD_BASE_URL` | `http://api:8000` | Internal artifact upload API URL |
 | `secrets.create` | `true` | Create a Secret from values |
 | `secrets.existingSecret` | empty | Existing Secret for production |
+| `secrets.values.INTERNAL_API_TOKEN` | `changeme` | Shared token for the internal upload gateway |
 | `uploads.accessModes` | `ReadWriteMany` | Shared uploads PVC mode |
 | `postgresql.enabled` | `true` | Deploy built-in ParadeDB PostgreSQL 17 with pg_search 0.24.3 |
 | `postgresql.external.host` | empty | External PG17+ host with pg_search 0.24.3 preloaded when built-in mode is disabled |
@@ -92,9 +94,9 @@ Existing PostgreSQL 16 volumes cannot be mounted directly by PostgreSQL 17. Migr
 
 ## Storage
 
-`api`, `worker`, and `sandbox-worker` share the `uploads` PVC at `/app/uploads`.
+`api` alone mounts the `uploads` PVC at `/app/uploads`. `worker` and `sandbox-worker` read authorized documents/attachments through the authenticated internal upload gateway, and `sandbox-worker` uploads artifacts through the API.
 
-Production multi-replica deployments require a `ReadWriteMany` capable StorageClass, such as NFS, EFS, or CephFS. If your cluster does not support RWX storage, keep `api`, `worker`, and `sandbox-worker` single-replica or move uploads/artifacts to object storage.
+Local upload storage needs a `ReadWriteMany` capable StorageClass, such as NFS, EFS, or CephFS, only when scaling `api` beyond one replica. With `ReadWriteOnce`, keep `api` at one replica; workers remain independently scalable.
 
 ## Beat Replica Safety
 

--- a/deploy/helm/clouisle/templates/api-deployment.yaml
+++ b/deploy/helm/clouisle/templates/api-deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "clouisle.componentLabels" (dict "root" . "component" "api") | nindent 4 }}
 spec:
   replicas: {{ .Values.api.replicas }}
+  strategy:
+    {{- toYaml .Values.api.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "clouisle.selectorLabels" (dict "root" . "component" "api") | nindent 6 }}
@@ -30,6 +32,9 @@ spec:
             - name: http
               containerPort: 8000
           {{- include "clouisle.envFrom" . | nindent 10 }}
+          env:
+            - name: INTERNAL_API_TOKEN_FILE
+              value: /var/run/secrets/clouisle/internal-api-token
           {{- with .Values.global.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -37,6 +42,9 @@ spec:
           volumeMounts:
             - name: uploads
               mountPath: {{ .Values.uploads.mountPath }}
+            - name: internal-api-token
+              mountPath: /var/run/secrets/clouisle
+              readOnly: true
           readinessProbe:
             httpGet:
               path: {{ .Values.api.probes.readiness.path }}
@@ -55,4 +63,10 @@ spec:
         - name: uploads
           persistentVolumeClaim:
             claimName: {{ include "clouisle.uploadsClaimName" . }}
+        - name: internal-api-token
+          secret:
+            secretName: {{ include "clouisle.secretName" . }}
+            items:
+              - key: INTERNAL_API_TOKEN
+                path: internal-api-token
 {{- end }}

--- a/deploy/helm/clouisle/templates/configmap.yaml
+++ b/deploy/helm/clouisle/templates/configmap.yaml
@@ -20,6 +20,8 @@ data:
   PROJECT_NAME: {{ .Values.config.PROJECT_NAME | quote }}
   TIMEZONE: {{ .Values.config.TIMEZONE | quote }}
   API_BASE_URL: {{ .Values.config.API_BASE_URL | quote }}
+  PUBLIC_API_URL: {{ .Values.config.PUBLIC_API_URL | quote }}
+  API_INTERNAL_BASE_URL: {{ .Values.config.API_INTERNAL_BASE_URL | quote }}
   SANDBOX_ARTIFACT_UPLOAD_BASE_URL: {{ .Values.config.SANDBOX_ARTIFACT_UPLOAD_BASE_URL | quote }}
   FRONTEND_URL: {{ .Values.config.FRONTEND_URL | quote }}
   BACKEND_CORS_ORIGINS: {{ .Values.config.BACKEND_CORS_ORIGINS | quote }}

--- a/deploy/helm/clouisle/templates/sandbox-worker-deployment.yaml
+++ b/deploy/helm/clouisle/templates/sandbox-worker-deployment.yaml
@@ -28,17 +28,26 @@ spec:
           command:
             {{- toYaml .Values.sandboxWorker.command | nindent 12 }}
           {{- include "clouisle.envFrom" . | nindent 10 }}
+          env:
+            - name: UPLOAD_STORAGE_MODE
+              value: "remote"
+            - name: INTERNAL_API_TOKEN_FILE
+              value: /var/run/secrets/clouisle/internal-api-token
+          volumeMounts:
+            - name: internal-api-token
+              mountPath: /var/run/secrets/clouisle
+              readOnly: true
           {{- with $sandboxSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          volumeMounts:
-            - name: uploads
-              mountPath: {{ .Values.uploads.mountPath }}
           resources:
             {{- toYaml .Values.sandboxWorker.resources | nindent 12 }}
       volumes:
-        - name: uploads
-          persistentVolumeClaim:
-            claimName: {{ include "clouisle.uploadsClaimName" . }}
+        - name: internal-api-token
+          secret:
+            secretName: {{ include "clouisle.secretName" . }}
+            items:
+              - key: INTERNAL_API_TOKEN
+                path: internal-api-token
 {{- end }}

--- a/deploy/helm/clouisle/templates/secret.yaml
+++ b/deploy/helm/clouisle/templates/secret.yaml
@@ -1,4 +1,8 @@
 {{- if and .Values.secrets.create (not .Values.secrets.existingSecret) }}
+{{- $internalAPIToken := required "secrets.values.INTERNAL_API_TOKEN must be set when secrets.create=true" (index .Values.secrets.values "INTERNAL_API_TOKEN") }}
+{{- if eq $internalAPIToken "changeme" }}
+{{- fail "secrets.values.INTERNAL_API_TOKEN must not use the insecure value changeme" }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/clouisle/templates/worker-deployment.yaml
+++ b/deploy/helm/clouisle/templates/worker-deployment.yaml
@@ -27,17 +27,26 @@ spec:
           command:
             {{- toYaml .Values.worker.command | nindent 12 }}
           {{- include "clouisle.envFrom" . | nindent 10 }}
+          env:
+            - name: UPLOAD_STORAGE_MODE
+              value: "remote"
+            - name: INTERNAL_API_TOKEN_FILE
+              value: /var/run/secrets/clouisle/internal-api-token
+          volumeMounts:
+            - name: internal-api-token
+              mountPath: /var/run/secrets/clouisle
+              readOnly: true
           {{- with .Values.global.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          volumeMounts:
-            - name: uploads
-              mountPath: {{ .Values.uploads.mountPath }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
       volumes:
-        - name: uploads
-          persistentVolumeClaim:
-            claimName: {{ include "clouisle.uploadsClaimName" . }}
+        - name: internal-api-token
+          secret:
+            secretName: {{ include "clouisle.secretName" . }}
+            items:
+              - key: INTERNAL_API_TOKEN
+                path: internal-api-token
 {{- end }}

--- a/deploy/helm/clouisle/values-production.yaml
+++ b/deploy/helm/clouisle/values-production.yaml
@@ -1,13 +1,13 @@
 images:
   backend:
-    repository: registry.example.com/clouisle/clouisle-backend
-    tag: 0.1.0
+    repository: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend
+    tag: latest
   sandboxWorker:
-    repository: registry.example.com/clouisle/clouisle-sandbox-worker
-    tag: 0.1.0
+    repository: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-sandbox-worker
+    tag: latest
   frontend:
-    repository: registry.example.com/clouisle/clouisle-frontend
-    tag: 0.1.0
+    repository: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-frontend
+    tag: latest
 
 config:
   API_BASE_URL: http://api:8000

--- a/deploy/helm/clouisle/values-production.yaml
+++ b/deploy/helm/clouisle/values-production.yaml
@@ -11,6 +11,8 @@ images:
 
 config:
   API_BASE_URL: http://api:8000
+  PUBLIC_API_URL: https://clouisle.example.com
+  API_INTERNAL_BASE_URL: http://api:8000
   SANDBOX_ARTIFACT_UPLOAD_BASE_URL: http://api:8000
   FRONTEND_URL: https://clouisle.example.com
   BACKEND_CORS_ORIGINS: '["https://clouisle.example.com"]'

--- a/deploy/helm/clouisle/values.yaml
+++ b/deploy/helm/clouisle/values.yaml
@@ -26,6 +26,8 @@ config:
   PROJECT_NAME: Clouisle
   TIMEZONE: Asia/Shanghai
   API_BASE_URL: http://api:8000
+  PUBLIC_API_URL: ""
+  API_INTERNAL_BASE_URL: http://api:8000
   SANDBOX_ARTIFACT_UPLOAD_BASE_URL: http://api:8000
   FRONTEND_URL: http://frontend:3000
   BACKEND_CORS_ORIGINS: '["http://localhost:3000"]'
@@ -63,6 +65,7 @@ secrets:
     QDRANT_API_KEY: changeme
     TAVILY_API_KEY: ""
     SANDBOX_ARTIFACT_UPLOAD_API_KEY: ""
+    INTERNAL_API_TOKEN: changeme
 
 serviceAccount:
   create: true
@@ -83,6 +86,11 @@ api:
   enabled: true
   replicas: 2
   command: ["python", "main.py", "server", "-H", "0.0.0.0", "-w", "4", "--no-reload"]
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   service:
     type: ClusterIP
     port: 8000

--- a/deploy/helm/clouisle/values.yaml
+++ b/deploy/helm/clouisle/values.yaml
@@ -10,15 +10,15 @@ global:
 
 images:
   backend:
-    repository: clouisle-backend
+    repository: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend
     tag: latest
     pullPolicy: IfNotPresent
   sandboxWorker:
-    repository: clouisle-sandbox-worker
+    repository: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-sandbox-worker
     tag: latest
     pullPolicy: IfNotPresent
   frontend:
-    repository: clouisle-frontend
+    repository: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-frontend
     tag: latest
     pullPolicy: IfNotPresent
 

--- a/deploy/helm/clouisle/values.yaml
+++ b/deploy/helm/clouisle/values.yaml
@@ -65,7 +65,7 @@ secrets:
     QDRANT_API_KEY: changeme
     TAVILY_API_KEY: ""
     SANDBOX_ARTIFACT_UPLOAD_API_KEY: ""
-    INTERNAL_API_TOKEN: changeme
+    INTERNAL_API_TOKEN: ""
 
 serviceAccount:
   create: true

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+REPOSITORY="${CLOUISLE_REPOSITORY:-clouisle/Clouisle}"
+REF="${CLOUISLE_REF:-main}"
+RAW_BASE_URL="${CLOUISLE_BASE_URL:-https://raw.githubusercontent.com/${REPOSITORY}/${REF}/deploy}"
+ARCHIVE_URL="${CLOUISLE_ARCHIVE_URL:-https://github.com/${REPOSITORY}/archive/${REF}.tar.gz}"
+DRY_RUN="${CLOUISLE_DRY_RUN:-0}"
+AUTO_APPROVE="${CLOUISLE_YES:-0}"
+SOURCE_DIR="${CLOUISLE_SOURCE_DIR:-}"
+TEMP_DIR=""
+CHART_PATH=""
+TTY_AVAILABLE=0
+
+if { exec 3<>/dev/tty; } 2>/dev/null; then
+  TTY_AVAILABLE=1
+fi
+
+cleanup() {
+  if [[ -n "$TEMP_DIR" && -d "$TEMP_DIR" ]]; then
+    rm -rf "$TEMP_DIR"
+  fi
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+log() {
+  printf '%s\n' "$*"
+}
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+prompt() {
+  local label="$1"
+  local default_value="$2"
+  local answer=""
+
+  [[ "$TTY_AVAILABLE" == "1" ]] || die "Interactive input requires a terminal. Set CLOUISLE_DEPLOYMENT and CLOUISLE_YES=1 for non-interactive use."
+  printf '%s [%s]: ' "$label" "$default_value" >&3
+  IFS= read -r answer <&3 || true
+  printf '%s' "${answer:-$default_value}"
+}
+
+confirm() {
+  local answer=""
+  if [[ "$AUTO_APPROVE" == "1" ]]; then
+    return
+  fi
+  [[ "$TTY_AVAILABLE" == "1" ]] || die "Confirmation requires a terminal. Set CLOUISLE_YES=1 for non-interactive use."
+  printf 'Continue? [Y/n]: ' >&3
+  IFS= read -r answer <&3 || true
+  case "${answer:-Y}" in
+    Y|y|yes|YES) ;;
+    *) die "Deployment cancelled" ;;
+  esac
+}
+
+choose_deployment() {
+  if [[ -n "${CLOUISLE_DEPLOYMENT:-}" ]]; then
+    printf '%s' "$CLOUISLE_DEPLOYMENT"
+    return
+  fi
+
+  [[ "$TTY_AVAILABLE" == "1" ]] || die "Set CLOUISLE_DEPLOYMENT=docker or CLOUISLE_DEPLOYMENT=helm."
+  printf '\nChoose a deployment target:\n' >&3
+  printf '  1) Docker Compose (single server)\n' >&3
+  printf '  2) Kubernetes with Helm\n' >&3
+  printf 'Selection [1]: ' >&3
+  local selection=""
+  IFS= read -r selection <&3 || true
+  case "${selection:-1}" in
+    1) printf 'docker' ;;
+    2) printf 'helm' ;;
+    *) die "Invalid deployment selection: $selection" ;;
+  esac
+}
+
+download() {
+  local url="$1"
+  local destination="$2"
+  curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 15 "$url" -o "$destination"
+}
+
+random_secret() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+  else
+    od -An -N32 -tx1 /dev/urandom | tr -d ' \n'
+  fi
+}
+
+set_env_value() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  local temporary="${file}.tmp.$$"
+
+  awk -v key="$key" -v value="$value" '
+    BEGIN { found = 0 }
+    index($0, key "=") == 1 { print key "=" value; found = 1; next }
+    { print }
+    END { if (!found) print key "=" value }
+  ' "$file" > "$temporary"
+  mv "$temporary" "$file"
+}
+
+ensure_secret() {
+  local file="$1"
+  local key="$2"
+  local insecure_value="${3:-}"
+  local current=""
+
+  current="$(awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$file")"
+  if [[ -z "$current" || ( -n "$insecure_value" && "$current" == "$insecure_value" ) ]]; then
+    set_env_value "$file" "$key" "$(random_secret)"
+  fi
+}
+
+validate_kubernetes_name() {
+  [[ "$2" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || die "$1 must be a valid Kubernetes DNS label: $2"
+}
+
+prepare_install_directory() {
+  local install_dir="$1"
+
+  if [[ ! -d "$install_dir" ]]; then
+    if ! mkdir -p "$install_dir" 2>/dev/null; then
+      require_command sudo
+      log "Creating $install_dir with sudo"
+      sudo mkdir -p "$install_dir"
+      sudo chown "$(id -u):$(id -g)" "$install_dir"
+    fi
+  fi
+
+  [[ -w "$install_dir" ]] || die "Installation directory is not writable: $install_dir"
+}
+
+install_docker() {
+  require_command docker
+  docker compose version >/dev/null 2>&1 || die "Docker Compose v2 is required"
+
+  local install_dir="/opt/clouisle"
+  if [[ "$TTY_AVAILABLE" == "1" ]]; then
+    install_dir="$(prompt "Installation directory" "$install_dir")"
+  fi
+  install_dir="${install_dir/#\~/$HOME}"
+
+  log ""
+  log "Deployment target: Docker Compose"
+  log "Installation directory: $install_dir"
+  log "Configuration: $install_dir/.env"
+  confirm
+
+  prepare_install_directory "$install_dir"
+  umask 077
+
+  local compose_file="$install_dir/docker-compose.yml"
+  local env_file="$install_dir/.env"
+  local compose_temporary="$install_dir/.docker-compose.yml.tmp.$$"
+
+  download "$RAW_BASE_URL/docker-compose.yml" "$compose_temporary"
+  mv "$compose_temporary" "$compose_file"
+
+  if [[ ! -f "$env_file" ]]; then
+    download "$RAW_BASE_URL/.env.example" "$env_file"
+  fi
+
+  ensure_secret "$env_file" SECRET_KEY changethis-to-a-secure-random-secret-key
+  ensure_secret "$env_file" POSTGRES_PASSWORD
+  ensure_secret "$env_file" REDIS_PASSWORD
+  ensure_secret "$env_file" QDRANT_API_KEY
+  ensure_secret "$env_file" SANDBOX_ARTIFACT_UPLOAD_API_KEY
+  chmod 600 "$env_file"
+
+  local compose=(docker compose --project-directory "$install_dir" --env-file "$env_file" -f "$compose_file")
+  "${compose[@]}" config --quiet
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "Docker Compose configuration validated. Dry run complete."
+    return
+  fi
+
+  "${compose[@]}" pull
+  "${compose[@]}" up -d --remove-orphans
+  "${compose[@]}" ps
+
+  log ""
+  log "Clouisle is starting."
+  log "Frontend: http://localhost:3000"
+  log "API documentation: http://localhost:8000/docs"
+  log "Configuration: $env_file"
+}
+
+write_helm_values() {
+  local file="$1"
+  local secret_name="$2"
+  local ingress_host="$3"
+  local ingress_class="$4"
+  local storage_class="$5"
+  local access_mode="$6"
+  local image_pull_secret="$7"
+
+  {
+    printf 'secrets:\n'
+    printf '  create: false\n'
+    printf '  existingSecret: "%s"\n' "$secret_name"
+    printf 'uploads:\n'
+    printf '  accessModes:\n'
+    printf '    - %s\n' "$access_mode"
+    if [[ -n "$storage_class" ]]; then
+      printf '  storageClassName: "%s"\n' "$storage_class"
+    fi
+    if [[ "$access_mode" == "ReadWriteOnce" ]]; then
+      printf 'api:\n  replicas: 1\n'
+      printf 'worker:\n  replicas: 1\n'
+    fi
+    if [[ -n "$image_pull_secret" ]]; then
+      printf 'global:\n'
+      printf '  imagePullSecrets:\n'
+      printf '    - name: "%s"\n' "$image_pull_secret"
+    fi
+    if [[ -n "$ingress_host" ]]; then
+      printf 'config:\n'
+      printf '  FRONTEND_URL: "https://%s"\n' "$ingress_host"
+      printf '  BACKEND_CORS_ORIGINS: '\''["https://%s"]'\''\n' "$ingress_host"
+      printf 'ingress:\n'
+      printf '  enabled: true\n'
+      printf '  className: "%s"\n' "$ingress_class"
+      printf '  hosts:\n'
+      printf '    - host: "%s"\n' "$ingress_host"
+      printf '      paths:\n'
+      printf '        api:\n          path: /api\n          pathType: Prefix\n'
+      printf '        frontend:\n          path: /\n          pathType: Prefix\n'
+    else
+      printf 'ingress:\n  enabled: false\n'
+    fi
+  } > "$file"
+}
+
+prepare_chart() {
+  if [[ -n "$SOURCE_DIR" ]]; then
+    CHART_PATH="$SOURCE_DIR/deploy/helm/clouisle"
+    return
+  fi
+
+  require_command tar
+  TEMP_DIR="$(mktemp -d)"
+  local archive="$TEMP_DIR/source.tar.gz"
+  local source="$TEMP_DIR/source"
+  mkdir -p "$source"
+  download "$ARCHIVE_URL" "$archive"
+  tar -xzf "$archive" -C "$source" --strip-components=1
+  CHART_PATH="$source/deploy/helm/clouisle"
+}
+
+install_helm() {
+  require_command helm
+
+  local namespace="${CLOUISLE_NAMESPACE:-}"
+  local release_name="${CLOUISLE_RELEASE:-}"
+  local ingress_host="${CLOUISLE_INGRESS_HOST:-}"
+  local ingress_class="${CLOUISLE_INGRESS_CLASS:-nginx}"
+  local storage_class="${CLOUISLE_STORAGE_CLASS:-}"
+  local access_mode="${CLOUISLE_STORAGE_ACCESS_MODE:-ReadWriteMany}"
+  local image_pull_secret="${CLOUISLE_IMAGE_PULL_SECRET:-}"
+  local secret_name="${CLOUISLE_SECRET_NAME:-clouisle-secret}"
+
+  [[ -n "$namespace" ]] || namespace="$(prompt "Kubernetes namespace" "clouisle")"
+  [[ -n "$release_name" ]] || release_name="$(prompt "Helm release name" "clouisle")"
+  if [[ -z "${CLOUISLE_INGRESS_HOST+x}" ]]; then
+    ingress_host="$(prompt "Ingress hostname (empty disables Ingress)" "")"
+  fi
+  if [[ -z "${CLOUISLE_STORAGE_CLASS+x}" ]]; then
+    storage_class="$(prompt "RWX StorageClass (empty uses cluster default)" "")"
+  fi
+  if [[ -z "${CLOUISLE_IMAGE_PULL_SECRET+x}" ]]; then
+    image_pull_secret="$(prompt "Existing imagePullSecret (empty if ACR is public)" "")"
+  fi
+
+  validate_kubernetes_name "Namespace" "$namespace"
+  validate_kubernetes_name "Release name" "$release_name"
+  validate_kubernetes_name "Secret name" "$secret_name"
+  [[ "$access_mode" == "ReadWriteMany" || "$access_mode" == "ReadWriteOnce" ]] || die "CLOUISLE_STORAGE_ACCESS_MODE must be ReadWriteMany or ReadWriteOnce"
+  [[ -z "$ingress_host" || "$ingress_host" =~ ^[A-Za-z0-9.-]+$ ]] || die "Ingress hostname contains unsupported characters"
+  [[ -z "$storage_class" || "$storage_class" =~ ^[A-Za-z0-9._-]+$ ]] || die "StorageClass contains unsupported characters"
+  [[ -z "$image_pull_secret" ]] || validate_kubernetes_name "imagePullSecret" "$image_pull_secret"
+
+  log ""
+  log "Deployment target: Kubernetes with Helm"
+  log "Namespace: $namespace"
+  log "Release: $release_name"
+  log "Ingress: ${ingress_host:-disabled}"
+  log "Uploads access mode: $access_mode"
+  log "Uploads StorageClass: ${storage_class:-cluster default}"
+  confirm
+
+  prepare_chart
+  local chart="$CHART_PATH"
+  [[ -f "$chart/Chart.yaml" ]] || die "Helm chart not found: $chart"
+
+  if [[ -z "$TEMP_DIR" ]]; then
+    TEMP_DIR="$(mktemp -d)"
+  fi
+  local values_file="$TEMP_DIR/clouisle-installer-values.yaml"
+  write_helm_values "$values_file" "$secret_name" "$ingress_host" "$ingress_class" "$storage_class" "$access_mode" "$image_pull_secret"
+
+  helm lint "$chart" -f "$values_file"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    helm template "$release_name" "$chart" --namespace "$namespace" -f "$values_file" >/dev/null
+    log "Helm chart validated. Dry run complete."
+    return
+  fi
+
+  require_command kubectl
+  kubectl cluster-info >/dev/null
+  kubectl create namespace "$namespace" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+  if ! kubectl -n "$namespace" get secret "$secret_name" >/dev/null 2>&1; then
+    kubectl -n "$namespace" create secret generic "$secret_name" \
+      --from-literal=SECRET_KEY="$(random_secret)" \
+      --from-literal=POSTGRES_PASSWORD="$(random_secret)" \
+      --from-literal=REDIS_PASSWORD="$(random_secret)" \
+      --from-literal=QDRANT_API_KEY="$(random_secret)" \
+      --from-literal=SANDBOX_ARTIFACT_UPLOAD_API_KEY="$(random_secret)" >/dev/null
+  fi
+
+  helm upgrade --install "$release_name" "$chart" \
+    --namespace "$namespace" \
+    --create-namespace \
+    -f "$values_file" \
+    --wait \
+    --timeout 15m
+
+  kubectl -n "$namespace" get pods
+  log ""
+  if [[ -n "$ingress_host" ]]; then
+    log "Clouisle URL: https://$ingress_host"
+  else
+    log "Ingress is disabled. Access the frontend with:"
+    log "kubectl -n $namespace port-forward service/frontend 3000:3000"
+  fi
+}
+
+main() {
+  require_command curl
+
+  case "$(choose_deployment)" in
+    docker) install_docker ;;
+    helm) install_helm ;;
+    *) die "CLOUISLE_DEPLOYMENT must be docker or helm" ;;
+  esac
+}
+
+main "$@"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -69,19 +69,50 @@ choose_deployment() {
     return
   fi
 
-  [[ "$TTY_AVAILABLE" == "1" ]] || die "Set CLOUISLE_DEPLOYMENT=docker or CLOUISLE_DEPLOYMENT=helm."
+  [[ "$TTY_AVAILABLE" == "1" ]] || die "Set CLOUISLE_DEPLOYMENT=docker, helm, or k8s."
   printf '\nChoose a deployment target:\n' >&3
   printf '  1) Docker Compose (single server)\n' >&3
   printf '  2) Kubernetes with Helm\n' >&3
+  printf '  3) Kubernetes single-file manifest (generate only)\n' >&3
   printf 'Selection [1]: ' >&3
   local selection=""
   IFS= read -r selection <&3 || true
   case "${selection:-1}" in
     1) printf 'docker' ;;
     2) printf 'helm' ;;
+    3) printf 'k8s' ;;
     *) die "Invalid deployment selection: $selection" ;;
   esac
 }
+
+base64_secret() {
+  printf '%s' "$1" | base64 | tr -d '\n'
+}
+
+set_manifest_secret() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  local encoded=""
+  local temporary="${file}.tmp.$$"
+
+  encoded="$(base64_secret "$value")"
+  if ! awk -v key="$key" -v encoded="$encoded" '
+    BEGIN { found = 0 }
+    $0 ~ "^[[:space:]]*" key ":[[:space:]]*" {
+      print "  " key ": " encoded
+      found = 1
+      next
+    }
+    { print }
+    END { if (!found) exit 1 }
+  ' "$file" > "$temporary"; then
+    rm -f "$temporary"
+    die "Kubernetes Secret key not found in manifest: $key"
+  fi
+  mv "$temporary" "$file"
+}
+
 
 download() {
   local url="$1"
@@ -121,6 +152,19 @@ ensure_secret() {
   current="$(awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$file")"
   if [[ -z "$current" || ( -n "$insecure_value" && "$current" == "$insecure_value" ) ]]; then
     set_env_value "$file" "$key" "$(random_secret)"
+  fi
+}
+
+ensure_kubernetes_internal_token() {
+  local namespace="$1"
+  local secret_name="$2"
+  local encoded=""
+
+  encoded="$(kubectl -n "$namespace" get secret "$secret_name" -o jsonpath='{.data.INTERNAL_API_TOKEN}' 2>/dev/null || true)"
+  if [[ -z "$encoded" ]]; then
+    kubectl -n "$namespace" patch secret "$secret_name" \
+      --type merge \
+      -p "{\"stringData\":{\"INTERNAL_API_TOKEN\":\"$(random_secret)\"}}" >/dev/null
   fi
 }
 
@@ -178,6 +222,7 @@ install_docker() {
   ensure_secret "$env_file" REDIS_PASSWORD
   ensure_secret "$env_file" QDRANT_API_KEY
   ensure_secret "$env_file" SANDBOX_ARTIFACT_UPLOAD_API_KEY
+  ensure_secret "$env_file" INTERNAL_API_TOKEN
   chmod 600 "$env_file"
 
   local compose=(docker compose --project-directory "$install_dir" --env-file "$env_file" -f "$compose_file")
@@ -220,7 +265,6 @@ write_helm_values() {
     fi
     if [[ "$access_mode" == "ReadWriteOnce" ]]; then
       printf 'api:\n  replicas: 1\n'
-      printf 'worker:\n  replicas: 1\n'
     fi
     if [[ -n "$image_pull_secret" ]]; then
       printf 'global:\n'
@@ -330,17 +374,17 @@ install_helm() {
       --from-literal=POSTGRES_PASSWORD="$(random_secret)" \
       --from-literal=REDIS_PASSWORD="$(random_secret)" \
       --from-literal=QDRANT_API_KEY="$(random_secret)" \
-      --from-literal=SANDBOX_ARTIFACT_UPLOAD_API_KEY="$(random_secret)" >/dev/null
+      --from-literal=SANDBOX_ARTIFACT_UPLOAD_API_KEY="$(random_secret)" \
+      --from-literal=INTERNAL_API_TOKEN="$(random_secret)" >/dev/null
   fi
 
+  ensure_kubernetes_internal_token "$namespace" "$secret_name"
   helm upgrade --install "$release_name" "$chart" \
     --namespace "$namespace" \
     --create-namespace \
     -f "$values_file" \
     --wait \
     --timeout 15m
-
-  kubectl -n "$namespace" get pods
   log ""
   if [[ -n "$ingress_host" ]]; then
     log "Clouisle URL: https://$ingress_host"
@@ -350,13 +394,65 @@ install_helm() {
   fi
 }
 
+install_k8s_manifest() {
+  require_command base64
+
+  local output_path="${CLOUISLE_K8S_MANIFEST:-./clouisle-k8s.yaml}"
+  output_path="${output_path/#\~/$HOME}"
+  if [[ -e "$output_path" || -L "$output_path" ]]; then
+    die "Refusing to overwrite existing Kubernetes manifest: $output_path"
+  fi
+
+  local output_dir
+  output_dir="$(dirname "$output_path")"
+
+  log ""
+  log "Deployment target: Kubernetes single-file manifest"
+  log "Generated manifest: $output_path"
+  log "The generated file contains secrets and will not be applied automatically."
+  confirm
+  mkdir -p "$output_dir"
+  [[ -w "$output_dir" ]] || die "Kubernetes manifest directory is not writable: $output_dir"
+
+  if [[ -z "$TEMP_DIR" ]]; then
+    TEMP_DIR="$(mktemp -d)"
+  fi
+  local temporary="$TEMP_DIR/clouisle-k8s.yaml"
+
+  if [[ -n "$SOURCE_DIR" ]]; then
+    local source_manifest="$SOURCE_DIR/deploy/k8s/clouisle.yaml"
+    [[ -f "$source_manifest" ]] || die "Kubernetes manifest not found: $source_manifest"
+    cp "$source_manifest" "$temporary"
+  else
+    download "$RAW_BASE_URL/k8s/clouisle.yaml" "$temporary"
+  fi
+
+  local key
+  for key in \
+    SECRET_KEY \
+    POSTGRES_PASSWORD \
+    REDIS_PASSWORD \
+    QDRANT_API_KEY \
+    SANDBOX_ARTIFACT_UPLOAD_API_KEY \
+    INTERNAL_API_TOKEN; do
+    set_manifest_secret "$temporary" "$key" "$(random_secret)"
+  done
+
+  chmod 600 "$temporary"
+  mv "$temporary" "$output_path"
+  log "Generated secure Kubernetes manifest: $output_path"
+  log "Review cluster-specific image, storage, and Ingress settings, then apply with:"
+  log "kubectl apply -f $output_path"
+}
+
 main() {
   require_command curl
 
   case "$(choose_deployment)" in
     docker) install_docker ;;
     helm) install_helm ;;
-    *) die "CLOUISLE_DEPLOYMENT must be docker or helm" ;;
+    k8s) install_k8s_manifest ;;
+    *) die "CLOUISLE_DEPLOYMENT must be docker, helm, or k8s" ;;
   esac
 }
 

--- a/deploy/k8s/clouisle.yaml
+++ b/deploy/k8s/clouisle.yaml
@@ -6,8 +6,7 @@
 # IMPORTANT: Before applying, replace base64 placeholder values in the Secret.
 #   echo -n 'your-value' | base64
 #
-# Replace image references with your registry, e.g.:
-#   registry.cn-hangzhou.aliyuncs.com/clouisle/clouisle-backend:0.1.0
+# Application images use the published Clouisle ACR repositories below.
 
 # ===========================================================================
 # 1. Namespace
@@ -368,7 +367,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: clouisle-backend:latest
+          image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest
           imagePullPolicy: IfNotPresent
           command: ["python", "main.py", "server", "-H", "0.0.0.0", "-w", "4", "--no-reload"]
           ports:
@@ -426,7 +425,7 @@ spec:
     spec:
       containers:
         - name: worker
-          image: clouisle-backend:latest
+          image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest
           imagePullPolicy: IfNotPresent
           command: ["python", "main.py", "worker", "-c", "4", "-Q", "default,knowledge,workflow"]
           envFrom:
@@ -470,7 +469,7 @@ spec:
     spec:
       containers:
         - name: sandbox-worker
-          image: clouisle-sandbox-worker:latest
+          image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-sandbox-worker:latest
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -527,7 +526,7 @@ spec:
     spec:
       containers:
         - name: beat
-          image: clouisle-backend:latest
+          image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest
           imagePullPolicy: IfNotPresent
           command: ["python", "main.py", "beat"]
           envFrom:
@@ -576,7 +575,7 @@ spec:
     spec:
       containers:
         - name: frontend
-          image: clouisle-frontend:latest
+          image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-frontend:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/deploy/k8s/clouisle.yaml
+++ b/deploy/k8s/clouisle.yaml
@@ -65,8 +65,8 @@ data:
   POSTGRES_PASSWORD: Y2hhbmdlbWU=   # changeme
   REDIS_PASSWORD: Y2hhbmdlbWU=      # changeme
   QDRANT_API_KEY: Y2hhbmdlbWU=      # changeme
-  INTERNAL_API_TOKEN: Y2hhbmdlbWU=  # changeme — worker -> api internal file gateway
-  SANDBOX_ARTIFACT_UPLOAD_API_KEY: Y2hhbmdlbWU=  # changeme
+  INTERNAL_API_TOKEN: ""  # required; install.sh generates it in output copies
+  SANDBOX_ARTIFACT_UPLOAD_API_KEY: ""  # required; install.sh generates it in output copies
 
 # ===========================================================================
 # 4. PostgreSQL — StatefulSet + Headless Service + PVC

--- a/deploy/k8s/clouisle.yaml
+++ b/deploy/k8s/clouisle.yaml
@@ -3,8 +3,8 @@
 # Apply:  kubectl apply -f deploy/k8s/clouisle.yaml
 # =============================================================================
 #
-# IMPORTANT: Before applying, replace base64 placeholder values in the Secret.
-#   echo -n 'your-value' | base64
+# IMPORTANT: Generate a separate secret-filled copy with `deploy/install.sh` (`CLOUISLE_DEPLOYMENT=k8s`),
+# or replace the base64 placeholder values below before applying this template manually.
 #
 # Application images use the published Clouisle ACR repositories below.
 
@@ -30,6 +30,8 @@ data:
   PROJECT_NAME: "Clouisle"
   TIMEZONE: "Asia/Shanghai"
   API_BASE_URL: "http://api:8000"
+  PUBLIC_API_URL: ""
+  API_INTERNAL_BASE_URL: "http://api:8000"
   SANDBOX_ARTIFACT_UPLOAD_BASE_URL: "http://api:8000"
   SANDBOX_WORKER_CONCURRENCY: "1"
   SANDBOX_FILESYSTEM_ISOLATION_ENABLED: "true"
@@ -49,8 +51,7 @@ data:
   RETRIEVAL_SHADOW_ENABLED: "false"
   BACKEND_CORS_ORIGINS: '["http://localhost:3000"]'
 
-# ===========================================================================
-# 3. Secret — sensitive values (replace base64 placeholders!)
+# 3. Secret — sensitive values (replace placeholders manually; the installer only changes generated copies)
 # ===========================================================================
 ---
 apiVersion: v1
@@ -64,6 +65,8 @@ data:
   POSTGRES_PASSWORD: Y2hhbmdlbWU=   # changeme
   REDIS_PASSWORD: Y2hhbmdlbWU=      # changeme
   QDRANT_API_KEY: Y2hhbmdlbWU=      # changeme
+  INTERNAL_API_TOKEN: Y2hhbmdlbWU=  # changeme — worker -> api internal file gateway
+  SANDBOX_ARTIFACT_UPLOAD_API_KEY: Y2hhbmdlbWU=  # changeme
 
 # ===========================================================================
 # 4. PostgreSQL — StatefulSet + Headless Service + PVC
@@ -318,9 +321,9 @@ spec:
             claimName: qdrant-data
 
 # ===========================================================================
-# 7. Uploads — Shared PVC
-#    Production multi-replica deployments require a ReadWriteMany-capable
-#    StorageClass. Use single replicas or object storage if RWX is unavailable.
+# 7. Uploads — API PVC
+#    Multiple API replicas using local storage require ReadWriteMany. Workers
+#    access uploads through the authenticated API gateway and do not mount it.
 # ===========================================================================
 ---
 apiVersion: v1
@@ -357,6 +360,11 @@ metadata:
   namespace: clouisle
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: api
@@ -365,6 +373,39 @@ spec:
       labels:
         app: api
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-postgres-pg-search:0.24.3-pg17-alpine1
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -ec
+            - |
+              until pg_isready -h "$POSTGRES_SERVER" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB"; do
+                echo "Waiting for PostgreSQL at ${POSTGRES_SERVER}:${POSTGRES_PORT}..."
+                sleep 2
+              done
+          env:
+            - name: POSTGRES_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_SERVER
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_PORT
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_USER
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_DB
       containers:
         - name: api
           image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest
@@ -377,9 +418,15 @@ spec:
                 name: clouisle-config
             - secretRef:
                 name: clouisle-secret
+          env:
+            - name: INTERNAL_API_TOKEN_FILE
+              value: /var/run/secrets/clouisle/internal-api-token
           volumeMounts:
             - name: uploads
               mountPath: /app/uploads
+            - name: internal-api-token
+              mountPath: /var/run/secrets/clouisle
+              readOnly: true
           readinessProbe:
             httpGet:
               path: /api/v1/health
@@ -403,6 +450,12 @@ spec:
         - name: uploads
           persistentVolumeClaim:
             claimName: uploads-data
+        - name: internal-api-token
+          secret:
+            secretName: clouisle-secret
+            items:
+              - key: INTERNAL_API_TOKEN
+                path: internal-api-token
 
 # ===========================================================================
 # 9. Worker — Deployment (no Service)
@@ -423,6 +476,39 @@ spec:
       labels:
         app: worker
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-postgres-pg-search:0.24.3-pg17-alpine1
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -ec
+            - |
+              until pg_isready -h "$POSTGRES_SERVER" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB"; do
+                echo "Waiting for PostgreSQL at ${POSTGRES_SERVER}:${POSTGRES_PORT}..."
+                sleep 2
+              done
+          env:
+            - name: POSTGRES_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_SERVER
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_PORT
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_USER
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_DB
       containers:
         - name: worker
           image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest
@@ -433,9 +519,15 @@ spec:
                 name: clouisle-config
             - secretRef:
                 name: clouisle-secret
+          env:
+            - name: UPLOAD_STORAGE_MODE
+              value: "remote"
+            - name: INTERNAL_API_TOKEN_FILE
+              value: /var/run/secrets/clouisle/internal-api-token
           volumeMounts:
-            - name: uploads
-              mountPath: /app/uploads
+            - name: internal-api-token
+              mountPath: /var/run/secrets/clouisle
+              readOnly: true
           resources:
             requests:
               cpu: 250m
@@ -444,9 +536,12 @@ spec:
               cpu: "2"
               memory: 2Gi
       volumes:
-        - name: uploads
-          persistentVolumeClaim:
-            claimName: uploads-data
+        - name: internal-api-token
+          secret:
+            secretName: clouisle-secret
+            items:
+              - key: INTERNAL_API_TOKEN
+                path: internal-api-token
 
 # ===========================================================================
 # 10. Sandbox Worker — Deployment (no Service)
@@ -467,6 +562,39 @@ spec:
       labels:
         app: sandbox-worker
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-postgres-pg-search:0.24.3-pg17-alpine1
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -ec
+            - |
+              until pg_isready -h "$POSTGRES_SERVER" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB"; do
+                echo "Waiting for PostgreSQL at ${POSTGRES_SERVER}:${POSTGRES_PORT}..."
+                sleep 2
+              done
+          env:
+            - name: POSTGRES_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_SERVER
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_PORT
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_USER
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_DB
       containers:
         - name: sandbox-worker
           image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-sandbox-worker:latest
@@ -480,6 +608,15 @@ spec:
                 name: clouisle-config
             - secretRef:
                 name: clouisle-secret
+          env:
+            - name: UPLOAD_STORAGE_MODE
+              value: "remote"
+            - name: INTERNAL_API_TOKEN_FILE
+              value: /var/run/secrets/clouisle/internal-api-token
+          volumeMounts:
+            - name: internal-api-token
+              mountPath: /var/run/secrets/clouisle
+              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -488,9 +625,6 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: Unconfined
-          volumeMounts:
-            - name: uploads
-              mountPath: /app/uploads
           resources:
             requests:
               cpu: 250m
@@ -499,9 +633,12 @@ spec:
               cpu: "2"
               memory: 2Gi
       volumes:
-        - name: uploads
-          persistentVolumeClaim:
-            claimName: uploads-data
+        - name: internal-api-token
+          secret:
+            secretName: clouisle-secret
+            items:
+              - key: INTERNAL_API_TOKEN
+                path: internal-api-token
 
 # ===========================================================================
 # 11. Beat — Deployment (single replica, Recreate)
@@ -524,6 +661,39 @@ spec:
       labels:
         app: beat
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-postgres-pg-search:0.24.3-pg17-alpine1
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -ec
+            - |
+              until pg_isready -h "$POSTGRES_SERVER" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB"; do
+                echo "Waiting for PostgreSQL at ${POSTGRES_SERVER}:${POSTGRES_PORT}..."
+                sleep 2
+              done
+          env:
+            - name: POSTGRES_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_SERVER
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_PORT
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_USER
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: clouisle-config
+                  key: POSTGRES_DB
       containers:
         - name: beat
           image: registry.cn-shanghai.aliyuncs.com/clouisle/clouisle-backend:latest

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -2,6 +2,17 @@
 
 ## Active
 
+- **kubernetes-manifest-installer-readiness** — Complete. Add a secure single-file Kubernetes manifest generation route to the guided installer and prevent raw-manifest backend workloads from starting before PostgreSQL accepts connections. See `docs/plan/kubernetes-manifest-installer-readiness.md`
+  - [x] 1. Generate an isolated secret-filled Kubernetes manifest
+  - [x] 2. Gate raw backend workloads on PostgreSQL readiness
+  - [x] 3. Document and validate the installer and manifest
+
+- **remove-worker-uploads-mount** — In progress. Removed the shared uploads volume mount from the Celery worker (and sandbox-worker) so distributed deployments without distributed storage work: media assets moved onto UploadStorageBackend, worker file access goes through explicit internal `/internal/uploads/*` endpoints on api (`INTERNAL_API_TOKEN` auth), and the workflow `file_to_url` node became a pure URL passthrough. See `docs/plan/remove-worker-uploads-mount.md`
+  - [x] 1. Media assets on UploadStorageBackend (list/save/delete/serve)
+  - [x] 2. Internal file endpoints + token auth + worker remote-mode branches
+  - [x] 3. Deployment manifests, env/secret, and docs
+  - [ ] 4. End-to-end verification in a real cluster (local + object modes)
+
 - **yun-129-sandbox-oriented-asset-handling** — Complete. Replace parser- and URL-centric chat attachments with durable Assets that support on-demand parsing, stable conversation refs, Sandbox materialization, reusable media, and one Agent-level attachment capability. See `docs/plan/yun-129-sandbox-oriented-asset-handling.md`
   - [x] 1. Design and implementation index
   - [x] 2. Durable Asset domain and scoped references

--- a/docs/dev/backend/celery-and-async-jobs.md
+++ b/docs/dev/backend/celery-and-async-jobs.md
@@ -113,6 +113,8 @@ python main.py sandbox-worker --local-dev -c 1
 
 The local dev mode uses `deploy/dockerfiles/sandbox-worker.Dockerfile` with the repository root Docker context, so `.dockerignore` excludes local `.venv`, `node_modules`, caches, `.env` files, and other local artifacts. It does not bind mount the project directory; code changes require rebuilding by rerunning the command. The `-c/--concurrency` value is passed through to the Celery worker inside the container.
 
+The container sets `UPLOAD_STORAGE_MODE=remote`: it reads authorized attachments through the API instead of mounting `uploads`. Set `INTERNAL_API_TOKEN` in the root `.env`; `API_INTERNAL_BASE_URL` defaults to the local API through `host.docker.internal` and localhost URLs are rewritten for the container.
+
 The container image installs Bubblewrap and enables `SANDBOX_FILESYSTEM_ISOLATION_ENABLED=true` with `SANDBOX_FILESYSTEM_ISOLATION_BINARY=/usr/bin/bwrap`. Each executable task receives its current workspace as a real `/workspace` bind mount. Direct host execution keeps isolation disabled unless both variables are set explicitly on a Linux host with working unprivileged user namespaces.
 
 Docker and Kubernetes must allow the namespace and mount syscalls used by rootless Bubblewrap. The supplied Compose and Helm configurations keep the worker non-root, disable privilege escalation, drop all capabilities, and use a worker-specific unconfined seccomp profile. Use an equivalent Localhost profile when cluster policy prohibits `Unconfined`.

--- a/docs/guide/README_zh-CN.md
+++ b/docs/guide/README_zh-CN.md
@@ -174,26 +174,18 @@
 
 ### 前置条件
 
-- Docker 和 Docker Compose
+- 单机部署需要 Docker 和 Docker Compose v2
+- Kubernetes 部署需要 `kubectl` 和 Helm 3
 
-### 1. 配置环境变量
-
-```bash
-# 复制 Docker 部署环境变量文件
-cp deploy/.env.example deploy/.env
-
-# 编辑 deploy/.env，为以下字段设置强随机值：
-#   SECRET_KEY、POSTGRES_PASSWORD、REDIS_PASSWORD、QDRANT_API_KEY
-```
-
-### 2. 启动 Clouisle
+### 1. 运行引导式安装脚本
 
 ```bash
-cd deploy
-docker compose --env-file .env up -d
+curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
 ```
 
-### 3. 访问应用
+根据提示选择单机 Docker Compose 或 Kubernetes Helm。Docker 模式会交互式选择安装目录，默认为 `/opt/clouisle`。脚本会生成必要的随机密钥，并在启动前验证部署配置。
+
+### 2. 访问应用
 
 - **前端**：http://localhost:3000
 - **API 文档**：http://localhost:8000/docs

--- a/docs/guide/README_zh-CN.md
+++ b/docs/guide/README_zh-CN.md
@@ -183,7 +183,7 @@
 curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
 ```
 
-根据提示选择单机 Docker Compose 或 Kubernetes Helm。Docker 模式会交互式选择安装目录，默认为 `/opt/clouisle`。脚本会生成必要的随机密钥，并在启动前验证部署配置。
+根据提示选择单机 Docker Compose、Kubernetes Helm，或 Kubernetes 单文件 manifest（仅生成）。Docker 模式会交互式选择安装目录，默认为 `/opt/clouisle`；脚本会生成必要的随机密钥，并在启动前验证部署配置。选择单文件 manifest 时，脚本默认在当前目录生成权限为 `0600` 的 `./clouisle-k8s.yaml`（可通过 `CLOUISLE_K8S_MANIFEST` 指定路径），不会自动执行 `kubectl apply`；请先审阅生成文件，再运行 `kubectl apply -f ./clouisle-k8s.yaml`。
 
 ### 2. 访问应用
 

--- a/docs/guide/README_zh-CN.md
+++ b/docs/guide/README_zh-CN.md
@@ -183,7 +183,7 @@
 curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
 ```
 
-根据提示选择单机 Docker Compose、Kubernetes Helm，或 Kubernetes 单文件 manifest（仅生成）。Docker 模式会交互式选择安装目录，默认为 `/opt/clouisle`；脚本会生成必要的随机密钥，并在启动前验证部署配置。选择单文件 manifest 时，脚本默认在当前目录生成权限为 `0600` 的 `./clouisle-k8s.yaml`（可通过 `CLOUISLE_K8S_MANIFEST` 指定路径），不会自动执行 `kubectl apply`；请先审阅生成文件，再运行 `kubectl apply -f ./clouisle-k8s.yaml`。
+根据提示选择单机 Docker Compose、Kubernetes Helm，或 Kubernetes 单文件 manifest（仅生成）。Docker 模式会交互式选择安装目录，默认为 `/opt/clouisle`；脚本会生成必要的随机密钥，并在启动前验证部署配置。选择单文件 manifest 时，脚本默认在当前目录生成权限为 `0600` 的 `./clouisle-k8s.yaml`（可通过 `CLOUISLE_K8S_MANIFEST` 指定路径），不会自动执行 `kubectl apply`；请先审阅生成文件，再使用实际生成路径运行 `kubectl apply -f <manifest-path>`；未设置 `CLOUISLE_K8S_MANIFEST` 时使用 `./clouisle-k8s.yaml`。
 
 ### 2. 访问应用
 

--- a/docs/guide/deployment/DEPLOYMENT.md
+++ b/docs/guide/deployment/DEPLOYMENT.md
@@ -147,28 +147,24 @@ The plain manifest remains available at `deploy/k8s/clouisle.yaml` for fallback 
 
 ### Quick Start
 
+Run the interactive installer from any directory:
+
 ```bash
-cd deploy
+curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
+```
 
-# 1. Create and edit environment file
-cp .env.example .env
+Choose Docker Compose for a single server or Kubernetes with Helm. Docker mode prompts for an installation directory, defaulting to `/opt/clouisle`, then generates strong secrets, downloads the current Compose file, pulls images, and starts all services. Helm mode guides you through namespace, Ingress, shared storage, and optional image-pull-secret settings.
 
-# 2. Generate secure passwords (run each command, paste results into .env)
-openssl rand -base64 32    # → SECRET_KEY
-openssl rand -base64 16    # → POSTGRES_PASSWORD
-openssl rand -base64 16    # → REDIS_PASSWORD
-openssl rand -base64 16    # → QDRANT_API_KEY
+For non-interactive Docker installation:
 
-# 3. Build images and start all services
-docker compose up -d --build
-
-# 4. Verify all services are healthy
-docker compose ps
+```bash
+curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | \
+  CLOUISLE_DEPLOYMENT=docker CLOUISLE_YES=1 bash
 ```
 
 ### Configuration
 
-Edit `deploy/.env` before starting. The following variables **must** be changed:
+Docker installations keep their generated configuration in `<installation-directory>/.env` (`/opt/clouisle/.env` by default). Review it before exposing the deployment publicly. The following variables are generated automatically when empty:
 
 | Variable | Why | Example |
 |----------|-----|---------|
@@ -365,7 +361,7 @@ docker compose down -v
 
 # Update images and restart
 docker compose pull
-docker compose up -d --build
+docker compose up -d
 ```
 
 ---

--- a/docs/guide/deployment/DEPLOYMENT.md
+++ b/docs/guide/deployment/DEPLOYMENT.md
@@ -155,7 +155,7 @@ Run the interactive installer from any directory:
 curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
 ```
 
-Choose Docker Compose for a single server, Kubernetes with Helm, or Kubernetes single-file manifest generation. Docker mode prompts for an installation directory, defaulting to `/opt/clouisle`, then generates strong secrets, downloads the current Compose file, pulls images, and starts all services. Helm mode guides you through namespace, Ingress, shared storage, and optional image-pull-secret settings. The manifest mode writes a `0600` file at `./clouisle-k8s.yaml` by default (override with `CLOUISLE_K8S_MANIFEST`), does not apply it automatically, and prints the explicit `kubectl apply -f ./clouisle-k8s.yaml` command after generation; review the file before applying it.
+Choose Docker Compose for a single server, Kubernetes with Helm, or Kubernetes single-file manifest generation. Docker mode prompts for an installation directory, defaulting to `/opt/clouisle`, then generates strong secrets, downloads the current Compose file, pulls images, and starts all services. Helm mode guides you through namespace, Ingress, shared storage, and optional image-pull-secret settings. The manifest mode writes a `0600` file at `./clouisle-k8s.yaml` by default (override with `CLOUISLE_K8S_MANIFEST`), does not apply it automatically, and requires applying the generated file path after review; when `CLOUISLE_K8S_MANIFEST` is unset, use `kubectl apply -f ./clouisle-k8s.yaml`.
 
 For non-interactive Docker installation:
 

--- a/docs/guide/deployment/DEPLOYMENT.md
+++ b/docs/guide/deployment/DEPLOYMENT.md
@@ -126,10 +126,12 @@ docker push registry.example.com/clouisle/clouisle-frontend:latest
 Helm is the recommended Kubernetes deployment method:
 
 ```bash
-helm lint deploy/helm/clouisle
+helm lint deploy/helm/clouisle \
+  --set-string secrets.values.INTERNAL_API_TOKEN=lint-only-token
 helm upgrade --install clouisle deploy/helm/clouisle \
   --namespace clouisle \
-  --create-namespace
+  --create-namespace \
+  --set-string secrets.values.INTERNAL_API_TOKEN="$(openssl rand -hex 32)"
 ```
 
 For production, create `clouisle-secret` and use production values:
@@ -153,7 +155,7 @@ Run the interactive installer from any directory:
 curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
 ```
 
-Choose Docker Compose for a single server or Kubernetes with Helm. Docker mode prompts for an installation directory, defaulting to `/opt/clouisle`, then generates strong secrets, downloads the current Compose file, pulls images, and starts all services. Helm mode guides you through namespace, Ingress, shared storage, and optional image-pull-secret settings.
+Choose Docker Compose for a single server, Kubernetes with Helm, or Kubernetes single-file manifest generation. Docker mode prompts for an installation directory, defaulting to `/opt/clouisle`, then generates strong secrets, downloads the current Compose file, pulls images, and starts all services. Helm mode guides you through namespace, Ingress, shared storage, and optional image-pull-secret settings. The manifest mode writes a `0600` file at `./clouisle-k8s.yaml` by default (override with `CLOUISLE_K8S_MANIFEST`), does not apply it automatically, and prints the explicit `kubectl apply -f ./clouisle-k8s.yaml` command after generation; review the file before applying it.
 
 For non-interactive Docker installation:
 
@@ -172,6 +174,8 @@ Docker installations keep their generated configuration in `<installation-direct
 | `POSTGRES_PASSWORD` | Database access | `openssl rand -base64 16` |
 | `REDIS_PASSWORD` | Cache/queue access | `openssl rand -base64 16` |
 | `QDRANT_API_KEY` | Vector DB access | `openssl rand -base64 16` |
+| `SANDBOX_ARTIFACT_UPLOAD_API_KEY` | Optional API-key authentication for sandbox artifact uploads | `openssl rand -base64 32` |
+| `INTERNAL_API_TOKEN` | Authenticated worker-to-API upload gateway | `openssl rand -base64 32` |
 
 The following should be changed for production domains:
 

--- a/docs/guide/deployment/DEPLOYMENT_zh-CN.md
+++ b/docs/guide/deployment/DEPLOYMENT_zh-CN.md
@@ -147,28 +147,24 @@ helm upgrade --install clouisle deploy/helm/clouisle \
 
 ### 快速开始
 
+在任意目录运行交互式安装脚本：
+
 ```bash
-cd deploy
+curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
+```
 
-# 1. Create and edit environment file
-cp .env.example .env
+根据提示选择单机 Docker Compose 或 Kubernetes Helm。Docker 模式会交互式询问安装目录，默认为 `/opt/clouisle`，随后自动生成强随机密钥、下载当前 Compose 文件、拉取镜像并启动服务。Helm 模式会引导配置命名空间、Ingress、共享存储和可选的镜像拉取 Secret。
 
-# 2. Generate secure passwords (run each command, paste results into .env)
-openssl rand -base64 32    # → SECRET_KEY
-openssl rand -base64 16    # → POSTGRES_PASSWORD
-openssl rand -base64 16    # → REDIS_PASSWORD
-openssl rand -base64 16    # → QDRANT_API_KEY
+如需非交互式安装 Docker Compose：
 
-# 3. Build images and start all services
-docker compose up -d --build
-
-# 4. Verify all services are healthy
-docker compose ps
+```bash
+curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | \
+  CLOUISLE_DEPLOYMENT=docker CLOUISLE_YES=1 bash
 ```
 
 ### 配置说明
 
-启动前请编辑 `deploy/.env`。以下变量**必须**修改：
+Docker 安装会把生成的配置保存在 `<安装目录>/.env`（默认为 `/opt/clouisle/.env`）。对外开放前请检查该文件。以下变量为空时会自动生成：
 
 | 变量 | 原因 | 示例 |
 |------|------|------|
@@ -365,7 +361,7 @@ docker compose down -v
 
 # Update images and restart
 docker compose pull
-docker compose up -d --build
+docker compose up -d
 ```
 
 ---

--- a/docs/guide/deployment/DEPLOYMENT_zh-CN.md
+++ b/docs/guide/deployment/DEPLOYMENT_zh-CN.md
@@ -126,13 +126,26 @@ docker push registry.example.com/clouisle/clouisle-frontend:latest
 Kubernetes 推荐使用 Helm 部署：
 
 ```bash
-helm lint deploy/helm/clouisle
+helm lint deploy/helm/clouisle \
+  --set-string secrets.values.INTERNAL_API_TOKEN=lint-only-token
 helm upgrade --install clouisle deploy/helm/clouisle \
   --namespace clouisle \
-  --create-namespace
+  --create-namespace \
+  --set-string secrets.values.INTERNAL_API_TOKEN="$(openssl rand -hex 32)"
 ```
 
 生产环境建议先创建 `clouisle-secret`，再使用生产 values：
+```bash
+kubectl create namespace clouisle
+kubectl -n clouisle create secret generic clouisle-secret \
+  --from-literal=SECRET_KEY='replace-with-strong-random-key' \
+  --from-literal=POSTGRES_PASSWORD='replace-with-postgres-password' \
+  --from-literal=REDIS_PASSWORD='replace-with-redis-password' \
+  --from-literal=QDRANT_API_KEY='replace-with-qdrant-api-key' \
+  --from-literal=SANDBOX_ARTIFACT_UPLOAD_API_KEY='replace-with-sandbox-artifact-key' \
+  --from-literal=INTERNAL_API_TOKEN="$(openssl rand -base64 32)"
+```
+
 
 ```bash
 helm upgrade --install clouisle deploy/helm/clouisle \
@@ -153,7 +166,7 @@ helm upgrade --install clouisle deploy/helm/clouisle \
 curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
 ```
 
-根据提示选择单机 Docker Compose 或 Kubernetes Helm。Docker 模式会交互式询问安装目录，默认为 `/opt/clouisle`，随后自动生成强随机密钥、下载当前 Compose 文件、拉取镜像并启动服务。Helm 模式会引导配置命名空间、Ingress、共享存储和可选的镜像拉取 Secret。
+根据提示选择单机 Docker Compose、Kubernetes Helm，或 Kubernetes 单文件 manifest（仅生成）。Docker 模式会交互式询问安装目录，默认为 `/opt/clouisle`，随后自动生成强随机密钥、下载当前 Compose 文件、拉取镜像并启动服务。Helm 模式会引导配置命名空间、Ingress、共享存储和可选的镜像拉取 Secret。单文件 manifest 模式默认在当前目录生成权限为 `0600` 的 `./clouisle-k8s.yaml`（可通过 `CLOUISLE_K8S_MANIFEST` 指定路径），不会自动应用；请先审阅文件，再运行 `kubectl apply -f ./clouisle-k8s.yaml`。
 
 如需非交互式安装 Docker Compose：
 
@@ -172,6 +185,8 @@ Docker 安装会把生成的配置保存在 `<安装目录>/.env`（默认为 `/
 | `POSTGRES_PASSWORD` | 数据库访问密码 | `openssl rand -base64 16` |
 | `REDIS_PASSWORD` | 缓存/队列访问密码 | `openssl rand -base64 16` |
 | `QDRANT_API_KEY` | 向量数据库访问密钥 | `openssl rand -base64 16` |
+| `SANDBOX_ARTIFACT_UPLOAD_API_KEY` | 沙箱产物上传的可选 API Key 认证 | `openssl rand -base64 32` |
+| `INTERNAL_API_TOKEN` | worker 到 API 上传网关的认证令牌 | `openssl rand -base64 32` |
 
 以下变量在生产域名下建议修改：
 

--- a/docs/guide/deployment/docker-compose.md
+++ b/docs/guide/deployment/docker-compose.md
@@ -54,11 +54,19 @@ docker compose version
 
 ## Quick Start
 
-### Clone Repository
+### Guided Installation
 
 ```bash
-git clone https://github.com/your-org/clouisle.git
-cd clouisle
+curl -fsSL https://raw.githubusercontent.com/clouisle/Clouisle/main/deploy/install.sh | bash
+```
+
+Choose Docker Compose when prompted. The installer downloads the current deployment files, generates required secrets, validates the configuration, pulls images, and starts the services.
+
+### Manual Installation from Source
+
+```bash
+git clone https://github.com/clouisle/Clouisle.git
+cd Clouisle
 ```
 
 ### Configure Environment

--- a/docs/guide/deployment/kubernetes.md
+++ b/docs/guide/deployment/kubernetes.md
@@ -18,12 +18,16 @@ Kubernetes deployment provides:
 Helm is the recommended Kubernetes deployment method for Clouisle. It keeps the large manifest behind templates and lets each environment maintain a small values file.
 
 ```bash
-helm lint deploy/helm/clouisle
+helm lint deploy/helm/clouisle \
+  --set-string secrets.values.INTERNAL_API_TOKEN=lint-only-token
 helm upgrade --install clouisle deploy/helm/clouisle \
   --namespace clouisle \
-  --create-namespace
+  --create-namespace \
+  --set-string secrets.values.INTERNAL_API_TOKEN="$(openssl rand -hex 32)"
 ```
 
+
+The existing Secret must include a unique non-empty `INTERNAL_API_TOKEN` shared by the API, worker, and sandbox-worker.
 For production, create `clouisle-secret` and use `deploy/helm/clouisle/values-production.yaml`:
 
 ```bash

--- a/docs/guide/deployment/kubernetes.md
+++ b/docs/guide/deployment/kubernetes.md
@@ -54,7 +54,7 @@ The single-file manifest `deploy/k8s/clouisle.yaml` is still available as a fall
 - Storage: 100GB+ persistent volumes
 
 **External Services:**
-- PostgreSQL 14+ (or use in-cluster)
+- PostgreSQL 17+ with pg_search 0.24.3 installed and `pg_search,pg_stat_statements` preloaded (or use in-cluster)
 - Redis 6+ (or use in-cluster)
 - Qdrant 1.7+ (or use in-cluster)
 

--- a/docs/plan/helm-chart-deployment.md
+++ b/docs/plan/helm-chart-deployment.md
@@ -29,7 +29,7 @@ Success criteria:
 ### Stage 2: Chart scaffold and values schema
 - **Files modified**: `deploy/helm/clouisle/Chart.yaml`, `deploy/helm/clouisle/values.yaml`, `deploy/helm/clouisle/values-production.yaml`, `deploy/helm/clouisle/templates/_helpers.tpl`, `deploy/helm/clouisle/templates/NOTES.txt`
 - **Specific logic**: Define chart metadata, images, config, secrets, service settings, persistence, ingress, and infrastructure toggles.
-- **Validation**: `helm lint deploy/helm/clouisle` after templates are added.
+- **Validation**: `helm lint deploy/helm/clouisle --set-string secrets.values.INTERNAL_API_TOKEN=lint-only-token` after templates are added.
 
 ### Stage 3: Application service templates
 - **Files modified**: `deploy/helm/clouisle/templates/configmap.yaml`, `secret.yaml`, `serviceaccount.yaml`, `uploads-pvc.yaml`, `api-*`, `worker-deployment.yaml`, `sandbox-worker-deployment.yaml`, `beat-deployment.yaml`, `frontend-*`, `ingress.yaml`
@@ -48,12 +48,12 @@ Success criteria:
 
 ## Testing Strategy
 
-- `helm lint deploy/helm/clouisle`
-- `helm template clouisle deploy/helm/clouisle --namespace clouisle --create-namespace`
+- `helm lint deploy/helm/clouisle --set-string secrets.values.INTERNAL_API_TOKEN=lint-only-token`
+- `helm template clouisle deploy/helm/clouisle --namespace clouisle --create-namespace --set-string secrets.values.INTERNAL_API_TOKEN=lint-only-token`
 - `helm template clouisle deploy/helm/clouisle --namespace clouisle --create-namespace -f deploy/helm/clouisle/values-production.yaml`
 - `helm template clouisle deploy/helm/clouisle --namespace clouisle --set secrets.create=false --set secrets.existingSecret=clouisle-secret`
-- `helm template clouisle deploy/helm/clouisle --namespace clouisle --set postgresql.enabled=false --set postgresql.external.host=postgres.example.internal --set redis.enabled=false --set redis.external.host=redis.example.internal --set qdrant.enabled=false --set qdrant.external.url=https://qdrant.example.internal`
-- `helm template clouisle deploy/helm/clouisle --namespace clouisle --create-namespace | kubectl apply --dry-run=client -f -`
+- `helm template clouisle deploy/helm/clouisle --namespace clouisle --set secrets.create=false --set secrets.existingSecret=clouisle-secret --set postgresql.enabled=false --set postgresql.external.host=postgres.example.internal --set redis.enabled=false --set redis.external.host=redis.example.internal --set qdrant.enabled=false --set qdrant.external.url=https://qdrant.example.internal`
+- `helm template clouisle deploy/helm/clouisle --namespace clouisle --create-namespace --set secrets.create=false --set secrets.existingSecret=clouisle-secret | kubectl apply --dry-run=client -f -`
 
 ## Current Validation Status
 

--- a/docs/plan/kubernetes-manifest-installer-readiness.md
+++ b/docs/plan/kubernetes-manifest-installer-readiness.md
@@ -1,0 +1,125 @@
+# Kubernetes Manifest Installer and Startup Readiness Design Document
+
+## Background & Goals
+
+### Problem
+
+`deploy/install.sh` currently supports only Docker Compose and Helm. The plain
+`deploy/k8s/clouisle.yaml` must be edited manually to replace embedded Secret
+placeholders. It is easy to apply an insecure manifest accidentally.
+
+Kubernetes schedules the PostgreSQL StatefulSet and backend workloads
+independently. The raw manifest has no dependency gate, so the API, Celery
+worker, sandbox worker, and beat can start before PostgreSQL accepts
+connections. Those processes may exit and enter a restart loop instead of
+remaining pending until their database dependency is ready.
+
+### Success Criteria
+
+- The guided installer offers a third `k8s` target that creates a separate,
+  secure single-file manifest without mutating the repository template.
+- The generated manifest contains independent strong values for `SECRET_KEY`,
+  `POSTGRES_PASSWORD`, `REDIS_PASSWORD`, `QDRANT_API_KEY`,
+  `SANDBOX_ARTIFACT_UPLOAD_API_KEY`, and `INTERNAL_API_TOKEN`.
+- The generated manifest is mode `0600`, never overwrites an existing output,
+  and is not applied automatically.
+- Every raw-manifest backend workload waits for PostgreSQL readiness before its
+  application container starts.
+- Documentation explains the new route, the generated file's sensitivity, and
+  remaining cluster-specific settings.
+
+## High-Level Design
+
+The installer adds a third deployment choice:
+
+```text
+Docker Compose  -> install and start services
+Helm            -> create/reuse cluster Secret and install chart
+Kubernetes YAML -> generate a secret-filled manifest; operator reviews/applies it
+```
+
+`install_k8s_manifest` copies the repository/downloaded template into a caller
+selected output path (`CLOUISLE_K8S_MANIFEST`, default
+`./clouisle-k8s.yaml`). It creates six random values with the existing
+`random_secret` helper, base64-encodes each value, and replaces only the known
+`Secret.data` key lines. It creates the output directory when necessary,
+refuses to overwrite an existing file, sets mode `0600`, and prints the exact
+`kubectl apply -f` command. It does not require cluster access and never edits
+`deploy/k8s/clouisle.yaml` or Helm values.
+
+The raw manifest receives the same `wait-for-postgres` init container in the
+API, worker, sandbox-worker, and beat pod specs. It uses the published
+PostgreSQL image, reads the host/user/database fields from the ConfigMap, and
+loops on `pg_isready`. Kubernetes therefore holds each workload in
+`Init:0/1` until the database is accepting connections, instead of restarting
+application containers.
+
+## Implementation Plan
+
+### Stage 1: Add the secure manifest-generation installer route
+
+- **Files modified**: `deploy/install.sh`, `deploy/k8s/clouisle.yaml`,
+  `backend/tests/test_deploy_install_script.py`
+- **Specific logic**:
+  - Extend the deployment selector and non-interactive validation with `k8s`.
+  - Add source-template acquisition for local source and curl-piped installs.
+  - Add a base64 helper and exact-key replacement helper; never perform a
+    blanket placeholder replacement.
+  - Generate the six Secret values into a new output only, apply `chmod 600`,
+    and print the explicit apply command.
+  - Add the optional sandbox artifact upload API key to the raw Secret so the
+    generated document has the same secret contract as Docker/Helm.
+- **Validation**: execute the installer against a temporary output via
+  `CLOUISLE_SOURCE_DIR`; parse the result and decode every generated value.
+  Confirm the source template remains unchanged and reusing an output fails.
+
+### Stage 2: Gate raw backend workloads on PostgreSQL readiness
+
+- **Files modified**: `deploy/k8s/clouisle.yaml`,
+  `backend/tests/test_deploy_install_script.py`
+- **Specific logic**:
+  - Add `wait-for-postgres` init containers to `api`, `worker`,
+    `sandbox-worker`, and `beat`.
+  - Read PostgreSQL endpoint/user/database from `clouisle-config` and loop on
+    `pg_isready` with a short retry interval.
+  - Keep existing application readiness/liveness probes unchanged: the init
+    container solves dependency ordering; probes retain runtime health checks.
+- **Validation**: parse the manifest and assert each backend pod has the
+  expected init container and no unrelated pod is changed.
+
+### Stage 3: Document and verify deployment behavior
+
+- **Files modified**: `README.md`, `deploy/README.md`,
+  `docs/IMPLEMENTATION_PLAN.md`, this document
+- **Specific logic**:
+  - Document the third installer choice, output path environment variable,
+    generated-secret security boundary, and explicit apply step.
+  - Distinguish `kubectl` requirements for the raw-manifest path from Helm
+    requirements for the chart path.
+- **Validation**: `bash -n deploy/install.sh`, `uv run ruff check tests/test_deploy_install_script.py`, and `uv run pytest tests/test_deploy_install_script.py -q` passed. `kubectl apply --dry-run=client --validate=false -f deploy/k8s/clouisle.yaml` accepted all 20 documents. Full backend regression passed: 6692 passed, 3 skipped; line coverage 97.44% and branch coverage 95.01% (both above the 95% gate). Helm validation was not run because `helm` is not installed in the environment.
+
+## Testing Strategy
+
+- **Happy path**: non-interactive `CLOUISLE_DEPLOYMENT=k8s` creates a new
+  parseable manifest whose required Secret entries decode to six distinct
+  non-placeholder values.
+- **Failure path**: existing output is rejected before any secret rotation or
+  overwrite occurs.
+- **Startup ordering**: static manifest assertions require PostgreSQL wait
+  init containers for all database-dependent backend workloads.
+- **Regression scope**: existing Docker and Helm installer routes retain their
+  selection values and secret generation behavior; raw deployment YAML remains
+  valid Kubernetes YAML.
+
+## Risks & Mitigation
+
+- **Generated file leaks**: it contains base64-encoded secrets, not encryption.
+  Default/new output only and `0600` permissions reduce accidental exposure;
+  docs require operators to store it securely.
+- **Bad database configuration**: the init container intentionally waits rather
+  than restarting application containers. Its pod logs reveal the failed
+  `pg_isready` check; operators must correct ConfigMap/Secret values.
+- **Template drift**: replacements are keyed to the known Secret names and
+  fail if a key is absent, preventing silent insecure output.
+- **No implicit cluster mutation**: generation never calls `kubectl apply`, so
+  review and application stay under the operator's control.

--- a/docs/plan/remove-worker-uploads-mount.md
+++ b/docs/plan/remove-worker-uploads-mount.md
@@ -1,0 +1,178 @@
+# Remove Worker Uploads Mount Dependency
+
+## Background & Goals
+
+### Problem
+`worker` (Celery: `default,knowledge,workflow`) and `sandbox-worker` must run without an `uploads` PVC / volume at `/app/uploads` in every deployment manifest (`deploy/k8s/clouisle.yaml`,
+`deploy/helm/clouisle/templates/*`, `deploy/docker-compose.yml`). In a distributed deployment without
+distributed/object storage the worker pod may land on a node that cannot attach the uploads volume,
+or no RWX-capable StorageClass exists. The goal is to remove the uploads mount from both worker roles
+while keeping the **api** process as the sole owner of the local uploads directory.
+
+### Success criteria
+- `worker` and `sandbox-worker` run without any `uploads` volume in all storage modes (`local` and `object`/`s3`).
+- `api` remains the only process that mounts the local uploads directory.
+- No regression in knowledge-base ingestion, workflow file handling, upload/download, sandbox attachments, or sandbox artifacts.
+- Worker file reads and writes use the authenticated internal gateway; api remains the sole owner of the selected `UploadStorageBackend`.
+
+## Current State (verified 2026-08-10)
+
+File I/O already routed through `UploadStorageBackend` (`backend/app/services/upload_storage.py`,
+`get_upload_storage_backend(root)`, backend selected by SiteSetting `upload_storage_backend`
+= `local` | `object` | `s3`; `LocalUploadStorage` and `ObjectUploadStorage` implementations):
+
+- `upload.py::save_generated_upload` (user uploads, sandbox artifacts) — `storage.save`
+- `document_processor` `save_file` / `read_file` / `delete_file` / `extract_text` — `storage.*`
+- `skill_import.py` package save/delete — `storage.*`
+- `chat_tools.py::read_asset`, `llm/tools/builtin/media.py`, `sandbox/manager.py` input files — `storage.*`
+
+The worker-only local-path dependencies were removed. `sandbox-worker` stages authorized attachments through the internal upload gateway when `UPLOAD_STORAGE_MODE=remote`; this preserves the mount-free deployment contract.
+
+## High-Level Design
+
+Two layered changes, both keeping `api` as the storage owner:
+
+1. **Stage 1 — media assets move onto `UploadStorageBackend`.** Adds a `list(prefix)` capability to
+   the backend interface, then converts the three media-asset code paths (write, delete, serve).
+   Result: in `object`/`s3` mode the worker already has zero local storage dependency.
+
+2. **Stage 2 — worker talks to api through explicit internal HTTP endpoints.** New private
+   endpoints under `/internal/uploads/*` on `api`, authenticated with `INTERNAL_API_TOKEN`.
+   `document_processor` branches on `UPLOAD_STORAGE_MODE`: the api process (mode `local`) uses
+   `LocalUploadStorage` directly; the worker (mode `remote`) issues explicit HTTP calls to api for
+   every file operation (read document bytes, save media asset, delete media assets, delete file).
+   No new storage abstraction class — the worker's calls are explicit and visible.
+
+```
+┌──────────────┐  uploads  ┌──────────────┐
+│  api (server)│ ◄────────►│ local dir    │  (only process that mounts the volume)
+│  + internal  │           │ /app/uploads │
+│  file router │           └──────────────┘
+└──────┬───────┘
+       │ GET/PUT/DELETE /internal/uploads/*  (INTERNAL_API_TOKEN)
+┌──────▼───────┐
+│ worker       │  document and media operations → api (no volume)
+│ sandbox-     │  authorized attachment reads → api (no volume)
+│ worker       │  artifacts upload → api
+└──────────────┘
+```
+
+Process role selection is explicit via env (`UPLOAD_STORAGE_MODE`), not inferred from argv.
+
+## Implementation Plan
+
+### Stage 1: Media assets on UploadStorageBackend
+
+- **Files modified**: `backend/app/services/upload_storage.py`,
+  `backend/app/services/document_processor.py`,
+  `backend/app/api/v1/endpoints/knowledge_bases.py`, `backend/tests/...`
+- **Specific logic**:
+  - Add `async def list(self, prefix: str) -> list[str]` to `UploadStorageBackend`.
+    - `LocalUploadStorage.list`: scan `self.root.joinpath(*prefix.split("/"))`, return relative keys.
+    - `ObjectUploadStorage.list`: `list_objects_v2` with `Prefix=prefix` (paginated).
+  - `document_processor._save_media_asset`: build the stable key
+    `documents/{kb_id}/media/{doc_id}/{filename}`, persist it through `storage.save` when absent,
+    and return that relative key as `path`; the API media URL remains the storage-independent public reference.
+  - `document_processor.delete_media_assets`: `keys = await storage.list(f"documents/{kb_id}/media/{doc_id}/")`,
+    then `storage.delete` each; drop `shutil.rmtree`.
+  - `knowledge_bases.py::get_document_media`: `storage = get_upload_storage_backend(...)`,
+    `storage_key = f"documents/{kb_id}/media/{doc_id}/{filename}"`, return `await storage.response(key, ...)`.
+    Preserve a local fallback for media assets created before the object-storage cutover.
+- **Validation**: unit tests for `list()` on both backends, media write/delete/serve through
+  backend; full `uv run pytest` + `check_coverage.py` (95% line + branch).
+
+### Stage 2: Worker file access through explicit api endpoints
+
+- **Files modified**: `backend/app/core/config.py`, `backend/app/services/document_processor.py`,
+  new `backend/app/api/v1/endpoints/internal_uploads.py`, `backend/app/main.py`,
+  `backend/app/services/workflow/executors/subworkflow.py`, `backend/tests/...`
+- **Specific logic**:
+  - Config: `INTERNAL_API_TOKEN: str = ""`, `API_INTERNAL_BASE_URL: str = ""`,
+    `UPLOAD_STORAGE_MODE: str = "local"` (`local` | `remote`).
+  - New internal router mounted at `/internal` on the app (NOT under `/api`, NOT exposed by
+    Ingress — Ingress only routes `/api` and `/`; the worker reaches it via the api ClusterIP
+    service directly):
+    - `GET /internal/uploads/read?key=...` → file bytes
+    - `PUT /internal/uploads/save?key=...` → body bytes, returns storage path
+    - `HEAD /internal/uploads/exists?key=...` → 200/404
+    - `DELETE /internal/uploads/delete?key=...` → 204
+    - `PUT /internal/uploads/media/{kb_id}/{doc_id}` → save the request bytes using the content type;
+      the API determines the content-addressed filename and returns `{url, filename, ...}`.
+    - `DELETE /internal/uploads/media/{kb_id}/{doc_id}` → delete all media assets of the document
+    - Every handler requires `Authorization: Bearer {INTERNAL_API_TOKEN}` (constant-time compare);
+      token empty ⇒ router returns 404 (fail closed).
+  - `document_processor`: branch on `settings.UPLOAD_STORAGE_MODE == "remote"`:
+    - `read_file` → `GET /internal/uploads/read?key=...`
+    - `_save_media_asset` → `PUT /internal/uploads/media/{kb}/{doc}?filename=...` with bytes
+    - `delete_media_assets` → `DELETE /internal/uploads/media/{kb}/{doc}`
+    - `delete_file` → `DELETE /internal/uploads/delete?key=...`
+    - local mode (`api`) keeps the current storage-backend path. Callers (knowledge tasks) are
+      unchanged.
+  - Fix `FileToURLNodeExecutor` (subworkflow.py): the workflow file parameter value IS the upload
+    URL (`onChange(result.url)` in the frontend), so URL outputs never read local worker files.
+    Apply `ensureAbsolute` only with configured `PUBLIC_API_URL`, and support both
+    `fileToUrlConfig.inputs[]` (frontend) and legacy `config.inputVariable/inputType` shapes.
+    The legacy `path` → `base64` mode remains supported through the internal gateway, never a local path.
+- **Validation**: unit tests for internal router auth and endpoints, `document_processor` remote
+  branches against mocked HTTP, file_to_url URL-only behavior; full suite + coverage gate.
+
+### Stage 3: Deployment manifests
+
+- **Files modified**: `deploy/k8s/clouisle.yaml`, `deploy/helm/clouisle/templates/{api,worker,sandbox-worker}-deployment.yaml`,
+  `deploy/helm/clouisle/values.yaml`, `deploy/helm/clouisle/values-production.yaml`,
+  `deploy/helm/clouisle/templates/{secret,configmap}.yaml`, `deploy/docker-compose.yml`,
+  `deploy/install.sh`, `main.py`, deployment docs.
+- **Specific logic**:
+  - `worker` and `sandbox-worker`: remove `uploads` volumeMount + volume; set
+    `UPLOAD_STORAGE_MODE=remote`, use `API_INTERNAL_BASE_URL`, and mount the internal token Secret file.
+  - `api`: keeps uploads mount and mounts the same token file so rotations are read without process restart.
+  - K8s Secret adds `INTERNAL_API_TOKEN`; the API uses `RollingUpdate` with `maxUnavailable: 0`.
+  - compose: both workers drop `uploads_data`, gain gateway env, and wait for the API healthcheck.
+- **Validation**: `helm lint` + `helm template` render when Helm is available, YAML parse of
+  `deploy/k8s/clouisle.yaml`, `docker compose config` with placeholder env, `bash -n` on install.sh.
+
+### Stage 4: End-to-end verification
+
+- **Validation**:
+  - `local` mode: api with uploads mount, worker/sandbox-worker without; upload document or sandbox
+    attachment → knowledge ingestion and workspace staging succeed through the gateway; media URL render,
+    artifact upload, and delete remove files.
+  - `object`/`s3` mode (MinIO or moto): same flow with api resolving the selected object backend.
+  - Workflow `file_to_url` node produces a fetchable URL; legacy path-to-base64 reads through the gateway.
+  - Negative: wrong/missing `INTERNAL_API_TOKEN` → 401; `UPLOAD_STORAGE_MODE=remote` with unreachable
+    api → clear error surfaced in task logs and knowledge tasks retry.
+
+## Testing Strategy
+
+- Happy path: media write/delete/serve through `LocalUploadStorage` and `ObjectUploadStorage`;
+  internal gateway round-trip for document and sandbox attachment reads; knowledge ingestion in both storage modes.
+- Error path: missing/wrong internal token, disabled internal router, backend `list` on empty prefix,
+  remote backend when api is unreachable.
+- Regression scope: upload/download endpoints, sandbox artifact upload, skill import package
+  storage, chat `read_asset` / media tools, knowledge-base CRUD, workflow file nodes.
+
+## Risks & Mitigation
+
+- **Media asset compatibility**: the new key layout preserves current local files; pre-cutover media
+  remains readable from the legacy local location during the object-storage transition.
+- **File size over HTTP gateway**: uploads are capped at 10 MiB (`MAX_FILE_SIZE`); gateway response
+  bodies stream from storage and are accumulated only where document parsing/base64 output requires bytes.
+- **Internal endpoint exposure**: token auth, constant-time compare, router returns 404 when token
+  unset; Ingress routes only `/api` and `/`, so `/internal` is cluster-internal. Document that
+  users must not expose `/internal` publicly.
+- **Availability**: token files are re-read on each request and API rolling updates use `maxUnavailable: 0`.
+- **Rollback**: each stage is independently revertible; Stage 1 has no deployment impact, Stage 3
+  changes are limited to manifests + env.
+
+## Validation Evidence (2026-08-10)
+
+- `cd backend && uv run pytest && uv run python scripts/check_coverage.py`: 6,691 passed,
+  3 skipped; 97.44% line coverage and 95.01% branch coverage (both exceed the 95% gate).
+- Focused gateway/media/storage suite: 81 passed; Ruff passed for the changed backend paths.
+- `docker compose --env-file .env.example config --quiet` passed with temporary validation
+  credentials. The rendered Compose JSON asserts that only `api` mounts `/app/uploads`; both workers
+  set `UPLOAD_STORAGE_MODE=remote`. The temporary `deploy/.env` symlink was removed.
+- `deploy/k8s/clouisle.yaml` parses as 20 Kubernetes documents; a static contract assertion confirms
+  the api-only uploads mount and remote modes for `worker` and `sandbox-worker`. `bash -n deploy/install.sh` passed.
+- Helm CLI is not installed in this environment, so `helm lint` and rendered-template validation could
+  not run. Real-cluster local/object-storage validation remains Stage 4 in `docs/IMPLEMENTATION_PLAN.md`.

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ Usage:
     python main.py beat      - Start the Celery beat scheduler
     python main.py flower    - Start the Flower monitoring (if installed)
 """
+
 import os
 import sys
 import argparse
@@ -90,17 +91,28 @@ def start_server(
             f"with {workers} workers"
         )
         cmd = [
-            sys.executable, "-m", "gunicorn",
+            sys.executable,
+            "-m",
+            "gunicorn",
             "app.main:app",
-            "-k", "uvicorn.workers.UvicornWorker",
-            "--bind", f"{host}:{port}",
-            "--workers", str(workers),
-            "--graceful-timeout", "30",
-            "--timeout", "120",
-            "--keep-alive", "5",
-            "--access-logfile", "-",
-            "--error-logfile", "-",
-            "--forwarded-allow-ips", "*",
+            "-k",
+            "uvicorn.workers.UvicornWorker",
+            "--bind",
+            f"{host}:{port}",
+            "--workers",
+            str(workers),
+            "--graceful-timeout",
+            "30",
+            "--timeout",
+            "120",
+            "--keep-alive",
+            "5",
+            "--access-logfile",
+            "-",
+            "--error-logfile",
+            "-",
+            "--forwarded-allow-ips",
+            "*",
         ]
         subprocess.run(cmd)
 
@@ -118,8 +130,11 @@ def start_worker(
         f"🔧 Starting Celery worker (concurrency={concurrency}, queues={queues}, pool={pool or 'prefork'})"
     )
     cmd = [
-        sys.executable, "-m", "celery",
-        "-A", "app.core.celery:celery_app",
+        sys.executable,
+        "-m",
+        "celery",
+        "-A",
+        "app.core.celery:celery_app",
         "worker",
         "--loglevel=info",
         f"--concurrency={concurrency}",
@@ -139,8 +154,11 @@ def start_sandbox_worker(concurrency: int = 1):
         f"🔧 Starting Celery worker (concurrency={concurrency}, queues=sandbox, pool={pool or 'prefork'})"
     )
     cmd = [
-        os.path.join(BACKEND_DIR, ".venv", "bin", "python"), "-m", "celery",
-        "-A", "app.core.celery:celery_app",
+        os.path.join(BACKEND_DIR, ".venv", "bin", "python"),
+        "-m",
+        "celery",
+        "-A",
+        "app.core.celery:celery_app",
         "worker",
         "--loglevel=info",
         f"--concurrency={concurrency}",
@@ -158,9 +176,12 @@ def build_sandbox_worker_image(
 ):
     """Build the sandbox worker image from the repository root."""
     cmd = [
-        "docker", "build",
-        "-f", "deploy/dockerfiles/sandbox-worker.Dockerfile",
-        "-t", image_tag,
+        "docker",
+        "build",
+        "-f",
+        "deploy/dockerfiles/sandbox-worker.Dockerfile",
+        "-t",
+        image_tag,
     ]
     if no_cache:
         cmd.append("--no-cache")
@@ -200,8 +221,16 @@ def _map_local_url_to_host_gateway(url: str | None) -> str | None:
 
 def _sandbox_worker_container_env() -> dict[str, str]:
     root_env = _load_root_env_file()
-    env = {key: value for key in SANDBOX_WORKER_ENV_KEYS if (value := root_env.get(key))}
-    env.update({key: value for key in SANDBOX_WORKER_ENV_KEYS if (value := os.environ.get(key))})
+    env = {
+        key: value for key in SANDBOX_WORKER_ENV_KEYS if (value := root_env.get(key))
+    }
+    env.update(
+        {
+            key: value
+            for key in SANDBOX_WORKER_ENV_KEYS
+            if (value := os.environ.get(key))
+        }
+    )
     if env.get("REDIS_HOST") in {None, "localhost", "127.0.0.1"}:
         env["REDIS_HOST"] = "host.docker.internal"
     if env.get("POSTGRES_SERVER") in {None, "localhost", "127.0.0.1"}:
@@ -221,9 +250,7 @@ def _sandbox_worker_container_env() -> dict[str, str]:
         or api_base_url
         or "http://host.docker.internal:8000"
     )
-    env["API_INTERNAL_BASE_URL"] = _map_local_url_to_host_gateway(
-        api_internal_base_url
-    )
+    env["API_INTERNAL_BASE_URL"] = _map_local_url_to_host_gateway(api_internal_base_url)
 
     artifact_upload_base_url = env.get("SANDBOX_ARTIFACT_UPLOAD_BASE_URL")
     if artifact_upload_base_url:
@@ -246,27 +273,40 @@ def start_sandbox_worker_container(
     """Build and run a temporary local-dev sandbox worker container."""
     build_sandbox_worker_image(no_cache=no_cache, image_tag=image_tag)
     cmd = [
-        "docker", "run", "--rm",
-        "--name", f"clouisle-sandbox-worker-dev-{os.getpid()}",
+        "docker",
+        "run",
+        "--rm",
+        "--add-host",
+        "host.docker.internal:host-gateway",
+        "--name",
+        f"clouisle-sandbox-worker-dev-{os.getpid()}",
     ]
     for key, value in _sandbox_worker_container_env().items():
         cmd.extend(["-e", f"{key}={value}"])
-    cmd.extend([
-        image_tag,
-        "python", "main.py", "sandbox-worker",
-        "-c", str(concurrency),
-    ])
+    cmd.extend(
+        [
+            image_tag,
+            "python",
+            "main.py",
+            "sandbox-worker",
+            "-c",
+            str(concurrency),
+        ]
+    )
     subprocess.run(cmd, cwd=PROJECT_ROOT, check=True)
 
 
 def start_beat():
     """Start the Celery beat scheduler."""
     os.chdir(BACKEND_DIR)
-    
+
     print("⏰ Starting Celery beat scheduler")
     cmd = [
-        sys.executable, "-m", "celery",
-        "-A", "app.core.celery:celery_app",
+        sys.executable,
+        "-m",
+        "celery",
+        "-A",
+        "app.core.celery:celery_app",
         "beat",
         "--loglevel=info",
     ]
@@ -276,11 +316,14 @@ def start_beat():
 def start_flower(port: int = 5555):
     """Start the Flower monitoring dashboard."""
     os.chdir(BACKEND_DIR)
-    
+
     print(f"🌸 Starting Flower at http://localhost:{port}")
     cmd = [
-        sys.executable, "-m", "celery",
-        "-A", "app.core.celery:celery_app",
+        sys.executable,
+        "-m",
+        "celery",
+        "-A",
+        "app.core.celery:celery_app",
         "flower",
         f"--port={port}",
     ]
@@ -305,45 +348,97 @@ Examples:
                                              Build and run sandbox worker dev container
   python main.py beat                      Start Celery beat scheduler
   python main.py flower                    Start Flower monitoring
-        """
+        """,
     )
-    
+
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
-    
+
     # Server command
     server_parser = subparsers.add_parser("server", help="Start the API server")
-    server_parser.add_argument("-H", "--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1)")
-    server_parser.add_argument("-p", "--port", type=int, default=8000, help="Port to bind (default: 8000)")
-    server_parser.add_argument("-w", "--workers", type=int, default=0, help="Number of Gunicorn workers (default: auto, production only)")
-    server_parser.add_argument("--no-reload", action="store_true", help="Disable auto-reload (use Gunicorn for production)")
-    
+    server_parser.add_argument(
+        "-H", "--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1)"
+    )
+    server_parser.add_argument(
+        "-p", "--port", type=int, default=8000, help="Port to bind (default: 8000)"
+    )
+    server_parser.add_argument(
+        "-w",
+        "--workers",
+        type=int,
+        default=0,
+        help="Number of Gunicorn workers (default: auto, production only)",
+    )
+    server_parser.add_argument(
+        "--no-reload",
+        action="store_true",
+        help="Disable auto-reload (use Gunicorn for production)",
+    )
+
     # Worker command
     worker_parser = subparsers.add_parser("worker", help="Start the Celery worker")
-    worker_parser.add_argument("-c", "--concurrency", type=int, default=4, help="Number of worker processes (default: 4)")
-    worker_parser.add_argument("-Q", "--queues", default="default,workflow", help="Queues to consume (default: default,workflow)")
-    
+    worker_parser.add_argument(
+        "-c",
+        "--concurrency",
+        type=int,
+        default=4,
+        help="Number of worker processes (default: 4)",
+    )
+    worker_parser.add_argument(
+        "-Q",
+        "--queues",
+        default="default,workflow",
+        help="Queues to consume (default: default,workflow)",
+    )
+
     # Sandbox worker command
-    sandbox_worker_parser = subparsers.add_parser("sandbox-worker", help="Start the sandbox worker")
-    sandbox_worker_parser.add_argument("-c", "--concurrency", type=int, default=1, help="Number of sandbox worker processes (default: 1)")
-    sandbox_worker_parser.add_argument("--local-dev", action="store_true", help="Build and run the sandbox worker in a temporary local dev container")
-    sandbox_worker_parser.add_argument("--no-cache", action="store_true", help="Build the local dev sandbox image without Docker cache")
-    sandbox_worker_parser.add_argument("--image-tag", default=SANDBOX_WORKER_IMAGE_TAG, help=f"Local dev sandbox image tag (default: {SANDBOX_WORKER_IMAGE_TAG})")
+    sandbox_worker_parser = subparsers.add_parser(
+        "sandbox-worker", help="Start the sandbox worker"
+    )
+    sandbox_worker_parser.add_argument(
+        "-c",
+        "--concurrency",
+        type=int,
+        default=1,
+        help="Number of sandbox worker processes (default: 1)",
+    )
+    sandbox_worker_parser.add_argument(
+        "--local-dev",
+        action="store_true",
+        help="Build and run the sandbox worker in a temporary local dev container",
+    )
+    sandbox_worker_parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Build the local dev sandbox image without Docker cache",
+    )
+    sandbox_worker_parser.add_argument(
+        "--image-tag",
+        default=SANDBOX_WORKER_IMAGE_TAG,
+        help=f"Local dev sandbox image tag (default: {SANDBOX_WORKER_IMAGE_TAG})",
+    )
 
     # Beat command
     subparsers.add_parser("beat", help="Start the Celery beat scheduler")
-    
+
     # Flower command
     flower_parser = subparsers.add_parser("flower", help="Start Flower monitoring")
-    flower_parser.add_argument("-p", "--port", type=int, default=5555, help="Flower port (default: 5555)")
-    
+    flower_parser.add_argument(
+        "-p", "--port", type=int, default=5555, help="Flower port (default: 5555)"
+    )
+
     args = parser.parse_args()
-    
+
     if args.command is None:
         parser.print_help()
         sys.exit(1)
-    
+
     if args.command == "server":
-        start_server(host=args.host, port=args.port, reload=not args.no_reload, workers=args.workers)
+        start_server(
+            host=args.host,
+            port=args.port,
+            reload=not args.no_reload,
+            workers=args.workers,
+        )
     elif args.command == "worker":
         start_worker(concurrency=args.concurrency, queues=args.queues)
     elif args.command == "sandbox-worker":

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ BACKEND_DIR = os.path.join(PROJECT_ROOT, "backend")
 SANDBOX_WORKER_IMAGE_TAG = "clouisle-sandbox-worker:dev"
 SANDBOX_WORKER_ENV_KEYS = (
     "API_BASE_URL",
+    "API_INTERNAL_BASE_URL",
     "DATABASE_URL",
     "POSTGRES_SERVER",
     "POSTGRES_USER",
@@ -40,6 +41,7 @@ SANDBOX_WORKER_ENV_KEYS = (
     "QDRANT_DISTANCE",
     "SECRET_KEY",
     "SANDBOX_RUNTIME_ENABLED",
+    "INTERNAL_API_TOKEN",
     "SANDBOX_LEGACY_FALLBACK_ENABLED",
     "SANDBOX_WORKSPACE_ROOT",
     "SANDBOX_MAX_DISK_MB",
@@ -214,6 +216,15 @@ def _sandbox_worker_container_env() -> dict[str, str]:
     if api_base_url:
         env["API_BASE_URL"] = _map_local_url_to_host_gateway(api_base_url)
 
+    api_internal_base_url = (
+        env.get("API_INTERNAL_BASE_URL")
+        or api_base_url
+        or "http://host.docker.internal:8000"
+    )
+    env["API_INTERNAL_BASE_URL"] = _map_local_url_to_host_gateway(
+        api_internal_base_url
+    )
+
     artifact_upload_base_url = env.get("SANDBOX_ARTIFACT_UPLOAD_BASE_URL")
     if artifact_upload_base_url:
         env["SANDBOX_ARTIFACT_UPLOAD_BASE_URL"] = _map_local_url_to_host_gateway(
@@ -222,6 +233,7 @@ def _sandbox_worker_container_env() -> dict[str, str]:
     elif api_base_url:
         env["SANDBOX_ARTIFACT_UPLOAD_BASE_URL"] = env["API_BASE_URL"]
 
+    env["UPLOAD_STORAGE_MODE"] = "remote"
     return env
 
 


### PR DESCRIPTION
## Summary
- use the published Shanghai ACR images for backend, frontend, and sandbox-worker deployments
- add the guided Docker Compose, Helm, and secret-filled single-file Kubernetes installer paths
- remove worker and sandbox-worker uploads mounts in favor of an authenticated internal upload gateway
- add PostgreSQL startup gates for raw Kubernetes backend workloads and synchronize deployment documentation

## Verification
- `uv run pytest` — 6692 passed, 3 skipped
- backend coverage — 97.44% line, 95.01% branch
- `uv run ruff format --check`
- `uv run ruff check`
- `bash -n deploy/install.sh`
- `kubectl apply --dry-run=client --validate=false -f deploy/k8s/clouisle.yaml`

The generated Kubernetes manifest is review-only; the installer does not apply it automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided installer for Docker Compose, Helm, and generated Kubernetes manifests.
  * Workers can securely access uploads and document media through authenticated remote storage.
  * Added support for public/internal API URL configuration and token-based setup.
  * Kubernetes deployments now include generated secrets, readiness checks, and rolling updates.

* **Bug Fixes**
  * Improved media retrieval with storage-backed responses and legacy local-file fallback.
  * Upload writes are safer, preserving existing files if an operation fails.

* **Documentation**
  * Updated deployment guides and quick starts with prerequisites, configuration, scaling, and storage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->