### PR TITLE
feat(onboarding): align tour steps with current page UI

### DIFF
--- a/frontend/components/onboarding/steps/app-config-steps.ts
+++ b/frontend/components/onboarding/steps/app-config-steps.ts
@@ -80,14 +80,7 @@ const appConfigSteps: OnboardingStep[] = [
   },
   // ========== Capabilities ==========
   {
-    target: '[data-testid="agent-vision-section"]',
-    content: 'onboarding.step14a.description',
-    title: 'onboarding.step14a.title',
-    placement: 'left',
-    overlayClickAction: false,
-  },
-  {
-    target: '[data-testid="agent-file-upload-section"]',
+    target: '[data-testid="agent-attachments-section"]',
     content: 'onboarding.step14b.description',
     title: 'onboarding.step14b.title',
     placement: 'left',

--- a/frontend/components/onboarding/steps/kb-steps.ts
+++ b/frontend/components/onboarding/steps/kb-steps.ts
@@ -91,13 +91,6 @@ const kbSteps: OnboardingStep[] = [
     overlayClickAction: false,
   },
   {
-    target: '[data-testid="kb-dialog-rerank-fail-open"]',
-    content: 'onboarding.step7l.description',
-    title: 'onboarding.step7l.title',
-    placement: 'top',
-    overlayClickAction: false,
-  },
-  {
     target: '[data-testid="kb-dialog-submit"]',
     content: 'onboarding.step7e.description',
     title: 'onboarding.step7e.title',

--- a/frontend/components/onboarding/steps/platform-steps.test.ts
+++ b/frontend/components/onboarding/steps/platform-steps.test.ts
@@ -30,6 +30,16 @@ describe('onboarding tour configurations', () => {
     }
   })
 
+  test('uses selectors from the current pages', () => {
+    const appConfigTargets = getTourConfigById('appConfig')?.steps.map(step => step.target) ?? []
+    const knowledgeBaseTargets = getTourConfigById('kb')?.steps.map(step => step.target) ?? []
+
+    expect(appConfigTargets).toContain('[data-testid="agent-attachments-section"]')
+    expect(appConfigTargets).not.toContain('[data-testid="agent-vision-section"]')
+    expect(appConfigTargets).not.toContain('[data-testid="agent-file-upload-section"]')
+    expect(knowledgeBaseTargets).not.toContain('[data-testid="kb-dialog-rerank-fail-open"]')
+  })
+
   test('looks up known tours and returns undefined for unknown IDs', () => {
     expect(getTourConfigById('kb')).toBe(allTourConfigs[2])
     expect(getTourConfigById('unknown')).toBeUndefined()

--- a/frontend/i18n/en/onboarding.json
+++ b/frontend/i18n/en/onboarding.json
@@ -186,10 +186,6 @@
       "title": "Rerank Parameters",
       "description": "Candidate K is the number of top results passed to the rerank model. Score threshold filters out results below a certain score. Adjust both based on your needs."
     },
-    "step7l": {
-      "title": "Rerank Fail Open",
-      "description": "When enabled, if the rerank model fails, the original retrieval results are returned instead of raising an error. Recommended to keep enabled for production stability."
-    },
     "step8": {
       "title": "Apps Section",
       "description": "Click here to manage your Agents and Workflows. This is where you build AI applications."
@@ -238,13 +234,9 @@
       "title": "Save Configuration",
       "description": "Click here to save your Agent configuration. Remember to save after making changes!"
     },
-    "step14a": {
-      "title": "Image Understanding",
-      "description": "When enabled, your Agent can understand and analyze image content. Useful for scenarios that require processing images or extracting information from pictures."
-    },
     "step14b": {
-      "title": "File Upload",
-      "description": "When enabled, users can upload files to your Agent. Supports PDF, Word, Excel, and other formats. The Agent can read file content to answer questions."
+      "title": "Attachments",
+      "description": "Enable attachments when users need to share files or images with your Agent. You can then set the maximum amount of extracted content the Agent receives."
     },
     "step14c": {
       "title": "User Input Request",

--- a/frontend/i18n/types/onboarding.ts
+++ b/frontend/i18n/types/onboarding.ts
@@ -188,10 +188,6 @@ export type OnboardingMessages = {
       title: string
       description: string
     }
-    step7l: {
-      title: string
-      description: string
-    }
     step8: {
       title: string
       description: string
@@ -237,10 +233,6 @@ export type OnboardingMessages = {
       description: string
     }
     step14: {
-      title: string
-      description: string
-    }
-    step14a: {
       title: string
       description: string
     }

--- a/frontend/i18n/zh/onboarding.json
+++ b/frontend/i18n/zh/onboarding.json
@@ -186,10 +186,6 @@
       "title": "重排参数",
       "description": "候选数（Candidate K）是传递给重排模型的 Top N 结果数量；分数阈值会过滤掉低于指定分数的结果。可根据业务需要调整。"
     },
-    "step7l": {
-      "title": "重排失败开放",
-      "description": "开启后，若重排模型调用失败，将返回原始检索结果而不会报错。建议在生产环境保持开启，以保证稳定性。"
-    },
     "step8": {
       "title": "应用模块",
       "description": "点击这里管理您的 Agent 和工作流。这是您构建 AI 应用的地方。"
@@ -238,13 +234,9 @@
       "title": "保存配置",
       "description": "点击这里保存您的 Agent 配置。修改后记得保存！"
     },
-    "step14a": {
-      "title": "图像理解",
-      "description": "开启后，Agent 可以理解和分析图片内容。适用于需要处理图像或从图片提取信息的场景。"
-    },
     "step14b": {
-      "title": "文件上传",
-      "description": "开启后，用户可以向 Agent 上传文件。支持 PDF、Word、Excel 等格式，Agent 可以读取文件内容来回答问题。"
+      "title": "附件",
+      "description": "当用户需要向 Agent 分享文件或图片时，请开启附件功能。随后可设置 Agent 接收的已提取内容上限。"
     },
     "step14c": {
       "title": "用户输入请求",


### PR DESCRIPTION
## Summary

Refreshes the product tour steps to match the current page UI after the agent config page changed its capabilities section.

## Changes

- **Agent config tour** (`app-config-steps.ts`): remove the obsolete Image Understanding step (`agent-vision-section` no longer exists); repoint the File Upload step at the current Attachments section (`agent-attachments-section`)
- **KB tour** (`kb-steps.ts`): drop the stale `kb-dialog-rerank-fail-open` step (control removed from the KB dialog)
- **i18n**: update `step14b` copy to describe attachments (en/zh); remove orphaned `step7l`/`step14a` keys from both catalogs and the onboarding message types
- **Tests** (`platform-steps.test.ts`): add regression assertions that tours target current-page selectors

## Verification

- `bun test --isolate` onboarding-tour + platform-steps: 15 pass / 0 fail
- `bun test --isolate` platform-steps: 4 pass / 0 fail (100% coverage)
- Targeted ESLint and `bun run i18n:lint` pass
- All 82 tour targets audited against current page sources: 0 unresolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated onboarding guidance to introduce the current attachments capability, including file and image sharing and extracted-content limits.
* **Improvements**
  * Removed outdated onboarding steps for image understanding, file uploads, and reranker fallback behavior.
  * Updated English and Chinese onboarding content to match the latest setup experience.
* **Tests**
  * Added coverage confirming onboarding tours use current selectors and exclude obsolete steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->