### PR TITLE
fix(worker): consume knowledge queue by default

### DIFF
--- a/backend/tests/test_main_sandbox_worker.py
+++ b/backend/tests/test_main_sandbox_worker.py
@@ -9,7 +9,28 @@ from main import (
     main,
     start_sandbox_worker,
     start_sandbox_worker_container,
+    start_worker,
 )
+
+
+def test_start_worker_consumes_all_task_queues_by_default():
+    with patch("main.os.chdir") as mock_chdir, patch("main.subprocess.run") as mock_run:
+        start_worker()
+
+    mock_chdir.assert_called_once_with(str(PROJECT_ROOT) + "/backend")
+    mock_run.assert_called_once_with(
+        [
+            sys.executable,
+            "-m",
+            "celery",
+            "-A",
+            "app.core.celery:celery_app",
+            "worker",
+            "--loglevel=info",
+            "--concurrency=4",
+            "--queues=default,knowledge,workflow",
+        ]
+    )
 
 
 def test_start_sandbox_worker_uses_solo_pool_by_default():

--- a/main.py
+++ b/main.py
@@ -119,7 +119,7 @@ def start_server(
 
 def start_worker(
     concurrency: int = 4,
-    queues: str = "default,workflow",
+    queues: str = "default,knowledge,workflow",
     *,
     pool: str | None = None,
 ):
@@ -386,8 +386,8 @@ Examples:
     worker_parser.add_argument(
         "-Q",
         "--queues",
-        default="default,workflow",
-        help="Queues to consume (default: default,workflow)",
+        default="default,knowledge,workflow",
+        help="Queues to consume (default: default,knowledge,workflow)",
     )
 
     # Sandbox worker command


### PR DESCRIPTION
## 问题

知识库上传文档后，worker 收不到处理任务，任务滞留在 Redis 队列。

**根因**：`backend/app/core/celery.py` 的 `task_routes` 把 `app.tasks.knowledge_base.*`（文档处理、分块嵌入、词法索引）固定路由到 `knowledge` 队列，但 `main.py` 中 `start_worker()` 与 CLI `-Q` 的默认值都是 `default,workflow`。任何用裸 `python main.py worker` 启动的 worker 从不监听 `knowledge`，文档任务永远无法执行。Compose/Helm 部署显式传了 `-Q default,knowledge,workflow`，掩盖了该缺口。

## 修复

- `main.py`：`start_worker()` 默认队列与 CLI `-Q` 默认值、help 文本统一为 `default,knowledge,workflow`
- 新增回归测试 `test_start_worker_consumes_all_task_queues_by_default`，防止再次缺队列

## 验证

- `tests/test_main_sandbox_worker.py`：10 passed（含新增）
- 知识库任务套件（7 个文件）：71 passed
- 上传/派发 API 套件（4 个文件）：36 passed

## 注意

已运行的 worker 必须重启才生效（Celery 启动时读取 `--queues`）。