### PR TITLE
feat(onboarding): add YUN-136 admin model setup tour

### DIFF
--- a/frontend/app/(dashboard)/layout.test.tsx
+++ b/frontend/app/(dashboard)/layout.test.tsx
@@ -13,6 +13,15 @@ mock.module('@/hooks/use-settings', () => ({ useSettings: () => settings }))
 mock.module('@/components/auth-guard', () => ({
   AuthGuard: ({ children }: React.PropsWithChildren) => <>{children}</>,
 }))
+mock.module('@/contexts/team-context', () => ({
+  TeamProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}))
+mock.module('@/components/onboarding/onboarding-provider', () => ({
+  OnboardingProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}))
+mock.module('@/components/onboarding/onboarding-tour', () => ({
+  OnboardingTour: ({ tourId }: { tourId: string }) => <span data-tour={tourId} />,
+}))
 mock.module('@/components/ui/sidebar', () => ({
   SidebarProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
   SidebarInset: ({ children }: React.PropsWithChildren) => <main>{children}</main>,
@@ -51,4 +60,14 @@ test('uses hydration-safe sidebar defaults before settings mount', () => {
     collapsible: 'offExamples',
     side: 'left',
   })
+})
+
+test('mounts the dashboard-only admin model setup tour', () => {
+  let renderer: ReturnType<typeof create>
+  act(() => {
+    renderer = create(<DashboardLayout>content</DashboardLayout>)
+  })
+
+  expect(renderer!.root.findByProps({ 'data-tour': 'adminModelSetup' })).toBeTruthy()
+  act(() => renderer!.unmount())
 })

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -5,6 +5,9 @@ import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/layout/app-sidebar'
 import { useSettings } from '@/hooks/use-settings'
 import { AuthGuard } from '@/components/auth-guard'
+import { TeamProvider } from '@/contexts/team-context'
+import { OnboardingProvider } from '@/components/onboarding/onboarding-provider'
+import { OnboardingTour } from '@/components/onboarding/onboarding-tour'
 
 export default function DashboardLayout({
   children,
@@ -38,16 +41,21 @@ export default function DashboardLayout({
 
   return (
     <AuthGuard>
-      <SidebarProvider open={open} onOpenChange={setOpen}>
-        <AppSidebar
-          variant={effectiveSidebarVariant}
-          collapsible={collapsible}
-          side={sidebarSide}
-        />
-        <SidebarInset>
-          {children}
-        </SidebarInset>
-      </SidebarProvider>
+      <TeamProvider>
+        <OnboardingProvider>
+          <SidebarProvider open={open} onOpenChange={setOpen}>
+            <AppSidebar
+              variant={effectiveSidebarVariant}
+              collapsible={collapsible}
+              side={sidebarSide}
+            />
+            <SidebarInset>
+              {children}
+            </SidebarInset>
+          </SidebarProvider>
+          <OnboardingTour tourId="adminModelSetup" />
+        </OnboardingProvider>
+      </TeamProvider>
     </AuthGuard>
   )
 }

--- a/frontend/app/(dashboard)/models/_components/model-dialog.test.tsx
+++ b/frontend/app/(dashboard)/models/_components/model-dialog.test.tsx
@@ -186,6 +186,30 @@ describe('ModelDialog', () => {
     expect(invalidIds).toContain('modelId')
   })
 
+  test('anchors the direct setup controls without targeting portaled options', () => {
+    const tree = render()
+
+    for (const testId of [
+      'admin-model-dialog',
+      'admin-model-dialog-provider-selection',
+      'admin-model-dialog-model-type',
+      'admin-model-dialog-model-id',
+      'admin-model-dialog-api-config',
+      'admin-model-dialog-base-url',
+      'admin-model-dialog-api-key',
+      'admin-model-dialog-test-connection',
+      'admin-model-dialog-enabled',
+    ]) {
+      expect(find(tree, (node) => node.props['data-testid'] === testId)).toBeDefined()
+    }
+
+    const providerTrigger = find(tree, (node) => node.type === 'popovertrigger')
+    const providerButton = resolve(
+      (providerTrigger.props.render as (props: Record<string, unknown>) => ReactNode)({}),
+    ) as Tree
+    expect(providerButton.props['data-testid']).toBe('admin-model-dialog-provider')
+  })
+
   test('creates an Ollama chat model without requiring an API key', async () => {
     change('name', ' Local model ')
     chooseModelType()

--- a/frontend/app/(dashboard)/models/_components/model-dialog.tsx
+++ b/frontend/app/(dashboard)/models/_components/model-dialog.tsx
@@ -1076,11 +1076,11 @@ export function ModelDialog({
           <FieldError>{errors.name}</FieldError>
         </div>
         
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-4" data-testid="admin-model-dialog-provider-selection">
           <div className="space-y-2">
             <Label>{t('modelType')} *</Label>
             <Select value={modelType} onValueChange={handleModelTypeChange} disabled={isEditing}>
-              <SelectTrigger aria-invalid={!!errors.modelType}>
+              <SelectTrigger data-testid="admin-model-dialog-model-type" aria-invalid={!!errors.modelType}>
                 <SelectValue>{modelType ? getModelTypeName(modelType) : t('selectModelType')}</SelectValue>
               </SelectTrigger>
               <SelectContent side="bottom" alignItemWithTrigger={false}>
@@ -1100,6 +1100,7 @@ export function ModelDialog({
               <PopoverTrigger
                 render={(props) => (
                   <Button
+                    data-testid="admin-model-dialog-provider"
                     {...props}
                     type="button"
                     variant="outline"
@@ -1282,6 +1283,7 @@ export function ModelDialog({
               onValueChange={handleDiscoveredModelChange}
             >
               <ComboboxInput
+                data-testid="admin-model-dialog-model-id"
                 id="modelId"
                 placeholder={t('modelIdPlaceholder')}
                 className="w-full"
@@ -1345,13 +1347,14 @@ export function ModelDialog({
       </div>
       
       {/* API 配置 */}
-      <div className="space-y-4">
+      <div className="space-y-4" data-testid="admin-model-dialog-api-config">
         <SectionTitle>{t('apiConfig')}</SectionTitle>
         
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-2">
             <Label htmlFor="baseUrl">{t('baseUrl')}</Label>
             <Input
+              data-testid="admin-model-dialog-base-url"
               id="baseUrl"
               value={baseUrl}
               onChange={(e) => {
@@ -1377,6 +1380,7 @@ export function ModelDialog({
             </Label>
             <div className="relative">
               <Input
+                data-testid="admin-model-dialog-api-key"
                 id="apiKey"
                 type={showApiKey ? 'text' : 'password'}
                 value={apiKey}
@@ -1414,6 +1418,7 @@ export function ModelDialog({
         {/* 测试连接按钮和结果 */}
         <div className="space-y-2">
           <Button
+            data-testid="admin-model-dialog-test-connection"
             type="button"
             variant="outline"
             size="sm"
@@ -1464,7 +1469,7 @@ export function ModelDialog({
               <Label className="text-sm font-medium">{t('enabled')}</Label>
               <p className="text-xs text-muted-foreground">{t('enabledHint')}</p>
             </div>
-            <Switch checked={isEnabled} onCheckedChange={setIsEnabled} />
+            <Switch data-testid="admin-model-dialog-enabled" checked={isEnabled} onCheckedChange={setIsEnabled} />
           </div>
           
           <div className="flex items-center justify-between rounded-lg border p-3 bg-muted/30">
@@ -2166,7 +2171,7 @@ export function ModelDialog({
   
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogContent data-testid="admin-model-dialog" className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{isEditing ? t('editModel') : t('createModel')}</DialogTitle>
           <DialogDescription>

--- a/frontend/app/(dashboard)/models/_components/models-client-issue255.test.tsx
+++ b/frontend/app/(dashboard)/models/_components/models-client-issue255.test.tsx
@@ -27,7 +27,7 @@ mock.module('lucide-react', () => ({
   Plus: () => null, Search: () => null, MoreHorizontal: () => null, Pencil: () => null,
   Trash2: () => null, ChevronLeft: () => null, ChevronRight: () => null, ChevronsLeft: () => null,
   ChevronsRight: () => null, X: () => null, Star: () => null, Power: () => null,
-  PowerOff: () => null, TestTube: () => null,
+  PowerOff: () => null, TestTube: () => null, GraduationCap: () => null,
 }))
 mock.module('@/lib/api/admin/models', () => ({ modelsApi: { getModels, updateModel, setDefault, testConnection, deleteModel } }))
 mock.module('@/lib/api/models', () => ({ modelsApi: { getProviders, getModelTypes } }))
@@ -36,6 +36,9 @@ mock.module('@/components/permission-guard', () => ({
   useCanPerform: () => ({ canPerform: (permission: string) => permissions.has(permission) }),
 }))
 mock.module('@/hooks/use-url-search-state', () => ({ useUrlSearchState: () => React.useState('') }))
+mock.module('@/components/onboarding/onboarding-provider', () => ({
+  useOptionalOnboarding: () => ({ startTour: mock() }),
+}))
 
 const passthrough = ({ children }: React.PropsWithChildren) => <>{children}</>
 const Button = ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => <button {...props}>{children}</button>

--- a/frontend/app/(dashboard)/models/_components/models-client.test.tsx
+++ b/frontend/app/(dashboard)/models/_components/models-client.test.tsx
@@ -14,6 +14,8 @@ const loading = mock(() => 'toast-1')
 const error = mock()
 const dismiss = mock()
 
+const startTour = mock()
+let canCreate = true
 mock.module('next-intl', () => ({
   useTranslations: () => {
     const translate = (key: string) => key
@@ -26,15 +28,19 @@ mock.module('lucide-react', () => ({
   Plus: () => null, Search: () => null, MoreHorizontal: () => null, Pencil: () => null,
   Trash2: () => null, ChevronLeft: () => null, ChevronRight: () => null, ChevronsLeft: () => null,
   ChevronsRight: () => null, X: () => null, Star: () => null, Power: () => null,
-  PowerOff: () => null, TestTube: () => null,
+  PowerOff: () => null, TestTube: () => null, GraduationCap: () => null,
 }))
 mock.module('@/lib/api/admin/models', () => ({ modelsApi: { getModels, updateModel, setDefault, testConnection, deleteModel } }))
 mock.module('@/lib/api/models', () => ({ modelsApi: { getProviders, getModelTypes } }))
 mock.module('@/components/permission-guard', () => ({
-  PermissionGuard: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  PermissionGuard: ({ permission, children }: React.PropsWithChildren<{ permission: string }>) =>
+    permission === 'admin:model:create' && !canCreate ? null : <>{children}</>,
   useCanPerform: () => ({ canPerform: () => true }),
 }))
 mock.module('@/hooks/use-url-search-state', () => ({ useUrlSearchState: () => React.useState('') }))
+mock.module('@/components/onboarding/onboarding-provider', () => ({
+  useOptionalOnboarding: () => ({ startTour }),
+}))
 
 const passthrough = ({ children }: React.PropsWithChildren) => <>{children}</>
 mock.module('@/components/ui/button', () => ({ Button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => <button {...props}>{children}</button> }))
@@ -43,7 +49,13 @@ mock.module('@/components/ui/badge', () => ({ Badge: passthrough }))
 mock.module('@/components/ui/checkbox', () => ({ Checkbox: ({ checked, onCheckedChange }: { checked: boolean; onCheckedChange: (checked: boolean) => void }) => <input type="checkbox" checked={checked} onChange={() => onCheckedChange(!checked)} /> }))
 mock.module('@/components/ui/table', () => ({ Table: passthrough, TableBody: passthrough, TableCell: passthrough, TableHead: passthrough, TableHeader: passthrough, TableRow: passthrough }))
 mock.module('@/components/ui/select', () => ({ Select: passthrough, SelectContent: passthrough, SelectItem: passthrough, SelectTrigger: passthrough, SelectValue: passthrough }))
-mock.module('@/components/ui/dropdown-menu', () => ({ DropdownMenu: passthrough, DropdownMenuContent: passthrough, DropdownMenuItem: ({ children, onClick }: React.PropsWithChildren<{ onClick?: () => void }>) => <button onClick={onClick}>{children}</button>, DropdownMenuSeparator: () => null, DropdownMenuTrigger: passthrough }))
+mock.module('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: passthrough,
+  DropdownMenuContent: passthrough,
+  DropdownMenuItem: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => <button {...props}>{children}</button>,
+  DropdownMenuSeparator: () => null,
+  DropdownMenuTrigger: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => <button {...props}>{children}</button>,
+}))
 mock.module('@/components/ui/data-table-faceted-filter', () => ({ DataTableFacetedFilter: () => null }))
 mock.module('@/components/ui/tooltip', () => ({ Tooltip: passthrough, TooltipContent: passthrough, TooltipTrigger: ({ render, ...props }: { render: React.ReactElement } & Record<string, unknown>) => React.cloneElement(render, props) }))
 mock.module('@/components/ui/alert-dialog', () => ({ AlertDialog: passthrough, AlertDialogAction: ({ children, onClick }: React.PropsWithChildren<{ onClick?: () => void }>) => <button onClick={onClick}>{children}</button>, AlertDialogCancel: passthrough, AlertDialogContent: passthrough, AlertDialogDescription: passthrough, AlertDialogFooter: passthrough, AlertDialogHeader: passthrough, AlertDialogTitle: passthrough }))
@@ -74,6 +86,8 @@ beforeEach(() => {
   loading.mockClear()
   error.mockClear()
   dismiss.mockClear()
+  startTour.mockClear()
+  canCreate = true
 })
 afterEach(() => { if (renderer) act(() => renderer.unmount()) })
 
@@ -101,6 +115,34 @@ test('loads and lists models, then refreshes after the model form saves', async 
   await act(async () => buttonsNamed('createModel')[0].props.onClick())
   await act(async () => buttonsNamed('save-model')[0].props.onClick())
   expect(getModels).toHaveBeenCalledTimes(2)
+})
+
+test('gates the admin model setup launcher and anchors its supported controls', async () => {
+  getModels.mockResolvedValue(page())
+  canCreate = false
+  render()
+  await act(async () => {})
+
+  expect(renderer.root.findAllByProps({ 'data-testid': 'admin-models-onboarding-button' })).toHaveLength(0)
+  act(() => renderer.unmount())
+
+  canCreate = true
+  render()
+  await act(async () => {})
+
+  expect(renderer.root.findByProps({ 'data-testid': 'admin-models-list' })).toBeTruthy()
+  expect(renderer.root.findByProps({ 'data-testid': 'admin-models-create-button' })).toBeTruthy()
+  expect(renderer.root.findByProps({ 'data-testid': 'admin-model-actions-model-1' })).toBeTruthy()
+  expect(renderer.root.findByProps({ 'data-testid': 'admin-model-toggle-enabled-model-1' })).toBeTruthy()
+  expect(renderer.root.findByProps({ 'data-testid': 'admin-model-test-connection-model-1' })).toBeTruthy()
+
+  const launcher = renderer.root.findByProps({ 'data-testid': 'admin-models-onboarding-button' })
+  act(() => launcher.props.onClick())
+  expect(startTour).not.toHaveBeenCalled()
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 350))
+  })
+  expect(startTour).toHaveBeenCalledWith('adminModelSetup')
 })
 
 test('disables a model and reloads the listing', async () => {

--- a/frontend/app/(dashboard)/models/_components/models-client.tsx
+++ b/frontend/app/(dashboard)/models/_components/models-client.tsx
@@ -17,6 +17,7 @@ import {
   Power,
   PowerOff,
   TestTube,
+  GraduationCap,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { modelsApi, type Model } from '@/lib/api/admin/models'
@@ -67,11 +68,14 @@ import {
 import { ModelDialog } from './model-dialog'
 import { DeleteModelDialog } from './delete-model-dialog'
 import { PermissionGuard, useCanPerform } from '@/components/permission-guard'
+import { useOptionalOnboarding } from '@/components/onboarding/onboarding-provider'
 import { useUrlSearchState } from '@/hooks/use-url-search-state'
 
 export function ModelsClient() {
   const t = useTranslations('models')
   const commonT = useTranslations('common')
+  const tOnboarding = useTranslations('onboarding')
+  const onboarding = useOptionalOnboarding()
   const { canPerform } = useCanPerform()
   
   // 数据状态
@@ -350,10 +354,28 @@ export function ModelsClient() {
         </div>
         <div className="flex items-center gap-2">
           <PermissionGuard permission="admin:model:create">
-            <Button onClick={handleCreate}>
-              <Plus className="mr-2 h-4 w-4" />
-              {t('createModel')}
-            </Button>
+            <>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      data-testid="admin-models-onboarding-button"
+                      aria-label={tOnboarding('tourAdminModelSetupTitle')}
+                      onClick={() => setTimeout(() => onboarding?.startTour('adminModelSetup'), 300)}
+                    >
+                      <GraduationCap className="h-4 w-4" />
+                    </Button>
+                  }
+                />
+                <TooltipContent>{tOnboarding('tourAdminModelSetupTitle')}</TooltipContent>
+              </Tooltip>
+              <Button data-testid="admin-models-create-button" onClick={handleCreate}>
+                <Plus className="mr-2 h-4 w-4" />
+                {t('createModel')}
+              </Button>
+            </>
           </PermissionGuard>
         </div>
       </div>
@@ -406,7 +428,7 @@ export function ModelsClient() {
       </div>
       
       {/* 表格 */}
-      <div className="rounded-lg border">
+      <div className="rounded-lg border" data-testid="admin-models-list">
         <Table>
           <TableHeader>
             <TableRow className="bg-muted/50 hover:bg-muted/50">
@@ -480,7 +502,10 @@ export function ModelsClient() {
                   <TableCell>
                     {(canPerform('admin:model:update') || canPerform('admin:model:delete')) && (
                       <DropdownMenu>
-                        <DropdownMenuTrigger className="ring-offset-background focus-visible:ring-ring data-[state=open]:bg-accent inline-flex h-8 w-8 items-center justify-center rounded-md hover:bg-accent focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none">
+                        <DropdownMenuTrigger
+                          data-testid={`admin-model-actions-${model.id}`}
+                          className="ring-offset-background focus-visible:ring-ring data-[state=open]:bg-accent inline-flex h-8 w-8 items-center justify-center rounded-md hover:bg-accent focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                        >
                           <MoreHorizontal className="h-4 w-4" />
                           <span className="sr-only">{t('common.openMenu')}</span>
                         </DropdownMenuTrigger>
@@ -492,7 +517,10 @@ export function ModelsClient() {
                                 {commonT('edit')}
                               </DropdownMenuItem>
 
-                              <DropdownMenuItem onClick={() => handleToggleStatus(model)}>
+                              <DropdownMenuItem
+                                data-testid={`admin-model-toggle-enabled-${model.id}`}
+                                onClick={() => handleToggleStatus(model)}
+                              >
                                 {model.is_enabled ? (
                                   <>
                                     <PowerOff className="mr-2 h-4 w-4" />
@@ -514,7 +542,10 @@ export function ModelsClient() {
                               )}
 
                               {model.has_api_key && (
-                                <DropdownMenuItem onClick={() => handleTestConnection(model)}>
+                                <DropdownMenuItem
+                                  data-testid={`admin-model-test-connection-${model.id}`}
+                                  onClick={() => handleTestConnection(model)}
+                                >
                                   <TestTube className="mr-2 h-4 w-4" />
                                   {t('testConnection')}
                                 </DropdownMenuItem>

--- a/frontend/components/layout/platform-header.test.tsx
+++ b/frontend/components/layout/platform-header.test.tsx
@@ -13,11 +13,14 @@ const unreadCount = mock(async () => ({ total: 105 }))
 const removeItem = mock(() => {})
 const toastSuccess = mock(() => {})
 const requestPermission = mock(async () => 'granted')
+const startTour = mock(() => {})
 
 let canAccessDashboard = false
 let canAccessCapabilities = false
 let currentTeam: { id: string } | null = { id: 'team-1' }
 let headerVariant: 'default' | 'centered' | 'minimal' = 'centered'
+let onboarding: { isTourCompleted: (tourId: string) => boolean; startTour: (tourId: string) => void } | null = null
+const tourConfigs: Array<{ id: string; title: string; showInPlatformMenu?: boolean }> = []
 
 mock.module('next-intl', () => ({
   useLocale: () => 'en',
@@ -66,9 +69,9 @@ mock.module('@/hooks/use-settings', () => ({
   useSettings: () => ({ platformHeaderVariant: headerVariant, mounted: true }),
 }))
 mock.module('@/components/onboarding/onboarding-provider', () => ({
-  useOptionalOnboarding: () => null,
+  useOptionalOnboarding: () => onboarding,
 }))
-mock.module('@/components/onboarding/steps/platform-steps', () => ({ allTourConfigs: [] }))
+mock.module('@/components/onboarding/steps/platform-steps', () => ({ allTourConfigs: tourConfigs }))
 mock.module('@/lib/theme-config', () => ({
   getBrandingVisibility: () => ({ showIcon: true, showName: true }),
 }))
@@ -153,6 +156,9 @@ beforeEach(() => {
   removeItem.mockClear()
   toastSuccess.mockClear()
   requestPermission.mockClear()
+  onboarding = null
+  tourConfigs.splice(0)
+  startTour.mockClear()
   Object.defineProperty(globalThis, 'localStorage', {
     configurable: true,
     value: { removeItem },
@@ -270,5 +276,19 @@ describe('PlatformHeader', () => {
     expect(renderer.root.findAllByProps({ 'data-testid': 'platform-header-nav' })).toHaveLength(0)
     expect(renderer.root.findAllByProps({ 'data-testid': 'platform-team-switcher' })).toHaveLength(0)
     expect(renderer.root.findByProps({ 'data-testid': 'platform-user-menu' })).toBeTruthy()
+  })
+
+  test('excludes dashboard-scoped tours from the platform menu', async () => {
+    onboarding = { isTourCompleted: () => false, startTour }
+    tourConfigs.push(
+      { id: 'models', title: 'onboarding.tourModelsTitle' },
+      { id: 'adminModelSetup', title: 'onboarding.tourAdminModelSetupTitle', showInPlatformMenu: false },
+    )
+    const renderer = await renderHeader()
+
+    expect(renderer.root.findByProps({ 'data-testid': 'user-menu-tours' })).toBeTruthy()
+    const tourLabels = renderer.root.findAllByType('button').flatMap(button => button.children)
+    expect(tourLabels).toContain('tourModelsTitle')
+    expect(tourLabels).not.toContain('tourAdminModelSetupTitle')
   })
 })

--- a/frontend/components/layout/platform-header.tsx
+++ b/frontend/components/layout/platform-header.tsx
@@ -439,7 +439,9 @@ export function PlatformHeader() {
                     {tOnboarding('tourTitle')}
                   </DropdownMenuSubTrigger>
                   <DropdownMenuSubContent>
-                    {allTourConfigs.map((tourConfig) => {
+                    {allTourConfigs
+                      .filter(tourConfig => tourConfig.showInPlatformMenu !== false)
+                      .map((tourConfig) => {
                       const isCompleted = onboarding.isTourCompleted(tourConfig.id)
                       // tourConfig.title is like 'onboarding.tourOverviewTitle', we need 'tourOverviewTitle'
                       const titleKey = tourConfig.title.replace('onboarding.', '') as keyof OnboardingMessages['onboarding']

--- a/frontend/components/onboarding/onboarding-tour.test.tsx
+++ b/frontend/components/onboarding/onboarding-tour.test.tsx
@@ -9,7 +9,7 @@ import * as teamContext from '@/contexts/team-context'
 import * as onboardingProvider from './onboarding-provider'
 import * as platformSteps from './steps/platform-steps'
 import type { OnboardingTourConfig } from './steps/types'
-import { OnboardingTour } from './onboarding-tour'
+import { OnboardingTour, allTourIds } from './onboarding-tour'
 
 const push = mock(() => {})
 const startTour = mock(() => {})
@@ -73,6 +73,11 @@ afterEach(() => {
 afterAll(() => GlobalRegistrator.unregister())
 
 describe('OnboardingTour', () => {
+  it('does not render dashboard-only tour configs in platform layouts', () => {
+    expect(allTourIds).toContain('overview')
+    expect(allTourIds).not.toContain('adminModelSetup')
+  })
+
   it('auto-starts overview once only when the home/team/completion boundaries allow it', async () => {
     config = {
       id: 'overview', title: 'Overview', description: '', autoStart: true,
@@ -399,17 +404,28 @@ describe('OnboardingTour', () => {
     restore()
   })
 
-  it('adds the dialog overlay class only while the dialog step is mounted', () => {
+  it('adds the dialog overlay class only while dialog steps are mounted', () => {
     config = {
       id: 'appCreate', title: 'Create app', description: '',
       steps: [{ target: '.app-create-name-input', content: 'name' }],
     }
     state = { completedTours: [], currentTour: 'appCreate', currentStep: 0, isRunning: true }
     const restore = installSpies()
-    const view = render(<OnboardingTour tourId="appCreate" />)
+    const appCreateView = render(<OnboardingTour tourId="appCreate" />)
 
     expect(document.body.classList.contains('joyride-dialog-active')).toBe(true)
-    view.unmount()
+    appCreateView.unmount()
+    expect(document.body.classList.contains('joyride-dialog-active')).toBe(false)
+
+    config = {
+      id: 'adminModelSetup', title: 'Admin model setup', description: '',
+      steps: [{ target: '.admin-model-dialog-provider-selection', content: 'provider' }],
+    }
+    state = { completedTours: [], currentTour: 'adminModelSetup', currentStep: 0, isRunning: true }
+    const adminModelSetupView = render(<OnboardingTour tourId="adminModelSetup" />)
+
+    expect(document.body.classList.contains('joyride-dialog-active')).toBe(true)
+    adminModelSetupView.unmount()
     expect(document.body.classList.contains('joyride-dialog-active')).toBe(false)
     restore()
   })

--- a/frontend/components/onboarding/onboarding-tour.tsx
+++ b/frontend/components/onboarding/onboarding-tour.tsx
@@ -82,7 +82,9 @@ function routeMatches(pathname: string, route: string) {
 }
 
 // Export all tour IDs for rendering
-export const allTourIds: OnboardingTourId[] = allTourConfigs.map(c => c.id)
+export const allTourIds: OnboardingTourId[] = allTourConfigs
+  .filter(config => config.showInPlatformMenu !== false)
+  .map(config => config.id)
 
 export function OnboardingTour({ tourId }: OnboardingTourProps) {
   const t = useTranslations()
@@ -456,6 +458,7 @@ export function OnboardingTour({ tourId }: OnboardingTourProps) {
   // This effect must be before early returns to maintain hook order
   const targetSelector = typeof currentStep?.target === 'string' ? currentStep.target : ''
   const isDialogStep = state.isRunning && state.currentTour === tourId && targetSelector && (
+    targetSelector.includes('admin-model-dialog-') ||
     targetSelector.includes('app-create-type-selector') ||
     targetSelector.includes('app-create-name-input') ||
     targetSelector.includes('app-create-description-input') ||

--- a/frontend/components/onboarding/steps/admin-models-steps.ts
+++ b/frontend/components/onboarding/steps/admin-models-steps.ts
@@ -1,0 +1,69 @@
+import type { OnboardingStep, OnboardingTourConfig } from './types'
+
+const adminModelSetupSteps: OnboardingStep[] = [
+  {
+    target: '[data-testid="admin-models-list"]',
+    content: 'onboarding.step30a.description',
+    title: 'onboarding.step30a.title',
+    placement: 'auto',
+    route: '/models',
+  },
+  {
+    target: '[data-testid="admin-models-create-button"]',
+    content: 'onboarding.step30b.description',
+    title: 'onboarding.step30b.title',
+    placement: 'left',
+    route: '/models',
+    advanceOnClick: true,
+    overlayClickAction: false,
+  },
+  {
+    target: '[data-testid="admin-model-dialog-provider-selection"]',
+    content: 'onboarding.step30c.description',
+    title: 'onboarding.step30c.title',
+    placement: 'bottom',
+    route: '/models',
+    overlayClickAction: false,
+  },
+  {
+    target: '[data-testid="admin-model-dialog-api-config"]',
+    content: 'onboarding.step30d.description',
+    title: 'onboarding.step30d.title',
+    placement: 'bottom',
+    route: '/models',
+    overlayClickAction: false,
+  },
+  {
+    target: '[data-testid="admin-model-dialog-model-id"]',
+    content: 'onboarding.step30e.description',
+    title: 'onboarding.step30e.title',
+    placement: 'bottom',
+    route: '/models',
+    overlayClickAction: false,
+  },
+  {
+    target: '[data-testid="admin-model-dialog-test-connection"]',
+    content: 'onboarding.step30f.description',
+    title: 'onboarding.step30f.title',
+    placement: 'top',
+    route: '/models',
+    overlayClickAction: false,
+  },
+  {
+    target: '[data-testid="admin-model-dialog-enabled"]',
+    content: 'onboarding.step30g.description',
+    title: 'onboarding.step30g.title',
+    placement: 'left',
+    route: '/models',
+    overlayClickAction: false,
+  },
+]
+
+export const adminModelSetupTourConfig: OnboardingTourConfig = {
+  id: 'adminModelSetup',
+  title: 'onboarding.tourAdminModelSetupTitle',
+  description: 'onboarding.tourAdminModelSetupDescription',
+  steps: adminModelSetupSteps,
+  autoStart: false,
+  showInPlatformMenu: false,
+}

--- a/frontend/components/onboarding/steps/platform-steps.test.ts
+++ b/frontend/components/onboarding/steps/platform-steps.test.ts
@@ -16,6 +16,7 @@ describe('onboarding tour configurations', () => {
       'appConfig',
       'workflowConfig',
       'capabilities',
+      'adminModelSetup',
     ])
     for (const config of allTourConfigs) {
       expect(config.title).toStartWith('onboarding.')
@@ -34,6 +35,7 @@ describe('onboarding tour configurations', () => {
     const appConfigTargets = getTourConfigById('appConfig')?.steps.map(step => step.target) ?? []
     const knowledgeBaseTargets = getTourConfigById('kb')?.steps.map(step => step.target) ?? []
     const workflowTargets = getTourConfigById('workflowConfig')?.steps.map(step => step.target) ?? []
+    const adminModelSetup = getTourConfigById('adminModelSetup')
 
     expect(appConfigTargets).toContain('[data-testid="agent-attachments-section"]')
     expect(appConfigTargets).not.toContain('[data-testid="agent-vision-section"]')
@@ -54,10 +56,74 @@ describe('onboarding tour configurations', () => {
     ])
     expect(getTourConfigById('workflowConfig')?.steps.every(step => step.skipIfMissing)).toBe(true)
     expect(getTourConfigById('workflowConfig')?.steps[0]?.placement).toBe('center')
+    expect(adminModelSetup).toMatchObject({
+      id: 'adminModelSetup',
+      showInPlatformMenu: false,
+      steps: [
+        {
+          target: '[data-testid="admin-models-list"]',
+          content: 'onboarding.step30a.description',
+          title: 'onboarding.step30a.title',
+          placement: 'auto',
+          route: '/models',
+        },
+        {
+          target: '[data-testid="admin-models-create-button"]',
+          content: 'onboarding.step30b.description',
+          title: 'onboarding.step30b.title',
+          placement: 'left',
+          route: '/models',
+          advanceOnClick: true,
+          overlayClickAction: false,
+        },
+        {
+          target: '[data-testid="admin-model-dialog-provider-selection"]',
+          content: 'onboarding.step30c.description',
+          title: 'onboarding.step30c.title',
+          placement: 'bottom',
+          route: '/models',
+          overlayClickAction: false,
+        },
+        {
+          target: '[data-testid="admin-model-dialog-api-config"]',
+          content: 'onboarding.step30d.description',
+          title: 'onboarding.step30d.title',
+          placement: 'bottom',
+          route: '/models',
+          overlayClickAction: false,
+        },
+        {
+          target: '[data-testid="admin-model-dialog-model-id"]',
+          content: 'onboarding.step30e.description',
+          title: 'onboarding.step30e.title',
+          placement: 'bottom',
+          route: '/models',
+          overlayClickAction: false,
+        },
+        {
+          target: '[data-testid="admin-model-dialog-test-connection"]',
+          content: 'onboarding.step30f.description',
+          title: 'onboarding.step30f.title',
+          placement: 'top',
+          route: '/models',
+          overlayClickAction: false,
+        },
+        {
+          target: '[data-testid="admin-model-dialog-enabled"]',
+          content: 'onboarding.step30g.description',
+          title: 'onboarding.step30g.title',
+          placement: 'left',
+          route: '/models',
+          overlayClickAction: false,
+        },
+      ],
+    })
+    expect(adminModelSetup?.steps).toHaveLength(7)
   })
 
   test('looks up known tours and returns undefined for unknown IDs', () => {
     expect(getTourConfigById('kb')).toBe(allTourConfigs[2])
+    expect(getTourConfigById('adminModelSetup')).toBe(allTourConfigs[7])
     expect(getTourConfigById('unknown')).toBeUndefined()
   })
 

--- a/frontend/components/onboarding/steps/platform-steps.ts
+++ b/frontend/components/onboarding/steps/platform-steps.ts
@@ -6,6 +6,7 @@ import { appCreateTourConfig } from './app-create-steps'
 import { appConfigTourConfig } from './app-config-steps'
 import { workflowConfigTourConfig } from './workflow-steps'
 import { capabilitiesTourConfig } from './capabilities-steps'
+import { adminModelSetupTourConfig } from './admin-models-steps'
 
 // Export individual tour configs
 export {
@@ -16,6 +17,7 @@ export {
   appConfigTourConfig,
   workflowConfigTourConfig,
   capabilitiesTourConfig,
+  adminModelSetupTourConfig,
 }
 
 // Array of all tour configs for easy iteration
@@ -27,6 +29,7 @@ export const allTourConfigs: OnboardingTourConfig[] = [
   appConfigTourConfig,
   workflowConfigTourConfig,
   capabilitiesTourConfig,
+  adminModelSetupTourConfig,
 ]
 
 // Get tour config by ID

--- a/frontend/components/onboarding/steps/types.ts
+++ b/frontend/components/onboarding/steps/types.ts
@@ -1,6 +1,14 @@
 import type { Step, Placement } from 'react-joyride'
 
-export type OnboardingTourId = 'overview' | 'models' | 'kb' | 'appCreate' | 'appConfig' | 'workflowConfig' | 'capabilities'
+export type OnboardingTourId =
+  | 'overview'
+  | 'models'
+  | 'kb'
+  | 'appCreate'
+  | 'appConfig'
+  | 'workflowConfig'
+  | 'capabilities'
+  | 'adminModelSetup'
 
 export interface OnboardingStep extends Step {
   /** Route path for cross-page navigation */
@@ -30,6 +38,8 @@ export interface OnboardingTourConfig {
   steps: OnboardingStep[]
   /** Whether this tour should auto-start for new users */
   autoStart?: boolean
+  /** Whether this tour appears in the platform header menu */
+  showInPlatformMenu?: boolean
   /** Prerequisite tour IDs that must be completed first */
   prerequisites?: OnboardingTourId[]
 }

--- a/frontend/i18n/en/onboarding.json
+++ b/frontend/i18n/en/onboarding.json
@@ -16,6 +16,8 @@
     "tourWorkflowConfigDescription": "Build your workflow by adding and connecting nodes, then test and publish",
     "tourCapabilitiesTitle": "Capabilities",
     "tourCapabilitiesDescription": "Learn how to manage tools and skills",
+    "tourAdminModelSetupTitle": "Admin Model Setup",
+    "tourAdminModelSetupDescription": "Connect, test, enable, and authorize models before your team builds Agents and Knowledge Bases.",
     "startTour": "Start Tour",
     "restartTour": "Restart Tour",
     "back": "Back",
@@ -441,6 +443,34 @@
     "step29": {
       "title": "Refresh Skills",
       "description": "Click this button to refresh the skills list and get the latest data from the server."
+    },
+    "step30a": {
+      "title": "Model Provisioning",
+      "description": "This is the administrator model list. A model must be configured, enabled, and authorized to a team before Agents or Knowledge Bases can use it."
+    },
+    "step30b": {
+      "title": "Add a Model",
+      "description": "Click Add Model to register a provider configuration. Give it a name and choose the model type before selecting a provider."
+    },
+    "step30c": {
+      "title": "Choose a Provider",
+      "description": "Select a provider compatible with the model type. The provider can prefill its API base URL."
+    },
+    "step30d": {
+      "title": "Enter Connection Details",
+      "description": "Enter the API base URL and API key when the provider requires one. Discovery starts only after the required connection details are present."
+    },
+    "step30e": {
+      "title": "Discover the Model ID",
+      "description": "After the connection details are valid, select a discovered model ID or enter the exact ID supplied by the provider. Discovery can also fill the model name and capabilities."
+    },
+    "step30f": {
+      "title": "Test the Connection",
+      "description": "Use the form-level Test Connection button before creating the model. Resolve failures before saving."
+    },
+    "step30g": {
+      "title": "Enable and Authorize",
+      "description": "Leave the model enabled and create it. Then open Teams, choose the target team, open Model Authorization, and authorize this enabled model so Agents and Knowledge Bases can select it."
     }
   }
 }

--- a/frontend/i18n/types/onboarding.ts
+++ b/frontend/i18n/types/onboarding.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-08-17T05:37:33.238Z
+// GENERATED — 2026-08-17T13:17:10.952Z
 // Source: i18n/en/onboarding.json
 export type OnboardingMessages = {
   onboarding: {
@@ -18,6 +18,8 @@ export type OnboardingMessages = {
     tourWorkflowConfigDescription: string
     tourCapabilitiesTitle: string
     tourCapabilitiesDescription: string
+    tourAdminModelSetupTitle: string
+    tourAdminModelSetupDescription: string
     startTour: string
     restartTour: string
     back: string
@@ -441,6 +443,34 @@ export type OnboardingMessages = {
       description: string
     }
     step29: {
+      title: string
+      description: string
+    }
+    step30a: {
+      title: string
+      description: string
+    }
+    step30b: {
+      title: string
+      description: string
+    }
+    step30c: {
+      title: string
+      description: string
+    }
+    step30d: {
+      title: string
+      description: string
+    }
+    step30e: {
+      title: string
+      description: string
+    }
+    step30f: {
+      title: string
+      description: string
+    }
+    step30g: {
       title: string
       description: string
     }

--- a/frontend/i18n/zh/onboarding.json
+++ b/frontend/i18n/zh/onboarding.json
@@ -16,6 +16,8 @@
     "tourWorkflowConfigDescription": "通过添加和连接节点构建工作流，然后测试并发布",
     "tourCapabilitiesTitle": "能力",
     "tourCapabilitiesDescription": "了解如何管理工具和技能",
+    "tourAdminModelSetupTitle": "管理端模型配置",
+    "tourAdminModelSetupDescription": "在团队创建 Agent 和知识库前，连接、测试、启用模型并授权给团队。",
     "startTour": "开始引导",
     "restartTour": "重新引导",
     "back": "上一步",
@@ -441,6 +443,34 @@
     "step29": {
       "title": "刷新技能",
       "description": "点击此按钮刷新技能列表，从服务器获取最新数据。"
+    },
+    "step30a": {
+      "title": "模型配置",
+      "description": "这里是管理员模型列表。模型完成配置、启用并授权给团队后，Agent 和知识库才能使用它。"
+    },
+    "step30b": {
+      "title": "添加模型",
+      "description": "点击“添加模型”登记提供商配置。填写模型名称，先选择模型类型，再选择提供商。"
+    },
+    "step30c": {
+      "title": "选择提供商",
+      "description": "选择与模型类型兼容的提供商。提供商可能会自动填写 API 基础 URL。"
+    },
+    "step30d": {
+      "title": "填写连接信息",
+      "description": "填写 API 基础 URL；如果提供商要求，还要填写 API 密钥。必需的连接信息填写完成后才会开始发现模型。"
+    },
+    "step30e": {
+      "title": "发现模型 ID",
+      "description": "连接信息有效后，选择发现的模型 ID，或填写提供商提供的准确 ID。发现过程还可能自动填写模型名称和能力。"
+    },
+    "step30f": {
+      "title": "测试连接",
+      "description": "创建模型前使用表单中的“测试连接”按钮。保存前先解决连接失败问题。"
+    },
+    "step30g": {
+      "title": "启用并授权",
+      "description": "保持模型启用并创建模型。然后打开团队管理，选择目标团队，进入“模型授权”并授权此模型，Agent 和知识库才能选择它。"
     }
   }
 }


### PR DESCRIPTION
## Description

Adds a dashboard-only seven-step onboarding tour for administrator model provisioning at `/models`.

- Isolates the admin tour from the platform menu and platform renderer.
- Adds a permission-gated local launcher plus stable list, row-action, and creation-dialog anchors.
- Covers connection setup, discovery, testing, enablement, and the existing Team Model Authorization handoff.
- Adds matching English and Simplified Chinese onboarding copy.

Related: YUN-136

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- `cd frontend && bun run i18n:gen-types`
- `cd frontend && bun run i18n:lint --strict`
- Focused isolated Bun suite: 71 pass, 0 fail.
- `cd frontend && bunx tsc --noEmit`
- `cd frontend && bun run lint`

A live provider smoke requires an authenticated session and valid provider credentials; focused component tests cover mocked discovery and connection-test success, failure, and retry transitions.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my feature works
- [x] New and existing focused unit tests pass locally with my changes