### PR TITLE
[YUN-142] Fix agent conversation caching and token calculation

### DIFF
--- a/.yun-dev.json
+++ b/.yun-dev.json
@@ -1,0 +1,14 @@
+{
+    "services": {
+        "frontend": {
+            "command": "bun dev",
+            "cwd": "frontend"
+        },
+        "backend": {
+            "command": "uv run --project backend main.py server"
+        },
+        "worker": {
+            "command": "uv run --project backend main.py worker"
+        }
+    }
+}

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -1234,6 +1234,7 @@ async def delete_conversation(
 async def delete_message(
     conversation_id: UUID,
     message_id: UUID,
+    request: Request,
     current_user: User = Depends(deps.PermissionChecker("conversation:delete")),
 ) -> Any:
     """Delete a message from a conversation."""
@@ -1268,13 +1269,43 @@ async def delete_message(
             "prompt", 0
         ) + message.token_usage.get("completion", 0)
 
+    conversation_message_count = getattr(conversation, "message_count", 0) or 0
+    conversation_token_usage = getattr(conversation, "token_usage", 0) or 0
+    conversation_updated_at = getattr(conversation, "updated_at", None)
+    audit_before = {
+        "message_count": conversation_message_count,
+        "token_usage": conversation_token_usage,
+        "updated_at": (
+            conversation_updated_at.isoformat() if conversation_updated_at else None
+        ),
+    }
+    updated_at = now_utc()
+    audit_after = {
+        "message_count": conversation_message_count - 1,
+        "token_usage": conversation_token_usage - tokens_to_remove,
+        "updated_at": updated_at.isoformat(),
+    }
+
     await Conversation.filter(id=conversation.id).update(
         message_count=F("message_count") - 1,
         token_usage=F("token_usage") - tokens_to_remove,
-        updated_at=now_utc(),
+        updated_at=updated_at,
     )
 
     # Delete message
     await message.delete()
+
+    await AuditLogService.log(
+        user=current_user,
+        action="delete_message",
+        resource_type="message",
+        resource_id=message_id,
+        resource_name=getattr(conversation, "title", None) or str(conversation_id),
+        operation="delete",
+        status="success",
+        request=request,
+        changes={"before": audit_before, "after": audit_after},
+        metadata={"conversation_id": str(conversation_id)},
+    )
 
     return success(data={"id": str(message_id)}, msg_key="message_deleted")

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -52,6 +52,7 @@ from app.services.audit_log import AuditLogService
 from app.services.auto_notification import AutoNotificationService
 from app.models.notification import AutoNotificationType
 from app.core.i18n import t
+from app.core.timezone import now_utc
 from app.api.v1.endpoints.chat import build_message_round_payloads
 from app.services.message_branching import get_visible_conversation_messages
 
@@ -1270,6 +1271,7 @@ async def delete_message(
     await Conversation.filter(id=conversation.id).update(
         message_count=F("message_count") - 1,
         token_usage=F("token_usage") - tokens_to_remove,
+        updated_at=now_utc(),
     )
 
     # Delete message

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -1251,25 +1251,6 @@ async def delete_message(
             status_code=404,
         )
 
-    message = await Message.filter(
-        id=message_id,
-        conversation_id=conversation_id,
-    ).first()
-
-    if not message:
-        raise BusinessError(
-            code=ResponseCode.MESSAGE_NOT_FOUND,
-            msg_key="message_not_found",
-            status_code=404,
-        )
-
-    # Update stats atomically to prevent race conditions
-    tokens_to_remove = 0
-    if message.token_usage:
-        tokens_to_remove = message.token_usage.get(
-            "prompt", 0
-        ) + message.token_usage.get("completion", 0)
-
     async with in_transaction() as conn:
         locked_conversation = await (
             Conversation.filter(id=conversation.id)
@@ -1284,6 +1265,28 @@ async def delete_message(
                 status_code=404,
             )
 
+        locked_message = await (
+            Message.filter(
+                id=message_id,
+                conversation_id=locked_conversation.id,
+            )
+            .using_db(conn)
+            .select_for_update()
+            .first()
+        )
+        if not locked_message:
+            raise BusinessError(
+                code=ResponseCode.MESSAGE_NOT_FOUND,
+                msg_key="message_not_found",
+                status_code=404,
+            )
+
+        tokens_to_remove = 0
+        if locked_message.token_usage:
+            tokens_to_remove = locked_message.token_usage.get(
+                "prompt", 0
+            ) + locked_message.token_usage.get("completion", 0)
+
         audit_before = AuditLogService.snapshot(locked_conversation, "conversation")
         updated_at = now_utc()
         await (
@@ -1297,9 +1300,7 @@ async def delete_message(
         )
         await locked_conversation.refresh_from_db(using_db=conn)
         audit_after = AuditLogService.snapshot(locked_conversation, "conversation")
-
-    # Delete message
-    await message.delete()
+        await locked_message.delete(using_db=conn)
 
     await AuditLogService.log(
         user=current_user,

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Query, Request
 from tortoise.expressions import F, Q
 from tortoise.functions import Count
+from tortoise.transactions import in_transaction
 
 from app.api import deps
 from app.api.team_access import check_team_access
@@ -1269,28 +1270,33 @@ async def delete_message(
             "prompt", 0
         ) + message.token_usage.get("completion", 0)
 
-    conversation_message_count = getattr(conversation, "message_count", 0) or 0
-    conversation_token_usage = getattr(conversation, "token_usage", 0) or 0
-    conversation_updated_at = getattr(conversation, "updated_at", None)
-    audit_before = {
-        "message_count": conversation_message_count,
-        "token_usage": conversation_token_usage,
-        "updated_at": (
-            conversation_updated_at.isoformat() if conversation_updated_at else None
-        ),
-    }
-    updated_at = now_utc()
-    audit_after = {
-        "message_count": conversation_message_count - 1,
-        "token_usage": conversation_token_usage - tokens_to_remove,
-        "updated_at": updated_at.isoformat(),
-    }
+    async with in_transaction() as conn:
+        locked_conversation = await (
+            Conversation.filter(id=conversation.id)
+            .using_db(conn)
+            .select_for_update()
+            .first()
+        )
+        if not locked_conversation:
+            raise BusinessError(
+                code=ResponseCode.CONVERSATION_NOT_FOUND,
+                msg_key="conversation_not_found",
+                status_code=404,
+            )
 
-    await Conversation.filter(id=conversation.id).update(
-        message_count=F("message_count") - 1,
-        token_usage=F("token_usage") - tokens_to_remove,
-        updated_at=updated_at,
-    )
+        audit_before = AuditLogService.snapshot(locked_conversation, "conversation")
+        updated_at = now_utc()
+        await (
+            Conversation.filter(id=locked_conversation.id)
+            .using_db(conn)
+            .update(
+                message_count=F("message_count") - 1,
+                token_usage=F("token_usage") - tokens_to_remove,
+                updated_at=updated_at,
+            )
+        )
+        await locked_conversation.refresh_from_db(using_db=conn)
+        audit_after = AuditLogService.snapshot(locked_conversation, "conversation")
 
     # Delete message
     await message.delete()
@@ -1300,11 +1306,12 @@ async def delete_message(
         action="delete_message",
         resource_type="message",
         resource_id=message_id,
-        resource_name=getattr(conversation, "title", None) or str(conversation_id),
+        resource_name=getattr(locked_conversation, "title", None)
+        or str(conversation_id),
         operation="delete",
         status="success",
         request=request,
-        changes={"before": audit_before, "after": audit_after},
+        changes=AuditLogService.build_changes(audit_before, audit_after),
         metadata={"conversation_id": str(conversation_id)},
     )
 

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -135,13 +135,28 @@ def _calculate_model_usage(
     usage: Any | None,
     model_id: str | None,
     provider: str | None,
-) -> tuple[int, int]:
-    """Prefer provider totals and estimate only when they are unavailable."""
+) -> tuple[int, int, int, int, int]:
+    """Prefer provider totals and estimate only when they are unavailable.
+
+    Returns (prompt, completion, cache_read, cache_creation, total_input).
+    """
     prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
     completion_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
+    cache_read_tokens = int(getattr(usage, "cache_read_tokens", 0) or 0)
+    cache_creation_tokens = int(getattr(usage, "cache_creation_tokens", 0) or 0)
+    total_input_tokens = int(getattr(usage, "total_input_tokens", 0) or prompt_tokens)
     if prompt_tokens or completion_tokens:
-        return prompt_tokens, completion_tokens
+        return (
+            prompt_tokens,
+            completion_tokens,
+            cache_read_tokens,
+            cache_creation_tokens,
+            total_input_tokens,
+        )
 
+    estimated_prompt_tokens = count_message_tokens(
+        messages, model_id, provider, include_tool_calls=True
+    ) + count_tool_definition_tokens(tools, model_id, provider)
     estimated_completion_tokens = count_tokens(
         content or "", model_id, provider
     ) + count_tokens(reasoning_content or "", model_id, provider)
@@ -151,9 +166,11 @@ def _calculate_model_usage(
         )
 
     return (
-        count_message_tokens(messages, model_id, provider, include_tool_calls=True)
-        + count_tool_definition_tokens(tools, model_id, provider),
+        estimated_prompt_tokens,
         estimated_completion_tokens,
+        cache_read_tokens,
+        cache_creation_tokens,
+        estimated_prompt_tokens,
     )
 
 
@@ -1415,6 +1432,9 @@ async def chat(
         final_response = None
         total_prompt_tokens = 0
         total_completion_tokens = 0
+        total_cache_read_tokens = 0
+        total_cache_creation_tokens = 0
+        total_usage_input_tokens = 0
         max_iterations_reached = False
 
         while iteration < max_iterations:
@@ -1515,7 +1535,13 @@ async def chat(
                     tools=tools,
                 )
 
-            prompt_tokens, completion_tokens = _calculate_model_usage(
+            (
+                prompt_tokens,
+                completion_tokens,
+                cache_read_tokens,
+                cache_creation_tokens,
+                iteration_total_input_tokens,
+            ) = _calculate_model_usage(
                 tools=tools,
                 messages=messages_for_llm,
                 content=response.content,
@@ -1527,6 +1553,9 @@ async def chat(
             )
             total_prompt_tokens += prompt_tokens
             total_completion_tokens += completion_tokens
+            total_cache_read_tokens += cache_read_tokens
+            total_cache_creation_tokens += cache_creation_tokens
+            total_usage_input_tokens += iteration_total_input_tokens
 
             if response.tool_calls:
 
@@ -1705,6 +1734,9 @@ async def chat(
             token_usage={
                 "prompt": prompt_tokens,
                 "completion": completion_tokens,
+                "cache_read": total_cache_read_tokens,
+                "cache_creation": total_cache_creation_tokens,
+                "total_input": total_usage_input_tokens,
             },
             duration_ms=duration_ms,
             tool_calls=final_tool_calls,
@@ -1722,6 +1754,8 @@ async def chat(
             token_usage={
                 "prompt": prompt_tokens,
                 "completion": completion_tokens,
+                "cache_read": total_cache_read_tokens,
+                "cache_creation": total_cache_creation_tokens,
             },
         )
 
@@ -1755,6 +1789,9 @@ async def chat(
                     "prompt_tokens": prompt_tokens,
                     "completion_tokens": completion_tokens,
                     "total_tokens": prompt_tokens + completion_tokens,
+                    "cache_read_tokens": total_cache_read_tokens,
+                    "cache_creation_tokens": total_cache_creation_tokens,
+                    "total_input_tokens": total_usage_input_tokens,
                 },
             ),
             msg_key="chat_success",
@@ -2052,6 +2089,9 @@ async def chat_stream(
                     max_iterations_reached = False
                     aggregate_input_tokens = 0
                     aggregate_output_tokens = 0
+                    aggregate_cache_read_tokens = 0
+                    aggregate_cache_creation_tokens = 0
+                    aggregate_total_input_tokens = 0
 
                     while iteration < max_iterations:
                         iteration += 1
@@ -2259,6 +2299,10 @@ async def chat_stream(
                                         yield f"event: {SSEEventType.REASONING_END}\ndata: {json.dumps({})}\n\n"
                                     if chunk.finish_reason == FinishReason.LENGTH:
                                         yield f"event: {SSEEventType.OUTPUT_TRUNCATED}\ndata: {json.dumps({})}\n\n"
+                                    # OpenAI/DeepSeek 等端点的 usage 在 finish 之后的独立 chunk 上；
+                                    # finish chunk 未携带 usage 时继续消费以捕获终末 usage（流随后自然结束）
+                                    if stream_usage is None:
+                                        continue
                                     break
                         except ContextLengthError as context_error:
                             if (
@@ -2373,6 +2417,10 @@ async def chat_stream(
                                         yield f"event: {SSEEventType.REASONING_END}\ndata: {json.dumps({})}\n\n"
                                     if chunk.finish_reason == FinishReason.LENGTH:
                                         yield f"event: {SSEEventType.OUTPUT_TRUNCATED}\ndata: {json.dumps({})}\n\n"
+                                    # OpenAI/DeepSeek 等端点的 usage 在 finish 之后的独立 chunk 上；
+                                    # finish chunk 未携带 usage 时继续消费以捕获终末 usage（流随后自然结束）
+                                    if stream_usage is None:
+                                        continue
                                     break
 
                         # Fallback: if stream yields nothing and no tool calls, do a non-stream call
@@ -2407,20 +2455,29 @@ async def chat_stream(
                                     first_token_time = time.time()
                                 yield f"event: {SSEEventType.CONTENT_DELTA}\ndata: {json.dumps({'delta': response.content})}\n\n"
 
-                        iteration_input_tokens, iteration_output_tokens = (
-                            _calculate_model_usage(
-                                tools=tools,
-                                messages=messages_for_llm,
-                                content=iteration_content,
-                                reasoning_content=iteration_reasoning,
-                                tool_calls=collected_tool_calls,
-                                usage=stream_usage,
-                                model_id=tokenizer_model_id,
-                                provider=model_provider,
-                            )
+                        (
+                            iteration_input_tokens,
+                            iteration_output_tokens,
+                            iteration_cache_read_tokens,
+                            iteration_cache_creation_tokens,
+                            iteration_total_input_tokens,
+                        ) = _calculate_model_usage(
+                            tools=tools,
+                            messages=messages_for_llm,
+                            content=iteration_content,
+                            reasoning_content=iteration_reasoning,
+                            tool_calls=collected_tool_calls,
+                            usage=stream_usage,
+                            model_id=tokenizer_model_id,
+                            provider=model_provider,
                         )
                         aggregate_input_tokens += iteration_input_tokens
                         aggregate_output_tokens += iteration_output_tokens
+                        aggregate_cache_read_tokens += iteration_cache_read_tokens
+                        aggregate_cache_creation_tokens += (
+                            iteration_cache_creation_tokens
+                        )
+                        aggregate_total_input_tokens += iteration_total_input_tokens
                         if not used_nonstream_fallback:
                             await model_manager.record_stream_usage(
                                 team_id=str(agent.team_id),
@@ -2693,6 +2750,9 @@ async def chat_stream(
                     assistant_msg.token_usage = {
                         "prompt": input_tokens,
                         "completion": output_tokens,
+                        "cache_read": aggregate_cache_read_tokens,
+                        "cache_creation": aggregate_cache_creation_tokens,
+                        "total_input": aggregate_total_input_tokens,
                     }
                     await assistant_msg.save()
                     branch_prefix = await get_prefix_path_before(user_msg)
@@ -2737,7 +2797,7 @@ async def chat_stream(
                         if duration_ms > 0 and output_tokens > 0
                         else None
                     )
-                    yield f"event: {SSEEventType.MESSAGE_END}\ndata: {json.dumps({'usage': {'prompt_tokens': input_tokens, 'completion_tokens': output_tokens, 'total_tokens': input_tokens + output_tokens}, 'timing': {'first_token_ms': first_token_ms, 'duration_ms': duration_ms, 'tokens_per_second': tokens_per_second}, 'version_number': 1, 'version_count': 1})}\n\n"
+                    yield f"event: {SSEEventType.MESSAGE_END}\ndata: {json.dumps({'usage': {'prompt_tokens': input_tokens, 'completion_tokens': output_tokens, 'total_tokens': input_tokens + output_tokens, 'cache_read_tokens': aggregate_cache_read_tokens, 'cache_creation_tokens': aggregate_cache_creation_tokens, 'total_input_tokens': aggregate_total_input_tokens}, 'timing': {'first_token_ms': first_token_ms, 'duration_ms': duration_ms, 'tokens_per_second': tokens_per_second}, 'version_number': 1, 'version_count': 1})}\n\n"
 
                 except (QuotaExceededError, InsufficientQuotaError) as e:
                     await persist_partial_round_error(
@@ -3444,6 +3504,9 @@ async def edit_user_message_stream(
                     working_history_override: list[dict[str, Any]] | None = None
                     aggregate_input_tokens = 0
                     aggregate_output_tokens = 0
+                    aggregate_cache_read_tokens = 0
+                    aggregate_cache_creation_tokens = 0
+                    aggregate_total_input_tokens = 0
                     created_message_count = 2
 
                     while iteration < max_iterations:
@@ -3610,6 +3673,10 @@ async def edit_user_message_stream(
                                         yield f"event: {SSEEventType.REASONING_END}\ndata: {json.dumps({})}\n\n"
                                     if chunk.finish_reason == FinishReason.LENGTH:
                                         yield f"event: {SSEEventType.OUTPUT_TRUNCATED}\ndata: {json.dumps({})}\n\n"
+                                    # OpenAI/DeepSeek 等端点的 usage 在 finish 之后的独立 chunk 上；
+                                    # finish chunk 未携带 usage 时继续消费以捕获终末 usage（流随后自然结束）
+                                    if stream_usage is None:
+                                        continue
                                     break
                         except ContextLengthError as context_error:
                             if (
@@ -3704,22 +3771,33 @@ async def edit_user_message_stream(
                                         yield f"event: {SSEEventType.REASONING_END}\ndata: {json.dumps({})}\n\n"
                                     if chunk.finish_reason == FinishReason.LENGTH:
                                         yield f"event: {SSEEventType.OUTPUT_TRUNCATED}\ndata: {json.dumps({})}\n\n"
-                                    break
-
-                        iteration_input_tokens, iteration_output_tokens = (
-                            _calculate_model_usage(
-                                tools=tools,
-                                messages=messages_for_llm,
-                                content=full_content,
-                                reasoning_content=full_reasoning,
-                                tool_calls=collected_tool_calls,
-                                usage=stream_usage,
-                                model_id=tokenizer_model_id,
-                                provider=model_provider,
-                            )
+                                    # OpenAI/DeepSeek 等端点的 usage 在 finish 之后的独立 chunk 上；
+                                    # finish chunk 未携带 usage 时继续消费以捕获终末 usage（流随后自然结束）
+                                    if stream_usage is None:
+                                        continue
+                        (
+                            iteration_input_tokens,
+                            iteration_output_tokens,
+                            iteration_cache_read_tokens,
+                            iteration_cache_creation_tokens,
+                            iteration_total_input_tokens,
+                        ) = _calculate_model_usage(
+                            tools=tools,
+                            messages=messages_for_llm,
+                            content=full_content,
+                            reasoning_content=full_reasoning,
+                            tool_calls=collected_tool_calls,
+                            usage=stream_usage,
+                            model_id=tokenizer_model_id,
+                            provider=model_provider,
                         )
                         aggregate_input_tokens += iteration_input_tokens
                         aggregate_output_tokens += iteration_output_tokens
+                        aggregate_cache_read_tokens += iteration_cache_read_tokens
+                        aggregate_cache_creation_tokens += (
+                            iteration_cache_creation_tokens
+                        )
+                        aggregate_total_input_tokens += iteration_total_input_tokens
 
                         if client_disconnected:
                             assistant_msg.content = full_content
@@ -3944,6 +4022,9 @@ async def edit_user_message_stream(
                     assistant_msg.token_usage = {
                         "prompt": input_tokens,
                         "completion": output_tokens,
+                        "cache_read": aggregate_cache_read_tokens,
+                        "cache_creation": aggregate_cache_creation_tokens,
+                        "total_input": aggregate_total_input_tokens,
                     }
                     await assistant_msg.save()
                     await activate_edited_path()
@@ -3996,7 +4077,7 @@ async def edit_user_message_stream(
                         )
                     except Exception:
                         logger.exception("Failed to write message edit audit log")
-                    yield f"event: {SSEEventType.MESSAGE_END}\ndata: {json.dumps({'usage': {'prompt_tokens': input_tokens, 'completion_tokens': output_tokens, 'total_tokens': total_tokens}, 'timing': {'first_token_ms': assistant_msg.first_token_ms, 'duration_ms': duration_ms, 'tokens_per_second': tokens_per_second}, 'edited_version_number': new_user_version_number, 'edited_version_count': new_user_version_number})}\n\n"
+                    yield f"event: {SSEEventType.MESSAGE_END}\ndata: {json.dumps({'usage': {'prompt_tokens': input_tokens, 'completion_tokens': output_tokens, 'total_tokens': total_tokens, 'cache_read_tokens': aggregate_cache_read_tokens, 'cache_creation_tokens': aggregate_cache_creation_tokens, 'total_input_tokens': aggregate_total_input_tokens}, 'timing': {'first_token_ms': assistant_msg.first_token_ms, 'duration_ms': duration_ms, 'tokens_per_second': tokens_per_second}, 'edited_version_number': new_user_version_number, 'edited_version_count': new_user_version_number})}\n\n"
                 except (QuotaExceededError, InsufficientQuotaError) as e:
                     logger.warning(
                         "Quota exceeded during message edit: conversation=%s agent=%s error=%s",
@@ -4472,6 +4553,9 @@ async def regenerate_message(
                     max_iterations_reached = False
                     aggregate_input_tokens = 0
                     aggregate_output_tokens = 0
+                    aggregate_cache_read_tokens = 0
+                    aggregate_cache_creation_tokens = 0
+                    aggregate_total_input_tokens = 0
 
                     while iteration < max_iterations:
                         iteration += 1
@@ -4656,6 +4740,10 @@ async def regenerate_message(
                                         yield f"event: {SSEEventType.REASONING_END}\ndata: {json.dumps({})}\n\n"
                                     if chunk.finish_reason == FinishReason.LENGTH:
                                         yield f"event: {SSEEventType.OUTPUT_TRUNCATED}\ndata: {json.dumps({})}\n\n"
+                                    # OpenAI/DeepSeek 等端点的 usage 在 finish 之后的独立 chunk 上；
+                                    # finish chunk 未携带 usage 时继续消费以捕获终末 usage（流随后自然结束）
+                                    if stream_usage is None:
+                                        continue
                                     break
                         except ContextLengthError as context_error:
                             if (
@@ -4759,22 +4847,33 @@ async def regenerate_message(
                                         yield f"event: {SSEEventType.REASONING_END}\ndata: {json.dumps({})}\n\n"
                                     if chunk.finish_reason == FinishReason.LENGTH:
                                         yield f"event: {SSEEventType.OUTPUT_TRUNCATED}\ndata: {json.dumps({})}\n\n"
-                                    break
-
-                        iteration_input_tokens, iteration_output_tokens = (
-                            _calculate_model_usage(
-                                tools=tools,
-                                messages=messages_for_llm,
-                                content=full_content,
-                                reasoning_content=full_reasoning,
-                                tool_calls=collected_tool_calls,
-                                usage=stream_usage,
-                                model_id=tokenizer_model_id,
-                                provider=model_provider,
-                            )
+                                    # OpenAI/DeepSeek 等端点的 usage 在 finish 之后的独立 chunk 上；
+                                    # finish chunk 未携带 usage 时继续消费以捕获终末 usage（流随后自然结束）
+                                    if stream_usage is None:
+                                        continue
+                        (
+                            iteration_input_tokens,
+                            iteration_output_tokens,
+                            iteration_cache_read_tokens,
+                            iteration_cache_creation_tokens,
+                            iteration_total_input_tokens,
+                        ) = _calculate_model_usage(
+                            tools=tools,
+                            messages=messages_for_llm,
+                            content=full_content,
+                            reasoning_content=full_reasoning,
+                            tool_calls=collected_tool_calls,
+                            usage=stream_usage,
+                            model_id=tokenizer_model_id,
+                            provider=model_provider,
                         )
                         aggregate_input_tokens += iteration_input_tokens
                         aggregate_output_tokens += iteration_output_tokens
+                        aggregate_cache_read_tokens += iteration_cache_read_tokens
+                        aggregate_cache_creation_tokens += (
+                            iteration_cache_creation_tokens
+                        )
+                        aggregate_total_input_tokens += iteration_total_input_tokens
 
                         # If client disconnected, save current stopped state and exit
                         if client_disconnected:
@@ -5020,6 +5119,9 @@ async def regenerate_message(
                     new_message.token_usage = {
                         "prompt": input_tokens,
                         "completion": output_tokens,
+                        "cache_read": aggregate_cache_read_tokens,
+                        "cache_creation": aggregate_cache_creation_tokens,
+                        "total_input": aggregate_total_input_tokens,
                     }
                     await new_message.save()
                     prefix = await get_prefix_path_before(new_message)
@@ -5054,7 +5156,7 @@ async def regenerate_message(
                         if duration_ms > 0 and output_tokens > 0
                         else None
                     )
-                    yield f"event: {SSEEventType.MESSAGE_END}\ndata: {json.dumps({'usage': {'prompt_tokens': input_tokens, 'completion_tokens': output_tokens, 'total_tokens': input_tokens + output_tokens}, 'timing': {'first_token_ms': first_token_ms, 'duration_ms': duration_ms, 'tokens_per_second': tokens_per_second}, 'version_number': effective_version_number, 'version_count': effective_version_count})}\n\n"
+                    yield f"event: {SSEEventType.MESSAGE_END}\ndata: {json.dumps({'usage': {'prompt_tokens': input_tokens, 'completion_tokens': output_tokens, 'total_tokens': input_tokens + output_tokens, 'cache_read_tokens': aggregate_cache_read_tokens, 'cache_creation_tokens': aggregate_cache_creation_tokens, 'total_input_tokens': aggregate_total_input_tokens}, 'timing': {'first_token_ms': first_token_ms, 'duration_ms': duration_ms, 'tokens_per_second': tokens_per_second}, 'version_number': effective_version_number, 'version_count': effective_version_count})}\n\n"
 
                 except (QuotaExceededError, InsufficientQuotaError) as e:
                     logger.warning(

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -60,6 +60,12 @@ from app.schemas.response import (
 from app.llm.errors import ContextLengthError, InsufficientQuotaError
 from app.llm.tools import tool_registry
 from app.llm.types import ChatStreamChunk, Message as LLMChatMessage, ToolCall
+from app.llm.token_counter import (
+    count_message_tokens,
+    count_tokens,
+    count_tool_definition_tokens,
+    serialize_tool_calls,
+)
 from app.core.timezone import now_utc
 from app.services.chat_context import (
     build_model_messages,
@@ -117,6 +123,38 @@ logger = logging.getLogger(__name__)
 GENERIC_STREAM_ERROR_KEY = "unknown_error"
 AUTO_RAG_HISTORY_LIMIT = 6
 AUDIT_MESSAGE_CONTENT_PREVIEW_LENGTH = 500
+
+
+def _calculate_model_usage(
+    *,
+    messages: list[dict[str, Any]],
+    content: str | None,
+    reasoning_content: str | None,
+    tool_calls: list[Any] | None,
+    tools: list[Any] | None,
+    usage: Any | None,
+    model_id: str | None,
+    provider: str | None,
+) -> tuple[int, int]:
+    """Prefer provider totals and estimate only when they are unavailable."""
+    prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
+    completion_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
+    if prompt_tokens or completion_tokens:
+        return prompt_tokens, completion_tokens
+
+    estimated_completion_tokens = count_tokens(
+        content or "", model_id, provider
+    ) + count_tokens(reasoning_content or "", model_id, provider)
+    if tool_calls:
+        estimated_completion_tokens += count_tokens(
+            serialize_tool_calls(tool_calls), model_id, provider
+        )
+
+    return (
+        count_message_tokens(messages, model_id, provider, include_tool_calls=True)
+        + count_tool_definition_tokens(tools, model_id, provider),
+        estimated_completion_tokens,
+    )
 
 
 async def _append_asset_manifest(
@@ -1428,10 +1466,14 @@ async def chat(
                     protected_round_id=round_id,
                 )
                 context_retry_used = True
+            messages_for_llm = [
+                message.model_dump(exclude_none=True)
+                for message in prepared_context.messages
+            ]
             try:
                 response = await model_manager.team_chat(
                     team_id=str(agent.team_id),
-                    messages=[m.model_dump() for m in prepared_context.messages],
+                    messages=messages_for_llm,
                     model_id=model_id,
                     tools=tools,
                 )
@@ -1462,16 +1504,29 @@ async def chat(
                     protected_round_id=round_id,
                 )
                 context_retry_used = True
+                messages_for_llm = [
+                    message.model_dump(exclude_none=True)
+                    for message in prepared_context.messages
+                ]
                 response = await model_manager.team_chat(
                     team_id=str(agent.team_id),
-                    messages=[m.model_dump() for m in prepared_context.messages],
+                    messages=messages_for_llm,
                     model_id=model_id,
                     tools=tools,
                 )
 
-            if response.usage:
-                total_prompt_tokens += response.usage.prompt_tokens or 0
-                total_completion_tokens += response.usage.completion_tokens or 0
+            prompt_tokens, completion_tokens = _calculate_model_usage(
+                tools=tools,
+                messages=messages_for_llm,
+                content=response.content,
+                reasoning_content=response.reasoning_content,
+                tool_calls=response.tool_calls,
+                usage=response.usage,
+                model_id=tokenizer_model_id,
+                provider=model_provider,
+            )
+            total_prompt_tokens += prompt_tokens
+            total_completion_tokens += completion_tokens
 
             if response.tool_calls:
 
@@ -1681,11 +1736,9 @@ async def chat(
         await Conversation.filter(id=conversation.id).update(
             message_count=F("message_count") + 2,
             token_usage=F("token_usage") + (prompt_tokens + completion_tokens),
+            updated_at=now_utc(),
             **title_update,
         )
-
-        # Update agent stats atomically
-        await Agent.filter(id=agent.id).update(message_count=F("message_count") + 2)
 
         branch_prefix = await get_prefix_path_before(user_msg)
         await activate_conversation_branch(
@@ -1997,6 +2050,8 @@ async def chat_stream(
                     max_iterations = agent.max_iterations or 5
                     iteration = 0
                     max_iterations_reached = False
+                    aggregate_input_tokens = 0
+                    aggregate_output_tokens = 0
 
                     while iteration < max_iterations:
                         iteration += 1
@@ -2041,6 +2096,8 @@ async def chat_stream(
                         iteration_content = ""
                         iteration_reasoning = ""
                         collected_tool_calls = []  # For collecting tool calls from stream
+                        stream_usage = None
+                        used_nonstream_fallback = False
 
                         prepare_context = prepare_model_context
                         context_retry_used = False
@@ -2128,13 +2185,8 @@ async def chat_stream(
                             for message in prepared_context.messages
                         ]
 
-                        # Calculate input chars for this iteration
-                        iteration_input_chars = sum(
-                            len(m.get("content") or "")
-                            if isinstance(m.get("content"), str)
-                            else 0
-                            for m in messages_for_llm
-                        )
+                        # Provider usage is captured from the terminal chunk;
+                        # exact local counting remains the fallback.
 
                         # Use streaming call - works for both with and without tools
                         emitted_any = False
@@ -2151,6 +2203,8 @@ async def chat_stream(
                                 timeout_seconds=idle_timeout,
                                 activity_predicate=_is_model_stream_activity,
                             ):
+                                if chunk.usage:
+                                    stream_usage = chunk.usage
                                 # Check if client disconnected - stop LLM generation to save tokens
                                 if await request.is_disconnected():
                                     client_disconnected = True
@@ -2254,12 +2308,8 @@ async def chat_stream(
                                 message.model_dump(exclude_none=True)
                                 for message in prepared_context.messages
                             ]
-                            iteration_input_chars = sum(
-                                len(m.get("content") or "")
-                                if isinstance(m.get("content"), str)
-                                else 0
-                                for m in messages_for_llm
-                            )
+                            # The retry uses a distinct, freshly prepared prompt.
+                            stream_usage = None
                             emitted_any = False
                             client_disconnected = False
                             stream = model_manager.team_chat_stream(
@@ -2273,6 +2323,8 @@ async def chat_stream(
                                 timeout_seconds=idle_timeout,
                                 activity_predicate=_is_model_stream_activity,
                             ):
+                                if chunk.usage:
+                                    stream_usage = chunk.usage
                                 if await request.is_disconnected():
                                     client_disconnected = True
                                     logger.info(
@@ -2335,7 +2387,12 @@ async def chat_stream(
                                 model_id=model_id,
                                 tools=tools,
                             )
-                            if response.reasoning_content:
+                            used_nonstream_fallback = True
+                            stream_usage = getattr(response, "usage", None)
+                            collected_tool_calls = (
+                                getattr(response, "tool_calls", None) or []
+                            )
+                            if getattr(response, "reasoning_content", None):
                                 yield f"event: {SSEEventType.REASONING_START}\ndata: {json.dumps({})}\n\n"
                                 full_reasoning += response.reasoning_content
                                 iteration_reasoning += response.reasoning_content
@@ -2343,26 +2400,37 @@ async def chat_stream(
                                     first_token_time = time.time()
                                 yield f"event: {SSEEventType.REASONING_DELTA}\ndata: {json.dumps({'delta': response.reasoning_content})}\n\n"
                                 yield f"event: {SSEEventType.REASONING_END}\ndata: {json.dumps({})}\n\n"
-                            if response.content:
+                            if getattr(response, "content", None):
                                 full_content += response.content
                                 iteration_content += response.content
                                 if first_token_time is None:
                                     first_token_time = time.time()
                                 yield f"event: {SSEEventType.CONTENT_DELTA}\ndata: {json.dumps({'delta': response.content})}\n\n"
 
-                        # If client disconnected, save partial content and exit
-                        if client_disconnected:
-                            # Record usage for partial generation
-                            iteration_output_chars = len(iteration_content) + len(
-                                iteration_reasoning
+                        iteration_input_tokens, iteration_output_tokens = (
+                            _calculate_model_usage(
+                                tools=tools,
+                                messages=messages_for_llm,
+                                content=iteration_content,
+                                reasoning_content=iteration_reasoning,
+                                tool_calls=collected_tool_calls,
+                                usage=stream_usage,
+                                model_id=tokenizer_model_id,
+                                provider=model_provider,
                             )
-                            if iteration_output_chars > 0:
-                                await model_manager.record_stream_usage(
-                                    team_id=str(agent.team_id),
-                                    model_id=model_id,
-                                    input_text_length=iteration_input_chars,
-                                    output_text_length=iteration_output_chars,
-                                )
+                        )
+                        aggregate_input_tokens += iteration_input_tokens
+                        aggregate_output_tokens += iteration_output_tokens
+                        if not used_nonstream_fallback:
+                            await model_manager.record_stream_usage(
+                                team_id=str(agent.team_id),
+                                model_id=model_id,
+                                input_tokens=iteration_input_tokens,
+                                output_tokens=iteration_output_tokens,
+                            )
+
+                        # If client disconnected, save partial content and exit.
+                        if client_disconnected:
                             assistant_msg.content = full_content
                             assistant_msg.reasoning_content = (
                                 full_reasoning if full_reasoning else None
@@ -2380,18 +2448,7 @@ async def chat_stream(
                             )
                             assistant_msg.created_at = now_utc()
                             await assistant_msg.save()
-                            return  # Exit generator - client is gone
-
-                        # Record usage for this iteration (important: do this after each stream ends)
-                        iteration_output_chars = len(iteration_content) + len(
-                            iteration_reasoning
-                        )
-                        await model_manager.record_stream_usage(
-                            team_id=str(agent.team_id),
-                            model_id=model_id,
-                            input_text_length=iteration_input_chars,
-                            output_text_length=iteration_output_chars,
-                        )
+                            return
 
                         # Check if there are tool calls to execute
                         if collected_tool_calls:
@@ -2631,42 +2688,8 @@ async def chat_stream(
                     assistant_msg.round_status = terminal_round_status
                     # Ensure assistant message appears after tool calls/results in history
                     assistant_msg.created_at = now_utc()
-                    # Estimate token usage
-                    final_prepared_context = await prepare_model_context(
-                        agent=agent,
-                        conversation=conversation,
-                        user_message=model_message,
-                        model_id=model_id,
-                        tokenizer_model_id=tokenizer_model_id,
-                        model_context_limit=model_context_limit,
-                        model_max_output_tokens=model_max_output_tokens,
-                        provider=model_provider,
-                        file_content=file_content_str,
-                        user_locale=current_user.locale,
-                        history_override=working_history_override,
-                        current_images=image_pool,
-                        model_supports_vision=model_supports_vision,
-                        current_user_message_id=user_msg.id,
-                        include_current_user_message=True,
-                        exclude_message_ids=[assistant_msg.id],
-                        tool_timeouts=tool_timeouts,
-                        user=current_user,
-                        protected_round_id=round_id,
-                    )
-                    input_tokens = sum(
-                        len(message_content or "") // 4
-                        for message_content in (
-                            message.get("content")
-                            if isinstance(message, dict)
-                            else None
-                            for message in [
-                                item.model_dump(exclude_none=True)
-                                for item in final_prepared_context.messages
-                            ]
-                        )
-                        if isinstance(message_content, str)
-                    )
-                    output_tokens = len(terminal_content) // 4
+                    input_tokens = aggregate_input_tokens
+                    output_tokens = aggregate_output_tokens
                     assistant_msg.token_usage = {
                         "prompt": input_tokens,
                         "completion": output_tokens,
@@ -2691,6 +2714,7 @@ async def chat_stream(
                     await Conversation.filter(id=conversation.id).update(
                         message_count=F("message_count") + 2,
                         token_usage=F("token_usage") + (input_tokens + output_tokens),
+                        updated_at=now_utc(),
                         **title_update,
                     )
 
@@ -3420,7 +3444,6 @@ async def edit_user_message_stream(
                     working_history_override: list[dict[str, Any]] | None = None
                     aggregate_input_tokens = 0
                     aggregate_output_tokens = 0
-                    terminal_input_tokens = 0
                     created_message_count = 2
 
                     while iteration < max_iterations:
@@ -3536,14 +3559,7 @@ async def edit_user_message_stream(
                             item.model_dump(exclude_none=True)
                             for item in prepared_context.messages
                         ]
-                        iteration_input_tokens = sum(
-                            len(message_content or "") // 4
-                            for message_content in (
-                                item.get("content") if isinstance(item, dict) else None
-                                for item in messages_for_llm
-                            )
-                            if isinstance(message_content, str)
-                        )
+                        stream_usage = None
 
                         try:
                             stream = model_manager.team_chat_stream(
@@ -3557,6 +3573,8 @@ async def edit_user_message_stream(
                                 timeout_seconds=idle_timeout,
                                 activity_predicate=_is_model_stream_activity,
                             ):
+                                if chunk.usage:
+                                    stream_usage = chunk.usage
                                 if await request.is_disconnected():
                                     client_disconnected = True
                                     break
@@ -3637,16 +3655,7 @@ async def edit_user_message_stream(
                                 item.model_dump(exclude_none=True)
                                 for item in prepared_context.messages
                             ]
-                            iteration_input_tokens = sum(
-                                len(message_content or "") // 4
-                                for message_content in (
-                                    item.get("content")
-                                    if isinstance(item, dict)
-                                    else None
-                                    for item in messages_for_llm
-                                )
-                                if isinstance(message_content, str)
-                            )
+                            stream_usage = None
                             stream = model_manager.team_chat_stream(
                                 team_id=str(agent.team_id),
                                 messages=messages_for_llm,
@@ -3658,6 +3667,8 @@ async def edit_user_message_stream(
                                 timeout_seconds=idle_timeout,
                                 activity_predicate=_is_model_stream_activity,
                             ):
+                                if chunk.usage:
+                                    stream_usage = chunk.usage
                                 if await request.is_disconnected():
                                     client_disconnected = True
                                     break
@@ -3695,6 +3706,21 @@ async def edit_user_message_stream(
                                         yield f"event: {SSEEventType.OUTPUT_TRUNCATED}\ndata: {json.dumps({})}\n\n"
                                     break
 
+                        iteration_input_tokens, iteration_output_tokens = (
+                            _calculate_model_usage(
+                                tools=tools,
+                                messages=messages_for_llm,
+                                content=full_content,
+                                reasoning_content=full_reasoning,
+                                tool_calls=collected_tool_calls,
+                                usage=stream_usage,
+                                model_id=tokenizer_model_id,
+                                provider=model_provider,
+                            )
+                        )
+                        aggregate_input_tokens += iteration_input_tokens
+                        aggregate_output_tokens += iteration_output_tokens
+
                         if client_disconnected:
                             assistant_msg.content = full_content
                             assistant_msg.reasoning_content = full_reasoning or None
@@ -3715,8 +3741,6 @@ async def edit_user_message_stream(
                             return
 
                         if collected_tool_calls:
-                            aggregate_input_tokens += iteration_input_tokens
-                            aggregate_output_tokens += len(full_content) // 4
                             for tc in collected_tool_calls:
                                 if await request.is_disconnected():
                                     assistant_msg.content = full_content
@@ -3767,7 +3791,6 @@ async def edit_user_message_stream(
                                 model_message = append_conversation_image_inventory(
                                     final_message, image_inventory
                                 )
-                                aggregate_output_tokens += len(llm_result) // 4
                                 pending_tool_calls.append(
                                     {
                                         "id": tc.id,
@@ -3916,11 +3939,8 @@ async def edit_user_message_stream(
                     assistant_msg.is_manually_stopped = False
                     assistant_msg.round_status = terminal_round_status
                     assistant_msg.created_at = now_utc()
-                    terminal_input_tokens = (
-                        0 if max_iterations_reached else iteration_input_tokens
-                    )
-                    input_tokens = aggregate_input_tokens + terminal_input_tokens
-                    output_tokens = aggregate_output_tokens + len(terminal_content) // 4
+                    input_tokens = aggregate_input_tokens
+                    output_tokens = aggregate_output_tokens
                     assistant_msg.token_usage = {
                         "prompt": input_tokens,
                         "completion": output_tokens,
@@ -3943,6 +3963,7 @@ async def edit_user_message_stream(
                     await Conversation.filter(id=conversation.id).update(
                         message_count=F("message_count") + created_message_count,
                         token_usage=F("token_usage") + total_tokens,
+                        updated_at=now_utc(),
                     )
                     tokens_per_second = (
                         round(output_tokens / (duration_ms / 1000), 1)
@@ -4449,6 +4470,8 @@ async def regenerate_message(
                     max_iterations = agent.max_iterations or 5
                     iteration = 0
                     max_iterations_reached = False
+                    aggregate_input_tokens = 0
+                    aggregate_output_tokens = 0
 
                     while iteration < max_iterations:
                         iteration += 1
@@ -4495,6 +4518,7 @@ async def regenerate_message(
                         collected_tool_calls = []
                         client_disconnected = False
                         context_retry_used = False
+                        stream_usage = None
                         try:
                             prepared_context = await prepare_model_context(
                                 agent=agent,
@@ -4585,6 +4609,8 @@ async def regenerate_message(
                                 timeout_seconds=idle_timeout,
                                 activity_predicate=_is_model_stream_activity,
                             ):
+                                if chunk.usage:
+                                    stream_usage = chunk.usage
                                 # Check if client disconnected - stop LLM generation to save tokens
                                 if await request.is_disconnected():
                                     client_disconnected = True
@@ -4676,6 +4702,7 @@ async def regenerate_message(
                                 item.model_dump(exclude_none=True)
                                 for item in prepared_context.messages
                             ]
+                            stream_usage = None
                             stream = model_manager.team_chat_stream(
                                 team_id=str(agent.team_id),
                                 messages=messages_for_llm,
@@ -4687,6 +4714,8 @@ async def regenerate_message(
                                 timeout_seconds=idle_timeout,
                                 activity_predicate=_is_model_stream_activity,
                             ):
+                                if chunk.usage:
+                                    stream_usage = chunk.usage
                                 if await request.is_disconnected():
                                     client_disconnected = True
                                     logger.info(
@@ -4731,6 +4760,21 @@ async def regenerate_message(
                                     if chunk.finish_reason == FinishReason.LENGTH:
                                         yield f"event: {SSEEventType.OUTPUT_TRUNCATED}\ndata: {json.dumps({})}\n\n"
                                     break
+
+                        iteration_input_tokens, iteration_output_tokens = (
+                            _calculate_model_usage(
+                                tools=tools,
+                                messages=messages_for_llm,
+                                content=full_content,
+                                reasoning_content=full_reasoning,
+                                tool_calls=collected_tool_calls,
+                                usage=stream_usage,
+                                model_id=tokenizer_model_id,
+                                provider=model_provider,
+                            )
+                        )
+                        aggregate_input_tokens += iteration_input_tokens
+                        aggregate_output_tokens += iteration_output_tokens
 
                         # If client disconnected, save current stopped state and exit
                         if client_disconnected:
@@ -4971,38 +5015,8 @@ async def regenerate_message(
                     new_message.round_status = terminal_round_status
                     # Ensure regenerated message appears after tool calls/results in history
                     new_message.created_at = now_utc()
-                    final_prepared_context = await prepare_model_context(
-                        agent=agent,
-                        conversation=conversation,
-                        user_message=model_message,
-                        model_id=model_id,
-                        tokenizer_model_id=tokenizer_model_id,
-                        model_context_limit=model_context_limit,
-                        model_max_output_tokens=model_max_output_tokens,
-                        provider=model_provider,
-                        user_locale=current_user.locale,
-                        history_override=working_history_override,
-                        current_user_message_id=user_message.id,
-                        include_current_user_message=False,
-                        history_before_message_created_at=user_message.created_at,
-                        tool_timeouts=tool_timeouts,
-                        user=current_user,
-                        protected_round_id=round_id,
-                    )
-                    input_tokens = sum(
-                        len(message_content or "") // 4
-                        for message_content in (
-                            message.get("content")
-                            if isinstance(message, dict)
-                            else None
-                            for message in [
-                                item.model_dump(exclude_none=True)
-                                for item in final_prepared_context.messages
-                            ]
-                        )
-                        if isinstance(message_content, str)
-                    )
-                    output_tokens = len(terminal_content) // 4
+                    input_tokens = aggregate_input_tokens
+                    output_tokens = aggregate_output_tokens
                     new_message.token_usage = {
                         "prompt": input_tokens,
                         "completion": output_tokens,
@@ -5027,6 +5041,11 @@ async def regenerate_message(
                     await Team.filter(id=agent.team.id).update(
                         total_messages=F("total_messages") + 1,
                         total_tokens=F("total_tokens") + total_tokens,
+                    )
+                    await Conversation.filter(id=conversation.id).update(
+                        message_count=F("message_count") + 1,
+                        token_usage=F("token_usage") + total_tokens,
+                        updated_at=now_utc(),
                     )
 
                     first_token_ms = new_message.first_token_ms

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -3798,6 +3798,12 @@ async def edit_user_message_stream(
                             iteration_cache_creation_tokens
                         )
                         aggregate_total_input_tokens += iteration_total_input_tokens
+                        await model_manager.record_stream_usage(
+                            team_id=str(agent.team_id),
+                            model_id=model_id,
+                            input_tokens=iteration_input_tokens,
+                            output_tokens=iteration_output_tokens,
+                        )
 
                         if client_disconnected:
                             assistant_msg.content = full_content
@@ -4874,6 +4880,12 @@ async def regenerate_message(
                             iteration_cache_creation_tokens
                         )
                         aggregate_total_input_tokens += iteration_total_input_tokens
+                        await model_manager.record_stream_usage(
+                            team_id=str(agent.team_id),
+                            model_id=model_id,
+                            input_tokens=iteration_input_tokens,
+                            output_tokens=iteration_output_tokens,
+                        )
 
                         # If client disconnected, save current stopped state and exit
                         if client_disconnected:

--- a/backend/app/core/i18n_legacy.py
+++ b/backend/app/core/i18n_legacy.py
@@ -195,6 +195,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
     "audit_log_delete_tool": {"en": "Delete tool", "zh": "删除工具"},
     "audit_log_delete_user": {"en": "Delete user", "zh": "删除用户"},
     "audit_log_delete_workflow": {"en": "Delete workflow", "zh": "删除工作流"},
+    "audit_log_delete_message": {"en": "Delete message", "zh": "删除消息"},
     "audit_log_disable_totp": {
         "en": "Disable two-factor authentication",
         "zh": "禁用双因素认证",

--- a/backend/app/llm/adapters/chat/anthropic_adapter.py
+++ b/backend/app/llm/adapters/chat/anthropic_adapter.py
@@ -21,6 +21,7 @@ from app.llm.types import (
     ToolCall,
     FunctionCall,
 )
+from app.llm.token_counter import count_tokens
 
 from .base import BaseChatAdapter
 
@@ -221,6 +222,141 @@ class AnthropicAdapter(BaseChatAdapter):
             for tool in tools
         ]
 
+    # Anthropic prompt caching 写入要求缓存前缀至少 1024 tokens；
+    # 本地用 cl100k_base 近似估算可能高估，留 256 token 余量避免 API 400。
+    _MIN_CACHE_PREFIX_TOKENS = 1024 + 256
+    _CACHE_CONTROL = {"type": "ephemeral"}
+
+    @property
+    def cache_control_enabled(self) -> bool:
+        """是否启用 prompt caching（默认开启，可通过模型 config 的 cache_control 关闭）"""
+        return bool(self.config.get("cache_control", True))
+
+    def _count_tokens(self, text: str) -> int:
+        """按模型/provider 估算文本 token 数"""
+        if not text:
+            return 0
+        return count_tokens(
+            text,
+            model_id=self.model_id,
+            provider=getattr(self.model_config, "provider", None),
+        )
+
+    def _message_text(self, msg: dict[str, Any]) -> str:
+        """提取 Anthropic 消息的可计数文本"""
+        content = msg.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            texts: list[str] = []
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get("type") == "text":
+                        texts.append(block.get("text", ""))
+                    elif block.get("type") == "tool_result":
+                        texts.append(block.get("content", ""))
+            return "\n".join(texts)
+        return ""
+
+    def _is_real_user_message(self, msg: dict[str, Any]) -> bool:
+        """真用户消息：role=user 且不是 tool_result 包裹，且非空"""
+        if msg.get("role") != "user":
+            return False
+        content = msg.get("content")
+        if isinstance(content, list) and content and isinstance(content[0], dict):
+            if content[0].get("type") == "tool_result":
+                return False
+        return bool(content)
+
+    def _mark_message_cache_breakpoint(self, msg: dict[str, Any]) -> None:
+        """在消息第一个文本块上打缓存断点"""
+        content = msg.get("content")
+        if isinstance(content, str):
+            msg["content"] = [
+                {
+                    "type": "text",
+                    "text": content,
+                    "cache_control": self._CACHE_CONTROL,
+                }
+            ]
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    block["cache_control"] = self._CACHE_CONTROL
+                    break
+
+    def _apply_cache_breakpoints(
+        self,
+        system_prompt: str | None,
+        anthropic_messages: list[dict[str, Any]],
+        anthropic_tools: list[dict] | None,
+    ) -> tuple[
+        str | list[dict[str, Any]] | None,
+        list[dict[str, Any]],
+        list[dict] | None,
+    ]:
+        """
+        为 system / tools / 历史消息添加 Anthropic prompt caching 断点。
+
+        策略（Anthropic 官方多轮对话模式）：
+        - system prompt：整个缓存（稳定前缀）
+        - tools：最后一个工具打点（system+tools 前缀）
+        - 第一条真 user 消息：工具循环期间前缀稳定，可复用
+        - 倒数第二条真 user 消息：缓存几乎全部历史，跨轮次命中
+
+        每个断点前缀估算 token 不足最小要求时跳过（避免 API 400）。
+        """
+        if not self.cache_control_enabled:
+            return system_prompt, anthropic_messages, anthropic_tools
+
+        system_tokens = self._count_tokens(system_prompt or "")
+
+        # tools 断点：缓存 system + tools 前缀
+        tools_tokens = 0
+        if anthropic_tools:
+            tools_tokens = self._count_tokens(
+                json.dumps(anthropic_tools, ensure_ascii=False)
+            )
+            if system_tokens + tools_tokens >= self._MIN_CACHE_PREFIX_TOKENS:
+                anthropic_tools[-1] = {
+                    **anthropic_tools[-1],
+                    "cache_control": self._CACHE_CONTROL,
+                }
+
+        # system 断点
+        new_system: str | list[dict[str, Any]] | None = system_prompt
+        if system_prompt and system_tokens >= self._MIN_CACHE_PREFIX_TOKENS:
+            new_system = [
+                {
+                    "type": "text",
+                    "text": system_prompt,
+                    "cache_control": self._CACHE_CONTROL,
+                }
+            ]
+
+        # 消息断点：第一条 + 倒数第二条真 user 消息
+        cumulative = system_tokens + tools_tokens
+        user_breakpoints: list[tuple[int, int]] = []
+        for index, msg in enumerate(anthropic_messages):
+            cumulative += self._count_tokens(self._message_text(msg))
+            if self._is_real_user_message(msg):
+                user_breakpoints.append((index, cumulative))
+
+        targets: list[tuple[int, int]] = []
+        if user_breakpoints:
+            targets.append(user_breakpoints[0])
+            if (
+                len(user_breakpoints) >= 2
+                and user_breakpoints[-2][0] != user_breakpoints[0][0]
+            ):
+                targets.append(user_breakpoints[-2])
+
+        for index, prefix_tokens in targets:
+            if prefix_tokens >= self._MIN_CACHE_PREFIX_TOKENS:
+                self._mark_message_cache_breakpoint(anthropic_messages[index])
+
+        return new_system, anthropic_messages, anthropic_tools
+
     def _extract_response(
         self, response: Any
     ) -> tuple[str | None, str | None, list[ToolCall] | None]:
@@ -305,6 +441,11 @@ class AnthropicAdapter(BaseChatAdapter):
         try:
             system_prompt, anthropic_messages = self._convert_messages(messages)
             anthropic_tools = self.convert_tools(tools)
+            system_prompt, anthropic_messages, anthropic_tools = (
+                self._apply_cache_breakpoints(
+                    system_prompt, anthropic_messages, anthropic_tools
+                )
+            )
 
             request_params: dict[str, Any] = {
                 "model": self.model_id,
@@ -396,6 +537,22 @@ class AnthropicAdapter(BaseChatAdapter):
                     completion_tokens=response.usage.output_tokens,
                     total_tokens=response.usage.input_tokens
                     + response.usage.output_tokens,
+                    cache_read_tokens=getattr(
+                        response.usage, "cache_read_input_tokens", 0
+                    )
+                    or 0,
+                    cache_creation_tokens=getattr(
+                        response.usage, "cache_creation_input_tokens", 0
+                    )
+                    or 0,
+                    total_input_tokens=(
+                        response.usage.input_tokens
+                        + (getattr(response.usage, "cache_read_input_tokens", 0) or 0)
+                        + (
+                            getattr(response.usage, "cache_creation_input_tokens", 0)
+                            or 0
+                        )
+                    ),
                 )
 
             return self.create_response(
@@ -462,6 +619,11 @@ class AnthropicAdapter(BaseChatAdapter):
         try:
             system_prompt, anthropic_messages = self._convert_messages(messages)
             anthropic_tools = self.convert_tools(tools)
+            system_prompt, anthropic_messages, anthropic_tools = (
+                self._apply_cache_breakpoints(
+                    system_prompt, anthropic_messages, anthropic_tools
+                )
+            )
 
             request_params: dict[str, Any] = {
                 "model": self.model_id,
@@ -594,9 +756,51 @@ class AnthropicAdapter(BaseChatAdapter):
                     if event_type == "message_stop":
                         continue
 
-                    # 处理 message_delta (包含 stop_reason)
+                    # 处理 message_delta (包含 stop_reason 和 usage)
                     if event_type == "message_delta":
                         delta = getattr(event, "delta", None)
+
+                        # Anthropic 流式的 usage 在 message_delta 事件上返回
+                        usage = None
+                        event_usage = getattr(event, "usage", None)
+                        if event_usage:
+                            input_tokens = getattr(event_usage, "input_tokens", 0) or 0
+                            output_tokens = (
+                                getattr(event_usage, "output_tokens", 0) or 0
+                            )
+                            usage = Usage(
+                                prompt_tokens=input_tokens,
+                                completion_tokens=output_tokens,
+                                total_tokens=input_tokens + output_tokens,
+                                cache_read_tokens=getattr(
+                                    event_usage, "cache_read_input_tokens", 0
+                                )
+                                or 0,
+                                cache_creation_tokens=getattr(
+                                    event_usage, "cache_creation_input_tokens", 0
+                                )
+                                or 0,
+                                total_input_tokens=(
+                                    input_tokens
+                                    + (
+                                        getattr(
+                                            event_usage,
+                                            "cache_read_input_tokens",
+                                            0,
+                                        )
+                                        or 0
+                                    )
+                                    + (
+                                        getattr(
+                                            event_usage,
+                                            "cache_creation_input_tokens",
+                                            0,
+                                        )
+                                        or 0
+                                    )
+                                ),
+                            )
+
                         if delta:
                             stop_reason = getattr(delta, "stop_reason", None)
                             finish_reason = self._map_finish_reason(stop_reason)
@@ -605,6 +809,12 @@ class AnthropicAdapter(BaseChatAdapter):
                             yield self.create_stream_chunk(
                                 tool_calls=tool_calls if tool_calls else None,
                                 finish_reason=finish_reason,
+                                usage=usage,
+                                response_id=response_id,
+                            )
+                        elif usage:
+                            yield self.create_stream_chunk(
+                                usage=usage,
                                 response_id=response_id,
                             )
         finally:

--- a/backend/app/llm/adapters/chat/anthropic_adapter.py
+++ b/backend/app/llm/adapters/chat/anthropic_adapter.py
@@ -222,10 +222,15 @@ class AnthropicAdapter(BaseChatAdapter):
             for tool in tools
         ]
 
-    # Anthropic prompt caching 写入要求缓存前缀至少 1024 tokens；
-    # 本地用 cl100k_base 近似估算可能高估，留 256 token 余量避免 API 400。
-    _MIN_CACHE_PREFIX_TOKENS = 1024 + 256
+    # Anthropic prompt caching requires 1024 tokens for most models and 2048
+    # tokens for Claude 3 Haiku; leave 256 tokens of local estimation margin.
+    _CACHE_TOKEN_MARGIN = 256
     _CACHE_CONTROL = {"type": "ephemeral"}
+
+    def _min_cache_prefix_tokens(self) -> int:
+        """Return the model-specific cache prefix floor with safety margin."""
+        minimum = 2048 if "claude-3-haiku" in self.model_id.lower() else 1024
+        return minimum + self._CACHE_TOKEN_MARGIN
 
     @property
     def cache_control_enabled(self) -> bool:
@@ -254,7 +259,12 @@ class AnthropicAdapter(BaseChatAdapter):
                     if block.get("type") == "text":
                         texts.append(block.get("text", ""))
                     elif block.get("type") == "tool_result":
-                        texts.append(block.get("content", ""))
+                        result_content = block.get("content", "")
+                        if not isinstance(result_content, str):
+                            result_content = json.dumps(
+                                result_content, ensure_ascii=False, default=str
+                            )
+                        texts.append(result_content)
             return "\n".join(texts)
         return ""
 
@@ -317,7 +327,7 @@ class AnthropicAdapter(BaseChatAdapter):
             tools_tokens = self._count_tokens(
                 json.dumps(anthropic_tools, ensure_ascii=False)
             )
-            if system_tokens + tools_tokens >= self._MIN_CACHE_PREFIX_TOKENS:
+            if system_tokens + tools_tokens >= self._min_cache_prefix_tokens():
                 anthropic_tools[-1] = {
                     **anthropic_tools[-1],
                     "cache_control": self._CACHE_CONTROL,
@@ -325,7 +335,7 @@ class AnthropicAdapter(BaseChatAdapter):
 
         # system 断点
         new_system: str | list[dict[str, Any]] | None = system_prompt
-        if system_prompt and system_tokens >= self._MIN_CACHE_PREFIX_TOKENS:
+        if system_prompt and system_tokens >= self._min_cache_prefix_tokens():
             new_system = [
                 {
                     "type": "text",
@@ -352,7 +362,7 @@ class AnthropicAdapter(BaseChatAdapter):
                 targets.append(user_breakpoints[-2])
 
         for index, prefix_tokens in targets:
-            if prefix_tokens >= self._MIN_CACHE_PREFIX_TOKENS:
+            if prefix_tokens >= self._min_cache_prefix_tokens():
                 self._mark_message_cache_breakpoint(anthropic_messages[index])
 
         return new_system, anthropic_messages, anthropic_tools
@@ -655,6 +665,25 @@ class AnthropicAdapter(BaseChatAdapter):
             # 用于累积工具调用
             current_tool_use: dict[str, Any] | None = None
             tool_calls: list[ToolCall] = []
+            stream_usage_values = {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+            }
+            stream_usage_seen = False
+
+            def merge_stream_usage(usage_data: Any) -> None:
+                nonlocal stream_usage_seen
+                if not usage_data:
+                    return
+                stream_usage_seen = True
+                for field in stream_usage_values:
+                    value = getattr(usage_data, field, None)
+                    if value is not None:
+                        stream_usage_values[field] = max(
+                            stream_usage_values[field], int(value or 0)
+                        )
 
             async with client.messages.stream(
                 **request_params,
@@ -662,6 +691,11 @@ class AnthropicAdapter(BaseChatAdapter):
             ) as stream:
                 async for event in stream:
                     event_type = getattr(event, "type", None)
+
+                    if event_type == "message_start":
+                        message = getattr(event, "message", None)
+                        merge_stream_usage(getattr(message, "usage", None))
+                        continue
 
                     # 处理 content_block_start
                     if event_type == "content_block_start":
@@ -759,46 +793,28 @@ class AnthropicAdapter(BaseChatAdapter):
                     # 处理 message_delta (包含 stop_reason 和 usage)
                     if event_type == "message_delta":
                         delta = getattr(event, "delta", None)
+                        merge_stream_usage(getattr(event, "usage", None))
 
-                        # Anthropic 流式的 usage 在 message_delta 事件上返回
                         usage = None
-                        event_usage = getattr(event, "usage", None)
-                        if event_usage:
-                            input_tokens = getattr(event_usage, "input_tokens", 0) or 0
-                            output_tokens = (
-                                getattr(event_usage, "output_tokens", 0) or 0
+                        if stream_usage_seen:
+                            input_tokens = stream_usage_values["input_tokens"]
+                            output_tokens = stream_usage_values["output_tokens"]
+                            cache_read_tokens = stream_usage_values[
+                                "cache_read_input_tokens"
+                            ]
+                            cache_creation_tokens = stream_usage_values[
+                                "cache_creation_input_tokens"
+                            ]
+                            total_input_tokens = (
+                                input_tokens + cache_read_tokens + cache_creation_tokens
                             )
                             usage = Usage(
                                 prompt_tokens=input_tokens,
                                 completion_tokens=output_tokens,
-                                total_tokens=input_tokens + output_tokens,
-                                cache_read_tokens=getattr(
-                                    event_usage, "cache_read_input_tokens", 0
-                                )
-                                or 0,
-                                cache_creation_tokens=getattr(
-                                    event_usage, "cache_creation_input_tokens", 0
-                                )
-                                or 0,
-                                total_input_tokens=(
-                                    input_tokens
-                                    + (
-                                        getattr(
-                                            event_usage,
-                                            "cache_read_input_tokens",
-                                            0,
-                                        )
-                                        or 0
-                                    )
-                                    + (
-                                        getattr(
-                                            event_usage,
-                                            "cache_creation_input_tokens",
-                                            0,
-                                        )
-                                        or 0
-                                    )
-                                ),
+                                total_tokens=total_input_tokens + output_tokens,
+                                cache_read_tokens=cache_read_tokens,
+                                cache_creation_tokens=cache_creation_tokens,
+                                total_input_tokens=total_input_tokens,
                             )
 
                         if delta:
@@ -817,5 +833,7 @@ class AnthropicAdapter(BaseChatAdapter):
                                 usage=usage,
                                 response_id=response_id,
                             )
+                        continue
+
         finally:
             await client.close()

--- a/backend/app/llm/adapters/chat/base.py
+++ b/backend/app/llm/adapters/chat/base.py
@@ -29,6 +29,32 @@ from app.llm.types import (
 logger = logging.getLogger(__name__)
 
 
+def extract_cached_tokens(usage: Any) -> int:
+    """
+    从 OpenAI 兼容 usage 对象提取缓存命中 token 数。
+
+    优先读取 prompt_tokens_details.cached_tokens（OpenAI/OpenAI 兼容/Moonshot），
+    回退读取 prompt_cache_hit_tokens（DeepSeek）、cached_prompt_text_tokens（xAI 原生）。
+    """
+    details = getattr(usage, "prompt_tokens_details", None)
+    if details:
+        return int(getattr(details, "cached_tokens", 0) or 0)
+    deepseek_hit = getattr(usage, "prompt_cache_hit_tokens", None)
+    if deepseek_hit:
+        return int(deepseek_hit)
+    return int(getattr(usage, "cached_prompt_text_tokens", 0) or 0)
+
+
+def extract_total_input_tokens(usage: Any) -> int:
+    """返回供应商报告的完整输入 token 数，优先 DeepSeek hit + miss。"""
+    cache_miss = getattr(usage, "prompt_cache_miss_tokens", None)
+    if cache_miss is not None:
+        return int(getattr(usage, "prompt_cache_hit_tokens", 0) or 0) + int(
+            cache_miss or 0
+        )
+    return int(getattr(usage, "prompt_tokens", 0) or 0)
+
+
 class BaseChatAdapter(ABC):
     """
     Chat 适配器基类

--- a/backend/app/llm/adapters/chat/base.py
+++ b/backend/app/llm/adapters/chat/base.py
@@ -55,6 +55,21 @@ def extract_total_input_tokens(usage: Any) -> int:
     return int(getattr(usage, "prompt_tokens", 0) or 0)
 
 
+def usage_from_openai_usage(usage: Any) -> Usage:
+    """Build Usage from an OpenAI-compatible object with missing fields tolerated."""
+    prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
+    completion_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
+    total_tokens = int(getattr(usage, "total_tokens", 0) or 0)
+    return Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens or (prompt_tokens + completion_tokens),
+        cache_read_tokens=extract_cached_tokens(usage),
+        cache_creation_tokens=int(getattr(usage, "cache_creation_tokens", 0) or 0),
+        total_input_tokens=extract_total_input_tokens(usage),
+    )
+
+
 class BaseChatAdapter(ABC):
     """
     Chat 适配器基类

--- a/backend/app/llm/adapters/chat/deepseek_adapter.py
+++ b/backend/app/llm/adapters/chat/deepseek_adapter.py
@@ -19,7 +19,7 @@ from app.llm.types import (
     Usage,
 )
 
-from .base import BaseChatAdapter
+from .base import BaseChatAdapter, extract_cached_tokens, extract_total_input_tokens
 from .tool_call_accumulator import ToolCallAccumulator
 
 logger = logging.getLogger(__name__)
@@ -233,6 +233,8 @@ class DeepSeekAdapter(BaseChatAdapter):
                     prompt_tokens=response.usage.prompt_tokens,
                     completion_tokens=response.usage.completion_tokens,
                     total_tokens=response.usage.total_tokens,
+                    cache_read_tokens=extract_cached_tokens(response.usage),
+                    total_input_tokens=extract_total_input_tokens(response.usage),
                 )
 
             return self.create_response(
@@ -283,6 +285,9 @@ class DeepSeekAdapter(BaseChatAdapter):
             if self.thinking_enabled and self.reasoning_effort:
                 request_params["reasoning_effort"] = self.reasoning_effort
 
+            # 流式默认不返回 usage，需显式请求；在终末 chunk 上返回累计快照
+            request_params["stream_options"] = {"include_usage": True}
+
             logger.info(
                 "DeepSeek request params: %s",
                 request_params,
@@ -303,10 +308,25 @@ class DeepSeekAdapter(BaseChatAdapter):
 
             async for chunk in stream:
                 if not chunk.choices:
-                    yield self.create_stream_chunk(
-                        response_id=response_id,
-                        stream_activity=True,
-                    )
+                    # DeepSeek 流式的 usage 在最后一个 chunk 返回（choices 为空）
+                    if getattr(chunk, "usage", None):
+                        yield self.create_stream_chunk(
+                            response_id=response_id,
+                            usage=Usage(
+                                prompt_tokens=chunk.usage.prompt_tokens,
+                                completion_tokens=chunk.usage.completion_tokens,
+                                total_tokens=chunk.usage.total_tokens,
+                                cache_read_tokens=extract_cached_tokens(chunk.usage),
+                                total_input_tokens=extract_total_input_tokens(
+                                    chunk.usage
+                                ),
+                            ),
+                        )
+                    else:
+                        yield self.create_stream_chunk(
+                            response_id=response_id,
+                            stream_activity=True,
+                        )
                     continue
 
                 delta = chunk.choices[0].delta

--- a/backend/app/llm/adapters/chat/gemini_adapter.py
+++ b/backend/app/llm/adapters/chat/gemini_adapter.py
@@ -386,6 +386,10 @@ class GeminiAdapter(BaseChatAdapter):
                 prompt_tokens=getattr(usage_metadata, "prompt_token_count", 0),
                 completion_tokens=getattr(usage_metadata, "candidates_token_count", 0),
                 total_tokens=getattr(usage_metadata, "total_token_count", 0),
+                cache_read_tokens=getattr(
+                    usage_metadata, "cached_content_token_count", 0
+                ),
+                total_input_tokens=getattr(usage_metadata, "prompt_token_count", 0),
             )
 
         return self.create_response(
@@ -492,6 +496,29 @@ class GeminiAdapter(BaseChatAdapter):
         stream = await client.aio.models.generate_content_stream(**request_kwargs)
         async for chunk in stream:
             if not chunk.candidates:
+                # Gemini 流式的 usage 在最后一个 chunk 返回（candidates 可能为空）
+                usage_metadata = getattr(chunk, "usage_metadata", None)
+                if usage_metadata:
+                    yield self.create_stream_chunk(
+                        response_id=response_id,
+                        usage=Usage(
+                            prompt_tokens=getattr(
+                                usage_metadata, "prompt_token_count", 0
+                            ),
+                            completion_tokens=getattr(
+                                usage_metadata, "candidates_token_count", 0
+                            ),
+                            total_tokens=getattr(
+                                usage_metadata, "total_token_count", 0
+                            ),
+                            cache_read_tokens=getattr(
+                                usage_metadata, "cached_content_token_count", 0
+                            ),
+                            total_input_tokens=getattr(
+                                usage_metadata, "prompt_token_count", 0
+                            ),
+                        ),
+                    )
                 continue
 
             candidate = chunk.candidates[0]
@@ -541,6 +568,23 @@ class GeminiAdapter(BaseChatAdapter):
 
             # 检查是否完成
             finish_reason_raw = getattr(candidate, "finish_reason", None)
+
+            # Gemini 流式的 usage_metadata 在带 finish_reason 的最终 chunk 上
+            usage = None
+            usage_metadata = getattr(chunk, "usage_metadata", None)
+            if usage_metadata:
+                usage = Usage(
+                    prompt_tokens=getattr(usage_metadata, "prompt_token_count", 0),
+                    completion_tokens=getattr(
+                        usage_metadata, "candidates_token_count", 0
+                    ),
+                    total_tokens=getattr(usage_metadata, "total_token_count", 0),
+                    cache_read_tokens=getattr(
+                        usage_metadata, "cached_content_token_count", 0
+                    ),
+                    total_input_tokens=getattr(usage_metadata, "prompt_token_count", 0),
+                )
+
             if finish_reason_raw:
                 finish_reason = self._map_finish_reason(finish_reason_raw)
                 if accumulated_tool_calls:
@@ -551,5 +595,6 @@ class GeminiAdapter(BaseChatAdapter):
                     if accumulated_tool_calls
                     else None,
                     finish_reason=finish_reason,
+                    usage=usage,
                     response_id=response_id,
                 )

--- a/backend/app/llm/adapters/chat/moonshot_adapter.py
+++ b/backend/app/llm/adapters/chat/moonshot_adapter.py
@@ -19,7 +19,7 @@ from app.llm.types import (
     Usage,
 )
 
-from .base import BaseChatAdapter
+from .base import BaseChatAdapter, extract_cached_tokens
 from .thinking import ThinkingExtractor
 from .tool_call_accumulator import ToolCallAccumulator
 
@@ -205,6 +205,8 @@ class MoonshotAdapter(BaseChatAdapter):
                     prompt_tokens=response.usage.prompt_tokens,
                     completion_tokens=response.usage.completion_tokens,
                     total_tokens=response.usage.total_tokens,
+                    cache_read_tokens=extract_cached_tokens(response.usage),
+                    total_input_tokens=response.usage.prompt_tokens,
                 )
 
             return self.create_response(
@@ -271,10 +273,23 @@ class MoonshotAdapter(BaseChatAdapter):
 
             async for chunk in stream:
                 if not chunk.choices:
-                    yield self.create_stream_chunk(
-                        response_id=response_id,
-                        stream_activity=True,
-                    )
+                    # 兼容端点在流式最后 chunk 返回 usage（choices 为空）
+                    if getattr(chunk, "usage", None):
+                        yield self.create_stream_chunk(
+                            response_id=response_id,
+                            usage=Usage(
+                                prompt_tokens=chunk.usage.prompt_tokens,
+                                completion_tokens=chunk.usage.completion_tokens,
+                                total_tokens=chunk.usage.total_tokens,
+                                cache_read_tokens=extract_cached_tokens(chunk.usage),
+                                total_input_tokens=chunk.usage.prompt_tokens,
+                            ),
+                        )
+                    else:
+                        yield self.create_stream_chunk(
+                            response_id=response_id,
+                            stream_activity=True,
+                        )
                     continue
 
                 delta = chunk.choices[0].delta

--- a/backend/app/llm/adapters/chat/ollama_adapter.py
+++ b/backend/app/llm/adapters/chat/ollama_adapter.py
@@ -19,7 +19,7 @@ from app.llm.types import (
     Usage,
 )
 
-from .base import BaseChatAdapter
+from .base import BaseChatAdapter, extract_cached_tokens
 from .thinking import ThinkingExtractor
 from .tool_call_accumulator import ToolCallAccumulator
 
@@ -208,6 +208,8 @@ class OllamaAdapter(BaseChatAdapter):
                     prompt_tokens=response.usage.prompt_tokens,
                     completion_tokens=response.usage.completion_tokens,
                     total_tokens=response.usage.total_tokens,
+                    cache_read_tokens=extract_cached_tokens(response.usage),
+                    total_input_tokens=response.usage.prompt_tokens,
                 )
 
             return self.create_response(
@@ -264,10 +266,23 @@ class OllamaAdapter(BaseChatAdapter):
 
             async for chunk in stream:
                 if not chunk.choices:
-                    yield self.create_stream_chunk(
-                        response_id=response_id,
-                        stream_activity=True,
-                    )
+                    # 兼容端点在流式最后 chunk 返回 usage（choices 为空）
+                    if getattr(chunk, "usage", None):
+                        yield self.create_stream_chunk(
+                            response_id=response_id,
+                            usage=Usage(
+                                prompt_tokens=chunk.usage.prompt_tokens,
+                                completion_tokens=chunk.usage.completion_tokens,
+                                total_tokens=chunk.usage.total_tokens,
+                                cache_read_tokens=extract_cached_tokens(chunk.usage),
+                                total_input_tokens=chunk.usage.prompt_tokens,
+                            ),
+                        )
+                    else:
+                        yield self.create_stream_chunk(
+                            response_id=response_id,
+                            stream_activity=True,
+                        )
                     continue
 
                 delta = chunk.choices[0].delta

--- a/backend/app/llm/adapters/chat/openai_adapter.py
+++ b/backend/app/llm/adapters/chat/openai_adapter.py
@@ -17,7 +17,7 @@ from app.llm.types import (
     Usage,
 )
 
-from .base import BaseChatAdapter
+from .base import BaseChatAdapter, extract_cached_tokens
 from .thinking import ThinkingExtractor
 from .tool_call_accumulator import ToolCallAccumulator
 
@@ -195,6 +195,8 @@ class OpenAIAdapter(BaseChatAdapter):
                     prompt_tokens=response.usage.prompt_tokens,
                     completion_tokens=response.usage.completion_tokens,
                     total_tokens=response.usage.total_tokens,
+                    cache_read_tokens=extract_cached_tokens(response.usage),
+                    total_input_tokens=response.usage.prompt_tokens,
                 )
 
             return self.create_response(
@@ -249,6 +251,10 @@ class OpenAIAdapter(BaseChatAdapter):
             if "response_format" in kwargs and kwargs["response_format"] is not None:
                 request_params["response_format"] = kwargs["response_format"]
 
+            # Streaming responses omit usage unless explicitly requested;
+            # it arrives on the terminal chunk as an accumulated snapshot.
+            request_params["stream_options"] = {"include_usage": True}
+
             stream = await client.chat.completions.create(
                 **request_params,
                 extra_body=self.get_passthrough_body() or None,
@@ -259,10 +265,23 @@ class OpenAIAdapter(BaseChatAdapter):
 
             async for chunk in stream:
                 if not chunk.choices:
-                    yield self.create_stream_chunk(
-                        response_id=response_id,
-                        stream_activity=True,
-                    )
+                    # OpenAI 流式的 usage 在最后一个 chunk 返回（choices 为空）
+                    if getattr(chunk, "usage", None):
+                        yield self.create_stream_chunk(
+                            response_id=response_id,
+                            usage=Usage(
+                                prompt_tokens=chunk.usage.prompt_tokens,
+                                completion_tokens=chunk.usage.completion_tokens,
+                                total_tokens=chunk.usage.total_tokens,
+                                cache_read_tokens=extract_cached_tokens(chunk.usage),
+                                total_input_tokens=chunk.usage.prompt_tokens,
+                            ),
+                        )
+                    else:
+                        yield self.create_stream_chunk(
+                            response_id=response_id,
+                            stream_activity=True,
+                        )
                     continue
 
                 delta = chunk.choices[0].delta

--- a/backend/app/llm/adapters/chat/openai_compatible_adapter.py
+++ b/backend/app/llm/adapters/chat/openai_compatible_adapter.py
@@ -19,7 +19,7 @@ from app.llm.types import (
     Usage,
 )
 
-from .base import BaseChatAdapter
+from .base import BaseChatAdapter, extract_cached_tokens
 from .thinking import ThinkingExtractor
 from .tool_call_accumulator import ToolCallAccumulator
 
@@ -273,6 +273,8 @@ class OpenAICompatibleAdapter(BaseChatAdapter):
                     prompt_tokens=response.usage.prompt_tokens,
                     completion_tokens=response.usage.completion_tokens,
                     total_tokens=response.usage.total_tokens,
+                    cache_read_tokens=extract_cached_tokens(response.usage),
+                    total_input_tokens=response.usage.prompt_tokens,
                 )
 
             return self.create_response(
@@ -356,10 +358,24 @@ class OpenAICompatibleAdapter(BaseChatAdapter):
 
             async for chunk in stream:
                 if not chunk.choices:
-                    yield self.create_stream_chunk(
-                        response_id=response_id,
-                        stream_activity=True,
-                    )
+                    # 兼容端点在流式最后 chunk 返回 usage（choices 为空）。
+                    # 不主动请求 include_usage：部分端点不支持该参数。
+                    if getattr(chunk, "usage", None):
+                        yield self.create_stream_chunk(
+                            response_id=response_id,
+                            usage=Usage(
+                                prompt_tokens=chunk.usage.prompt_tokens,
+                                completion_tokens=chunk.usage.completion_tokens,
+                                total_tokens=chunk.usage.total_tokens,
+                                cache_read_tokens=extract_cached_tokens(chunk.usage),
+                                total_input_tokens=chunk.usage.prompt_tokens,
+                            ),
+                        )
+                    else:
+                        yield self.create_stream_chunk(
+                            response_id=response_id,
+                            stream_activity=True,
+                        )
                     continue
 
                 delta = chunk.choices[0].delta

--- a/backend/app/llm/adapters/chat/openai_compatible_adapter.py
+++ b/backend/app/llm/adapters/chat/openai_compatible_adapter.py
@@ -19,7 +19,7 @@ from app.llm.types import (
     Usage,
 )
 
-from .base import BaseChatAdapter, extract_cached_tokens
+from .base import BaseChatAdapter, extract_cached_tokens, usage_from_openai_usage
 from .thinking import ThinkingExtractor
 from .tool_call_accumulator import ToolCallAccumulator
 
@@ -363,13 +363,7 @@ class OpenAICompatibleAdapter(BaseChatAdapter):
                     if getattr(chunk, "usage", None):
                         yield self.create_stream_chunk(
                             response_id=response_id,
-                            usage=Usage(
-                                prompt_tokens=chunk.usage.prompt_tokens,
-                                completion_tokens=chunk.usage.completion_tokens,
-                                total_tokens=chunk.usage.total_tokens,
-                                cache_read_tokens=extract_cached_tokens(chunk.usage),
-                                total_input_tokens=chunk.usage.prompt_tokens,
-                            ),
+                            usage=usage_from_openai_usage(chunk.usage),
                         )
                     else:
                         yield self.create_stream_chunk(

--- a/backend/app/llm/adapters/chat/xai_adapter.py
+++ b/backend/app/llm/adapters/chat/xai_adapter.py
@@ -19,7 +19,7 @@ from app.llm.types import (
     Usage,
 )
 
-from .base import BaseChatAdapter, extract_cached_tokens
+from .base import BaseChatAdapter, extract_cached_tokens, usage_from_openai_usage
 from .thinking import ThinkingExtractor
 from .tool_call_accumulator import ToolCallAccumulator
 
@@ -277,13 +277,7 @@ class XAIAdapter(BaseChatAdapter):
                     if getattr(chunk, "usage", None):
                         yield self.create_stream_chunk(
                             response_id=response_id,
-                            usage=Usage(
-                                prompt_tokens=chunk.usage.prompt_tokens,
-                                completion_tokens=chunk.usage.completion_tokens,
-                                total_tokens=chunk.usage.total_tokens,
-                                cache_read_tokens=extract_cached_tokens(chunk.usage),
-                                total_input_tokens=chunk.usage.prompt_tokens,
-                            ),
+                            usage=usage_from_openai_usage(chunk.usage),
                         )
                     else:
                         yield self.create_stream_chunk(

--- a/backend/app/llm/adapters/chat/xai_adapter.py
+++ b/backend/app/llm/adapters/chat/xai_adapter.py
@@ -19,7 +19,7 @@ from app.llm.types import (
     Usage,
 )
 
-from .base import BaseChatAdapter
+from .base import BaseChatAdapter, extract_cached_tokens
 from .thinking import ThinkingExtractor
 from .tool_call_accumulator import ToolCallAccumulator
 
@@ -210,6 +210,8 @@ class XAIAdapter(BaseChatAdapter):
                     prompt_tokens=response.usage.prompt_tokens,
                     completion_tokens=response.usage.completion_tokens,
                     total_tokens=response.usage.total_tokens,
+                    cache_read_tokens=extract_cached_tokens(response.usage),
+                    total_input_tokens=response.usage.prompt_tokens,
                 )
 
             return self.create_response(
@@ -271,10 +273,23 @@ class XAIAdapter(BaseChatAdapter):
 
             async for chunk in stream:
                 if not chunk.choices:
-                    yield self.create_stream_chunk(
-                        response_id=response_id,
-                        stream_activity=True,
-                    )
+                    # 兼容端点在流式最后 chunk 返回 usage（choices 为空）
+                    if getattr(chunk, "usage", None):
+                        yield self.create_stream_chunk(
+                            response_id=response_id,
+                            usage=Usage(
+                                prompt_tokens=chunk.usage.prompt_tokens,
+                                completion_tokens=chunk.usage.completion_tokens,
+                                total_tokens=chunk.usage.total_tokens,
+                                cache_read_tokens=extract_cached_tokens(chunk.usage),
+                                total_input_tokens=chunk.usage.prompt_tokens,
+                            ),
+                        )
+                    else:
+                        yield self.create_stream_chunk(
+                            response_id=response_id,
+                            stream_activity=True,
+                        )
                     continue
 
                 delta = chunk.choices[0].delta

--- a/backend/app/llm/manager.py
+++ b/backend/app/llm/manager.py
@@ -14,9 +14,9 @@
 
 import logging
 import uuid
-from collections.abc import AsyncIterator
-from typing import Any
+from collections.abc import AsyncIterator, Sequence
 from uuid import UUID
+from typing import Any
 
 from langchain_core.embeddings import Embeddings
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -782,7 +782,7 @@ class ModelManager:
     async def team_chat(
         self,
         team_id: str,
-        messages: list[Message | dict],
+        messages: Sequence[Message | dict[str, Any]],
         model_id: str | None = None,
         tools: list[ToolDefinition] | None = None,
         **kwargs: Any,
@@ -830,11 +830,58 @@ class ModelManager:
         try:
             result = await adapter.chat(converted_messages, tools=tools, **kwargs)
 
-            # 记录用量
+            reported_tokens = int(
+                getattr(getattr(result, "usage", None), "total_tokens", 0) or 0
+            )
+            if reported_tokens:
+                tokens_used = reported_tokens
+            else:
+                from app.llm.token_counter import (
+                    count_message_tokens,
+                    count_tokens,
+                    count_tool_definition_tokens,
+                    serialize_tool_calls,
+                )
+
+                messages_for_counting = [
+                    message.model_dump(exclude_none=True)
+                    for message in converted_messages
+                ]
+                completion_tokens = count_tokens(
+                    getattr(result, "content", None) or "",
+                    model_config.model_id,
+                    model_config.provider,
+                ) + count_tokens(
+                    getattr(result, "reasoning_content", None) or "",
+                    model_config.model_id,
+                    model_config.provider,
+                )
+                tool_calls = getattr(result, "tool_calls", None)
+                if tool_calls:
+                    completion_tokens += count_tokens(
+                        serialize_tool_calls(tool_calls),
+                        model_config.model_id,
+                        model_config.provider,
+                    )
+                tokens_used = (
+                    count_message_tokens(
+                        messages_for_counting,
+                        model_config.model_id,
+                        model_config.provider,
+                        include_tool_calls=True,
+                    )
+                    + count_tool_definition_tokens(
+                        tools,
+                        model_config.model_id,
+                        model_config.provider,
+                    )
+                    + completion_tokens
+                )
+
             await self._check_and_record_usage(
                 team_id=team_id,
                 model_id=str(model_config.id),
-                tokens_used=result.usage.total_tokens if result.usage else 0,
+                tokens_used=tokens_used,
             )
 
             return result
@@ -845,7 +892,7 @@ class ModelManager:
     async def team_chat_stream(
         self,
         team_id: str,
-        messages: list[Message | dict],
+        messages: Sequence[Message | dict[str, Any]],
         model_id: str | None = None,
         tools: list[ToolDefinition] | None = None,
         record_usage: bool = True,
@@ -907,34 +954,31 @@ class ModelManager:
         self,
         team_id: str,
         model_id: str | None,
-        input_text_length: int,
-        output_text_length: int,
+        input_text_length: int | None = None,
+        output_text_length: int | None = None,
+        *,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
     ) -> None:
-        """
-        记录流式调用的用量（供调用方在流结束后调用）
-
-        Args:
-            team_id: 团队 ID
-            model_id: 模型 ID
-            input_text_length: 输入文本字符数
-            output_text_length: 输出文本字符数（包括 content 和 reasoning）
-        """
+        """Record stream usage from provider totals or a character fallback."""
         from app.llm.token_counter import count_tokens
 
-        # 获取模型配置以获取正确的 model UUID
+        # Resolve the team model for its internal ID even when the caller
+        # already has provider-reported token totals.
         model_config, _ = await self._get_team_model(team_id, model_id, ModelType.CHAT)
 
-        # 使用 tiktoken 进行准确的 token 计数
-        # 构造临时文本用于计数（实际使用时应该传入完整文本）
-        # 这里使用字符数作为文本近似
-        dummy_input = "x" * input_text_length
-        dummy_output = "x" * output_text_length
-        input_tokens = count_tokens(
-            dummy_input, model_config.model_id, model_config.provider
-        )
-        output_tokens = count_tokens(
-            dummy_output, model_config.model_id, model_config.provider
-        )
+        if input_tokens is None or output_tokens is None:
+            dummy_input = "x" * (input_text_length or 0)
+            dummy_output = "x" * (output_text_length or 0)
+            input_tokens = count_tokens(
+                dummy_input, model_config.model_id, model_config.provider
+            )
+            output_tokens = count_tokens(
+                dummy_output, model_config.model_id, model_config.provider
+            )
+        assert input_tokens is not None
+        assert output_tokens is not None
+
         total_tokens = input_tokens + output_tokens
 
         await self._check_and_record_usage(
@@ -943,7 +987,10 @@ class ModelManager:
             tokens_used=total_tokens,
         )
         logger.debug(
-            f"Recorded stream usage: {total_tokens} tokens (input={input_tokens}, output={output_tokens})"
+            "Recorded stream usage: %s tokens (input=%s, output=%s)",
+            total_tokens,
+            input_tokens,
+            output_tokens,
         )
 
     async def team_embed(

--- a/backend/app/llm/manager.py
+++ b/backend/app/llm/manager.py
@@ -961,20 +961,23 @@ class ModelManager:
         output_tokens: int | None = None,
     ) -> None:
         """Record stream usage from provider totals or a character fallback."""
-        from app.llm.token_counter import count_tokens
+        from app.llm.token_counter import estimate_tokens_from_chars
 
         # Resolve the team model for its internal ID even when the caller
         # already has provider-reported token totals.
         model_config, _ = await self._get_team_model(team_id, model_id, ModelType.CHAT)
 
-        if input_tokens is None or output_tokens is None:
-            dummy_input = "x" * (input_text_length or 0)
-            dummy_output = "x" * (output_text_length or 0)
-            input_tokens = count_tokens(
-                dummy_input, model_config.model_id, model_config.provider
+        if input_tokens is None:
+            input_tokens = (
+                estimate_tokens_from_chars(input_text_length)
+                if input_text_length
+                else 0
             )
-            output_tokens = count_tokens(
-                dummy_output, model_config.model_id, model_config.provider
+        if output_tokens is None:
+            output_tokens = (
+                estimate_tokens_from_chars(output_text_length)
+                if output_text_length
+                else 0
             )
         assert input_tokens is not None
         assert output_tokens is not None

--- a/backend/app/llm/token_counter.py
+++ b/backend/app/llm/token_counter.py
@@ -4,8 +4,11 @@ Token counting utilities using tiktoken.
 Provides accurate token counting for various model families.
 """
 
+import json
 import logging
+from collections.abc import Iterable, Mapping
 from functools import lru_cache
+from typing import Any
 
 import tiktoken
 
@@ -89,10 +92,46 @@ def count_tokens(
         return max(len(text) // 4, 1)
 
 
+def _serialize_token_payload(values: Iterable[Any]) -> str:
+    def to_jsonable(value: Any) -> Any:
+        if hasattr(value, "model_dump"):
+            return to_jsonable(value.model_dump(mode="json"))
+        if isinstance(value, Mapping):
+            return {str(key): to_jsonable(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [to_jsonable(item) for item in value]
+        return value
+
+    return json.dumps(
+        [to_jsonable(value) for value in values],
+        ensure_ascii=False,
+        separators=(",", ":"),
+        default=str,
+    )
+
+
+def serialize_tool_calls(tool_calls: Iterable[Any]) -> str:
+    """Serialize provider or model tool-call objects for token counting."""
+    return _serialize_token_payload(tool_calls)
+
+
+def count_tool_definition_tokens(
+    tools: list[Any] | None,
+    model_id: str | None = None,
+    provider: str | None = None,
+) -> int:
+    """Estimate tokens consumed by the tool schemas sent with a request."""
+    if not tools:
+        return 0
+    return count_tokens(_serialize_token_payload(tools), model_id, provider)
+
+
 def count_message_tokens(
     messages: list[dict],
     model_id: str | None = None,
     provider: str | None = None,
+    *,
+    include_tool_calls: bool = False,
 ) -> int:
     """Count chat-message tokens without fabricating a model identifier.
 
@@ -114,6 +153,14 @@ def count_message_tokens(
                     continue
                 if isinstance(value, str):
                     total_tokens += len(encoding.encode(value))
+                elif (
+                    key == "tool_calls"
+                    and include_tool_calls
+                    and isinstance(value, list)
+                ):
+                    total_tokens += len(
+                        encoding.encode(_serialize_token_payload(value))
+                    )
                 elif isinstance(value, list):
                     # Handle content arrays (for vision)
                     for item in value:
@@ -142,6 +189,8 @@ def count_message_tokens(
                 for item in content:
                     if isinstance(item, dict) and item.get("type") == "text":
                         total_content += item.get("text", "")
+            if include_tool_calls and isinstance(msg.get("tool_calls"), list):
+                total_content += _serialize_token_payload(msg["tool_calls"])
         return max(len(total_content) // 4, 1)
 
 

--- a/backend/app/llm/types/base.py
+++ b/backend/app/llm/types/base.py
@@ -3,6 +3,7 @@
 """
 
 from enum import Enum
+
 from pydantic import BaseModel, Field
 
 
@@ -68,6 +69,15 @@ class Usage(BaseModel):
     prompt_tokens: int = Field(default=0, description="输入 token 数")
     completion_tokens: int = Field(default=0, description="输出 token 数")
     total_tokens: int = Field(default=0, description="总 token 数")
+    cache_read_tokens: int = Field(
+        default=0, description="缓存命中 token 数（按折扣价计费）"
+    )
+    cache_creation_tokens: int = Field(
+        default=0, description="缓存写入 token 数（Claude cache_creation）"
+    )
+    total_input_tokens: int = Field(
+        default=0, description="缓存命中率分母：请求的全部输入 token 数"
+    )
 
 
 class TaskStatus(str, Enum):

--- a/backend/app/locales/en/LC_MESSAGES/messages.po
+++ b/backend/app/locales/en/LC_MESSAGES/messages.po
@@ -429,6 +429,9 @@ msgstr "Deactivate user"
 msgid "audit_log_delete_agent"
 msgstr "Delete agent"
 
+msgid "audit_log_delete_message"
+msgstr "Delete message"
+
 msgid "audit_log_delete_api_key"
 msgstr "Delete API key"
 

--- a/backend/app/locales/zh/LC_MESSAGES/messages.po
+++ b/backend/app/locales/zh/LC_MESSAGES/messages.po
@@ -429,6 +429,9 @@ msgstr "停用用户"
 msgid "audit_log_delete_agent"
 msgstr "删除 Agent"
 
+msgid "audit_log_delete_message"
+msgstr "删除消息"
+
 msgid "audit_log_delete_api_key"
 msgstr "删除 API 密钥"
 

--- a/backend/app/services/audit_log.py
+++ b/backend/app/services/audit_log.py
@@ -318,22 +318,28 @@ class AuditLogService:
         sanitized: dict[str, Any] = {}
 
         for key, value in data.items():
-            # 检查是否是敏感字段
-            if any(
+            # Conversation token counters are safe numeric metrics, not secrets.
+            if (
+                key == "token_usage"
+                and isinstance(value, (int, float))
+                and not isinstance(value, bool)
+            ):
+                sanitized[key] = value
+            # Check whether this is a sensitive field.
+            elif any(
                 sensitive in key.lower()
                 for sensitive in AuditLogService.SENSITIVE_FIELDS
             ):
-                # 脱敏处理
+                # Mask sensitive values while preserving a short preview for strings.
                 if isinstance(value, str) and len(value) > 8:
-                    # 只显示前8位
                     sanitized[key] = value[:8] + "***"
                 else:
                     sanitized[key] = "***"
             elif isinstance(value, dict):
-                # 递归处理嵌套字典
+                # Recursively sanitize nested dictionaries.
                 sanitized[key] = AuditLogService._sanitize_dict(value)
             elif key == "email" and isinstance(value, str):
-                # 邮箱部分隐藏
+                # Mask the email local part.
                 sanitized[key] = AuditLogService._mask_email(value)
             else:
                 sanitized[key] = value

--- a/backend/app/services/audit_log.py
+++ b/backend/app/services/audit_log.py
@@ -99,6 +99,12 @@ class AuditLogService:
             "embedding_dimension",
             "settings",
         ),
+        "conversation": (
+            "title",
+            "message_count",
+            "token_usage",
+            "updated_at",
+        ),
         "document": (
             "name",
             "doc_type",
@@ -168,7 +174,6 @@ class AuditLogService:
             "is_enabled",
             "priority",
         ),
-        "conversation": ("title",),
         "skill": ("name", "display_name", "is_enabled", "version"),
         "team_member": ("team_id", "user_id", "role"),
         "tool_share": ("tool_id", "shared_with_team_id", "permission"),

--- a/backend/tests/api/test_agents.py
+++ b/backend/tests/api/test_agents.py
@@ -1,8 +1,8 @@
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
-
 import pytest
 from pydantic import ValidationError
 from starlette.requests import Request
@@ -47,6 +47,12 @@ class Query:
     def group_by(self, *args):
         return self._chain("group_by", *args)
 
+    def using_db(self, *_args):
+        return self
+
+    def select_for_update(self):
+        return self
+
     def values(self, *args):
         return self._chain("values", *args)
 
@@ -64,11 +70,19 @@ class Query:
         self.calls.append(("update", (), kwargs))
         return 1
 
+    async def refresh_from_db(self, **_kwargs):
+        return self.value
+
     def __await__(self):
         async def resolve():
             return self.value
 
         return resolve().__await__()
+
+
+@asynccontextmanager
+async def transaction():
+    yield object()
 
 
 def request() -> Request:
@@ -598,6 +612,14 @@ async def test_delete_message_updates_token_totals(monkeypatch):
     fixed_updated_at = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
     monkeypatch.setattr(agents, "now_utc", lambda: fixed_updated_at)
     conv = conversation(user_id=current_user.id)
+    original_updated_at = conv.updated_at
+
+    async def refresh_from_db(**_kwargs):
+        conv.message_count = 1
+        conv.token_usage = -2
+        conv.updated_at = fixed_updated_at
+
+    conv.refresh_from_db = AsyncMock(side_effect=refresh_from_db)
     message = SimpleNamespace(
         id=uuid4(),
         token_usage={"prompt": 3, "completion": 4},
@@ -606,6 +628,7 @@ async def test_delete_message_updates_token_totals(monkeypatch):
     conv_query = Query(conv)
     message_query = Query(message)
     audit_log = AsyncMock()
+    monkeypatch.setattr(agents, "in_transaction", transaction)
     monkeypatch.setattr(agents.Conversation, "filter", lambda **_kwargs: conv_query)
     monkeypatch.setattr(agents.Message, "filter", lambda **_kwargs: message_query)
     monkeypatch.setattr(agents.AuditLogService, "log", audit_log)
@@ -616,18 +639,20 @@ async def test_delete_message_updates_token_totals(monkeypatch):
     update = next(call for call in conv_query.calls if call[0] == "update")
     assert "token_usage" in update[2]
     assert update[2]["updated_at"] == fixed_updated_at
-    assert "updated_at" in update[2]
+    conv.refresh_from_db.assert_awaited_once()
     audit_log.assert_awaited_once()
     assert audit_log.call_args.kwargs["action"] == "delete_message"
-    assert audit_log.call_args.kwargs["changes"]["before"] == {
-        "message_count": 2,
-        "token_usage": 5,
-        "updated_at": conv.updated_at.isoformat(),
-    }
-    assert audit_log.call_args.kwargs["changes"]["after"] == {
-        "message_count": 1,
-        "token_usage": -2,
-        "updated_at": fixed_updated_at.isoformat(),
+    assert audit_log.call_args.kwargs["changes"] == {
+        "before": {
+            "message_count": 2,
+            "token_usage": 5,
+            "updated_at": original_updated_at.isoformat(),
+        },
+        "after": {
+            "message_count": 1,
+            "token_usage": -2,
+            "updated_at": fixed_updated_at.isoformat(),
+        },
     }
     message.delete.assert_awaited_once()
 
@@ -925,7 +950,9 @@ async def test_conversation_optional_and_not_found_branches(monkeypatch):
 async def test_delete_message_without_usage_updates_count(monkeypatch):
     current_user = user()
     conv = conversation(user_id=current_user.id)
+    monkeypatch.setattr(agents, "in_transaction", transaction)
     message = SimpleNamespace(id=uuid4(), token_usage=None, delete=AsyncMock())
+    conv.refresh_from_db = AsyncMock()
     conv_query = Query(conv)
     monkeypatch.setattr(agents.Conversation, "filter", lambda **_kwargs: conv_query)
     monkeypatch.setattr(agents.Message, "filter", lambda **_kwargs: Query(message))

--- a/backend/tests/api/test_agents.py
+++ b/backend/tests/api/test_agents.py
@@ -611,6 +611,7 @@ async def test_delete_message_updates_token_totals(monkeypatch):
     assert result["data"]["id"] == str(message.id)
     update = next(call for call in conv_query.calls if call[0] == "update")
     assert "token_usage" in update[2]
+    assert "updated_at" in update[2]
     message.delete.assert_awaited_once()
 
     message_query.value = None

--- a/backend/tests/api/test_agents.py
+++ b/backend/tests/api/test_agents.py
@@ -655,6 +655,7 @@ async def test_delete_message_updates_token_totals(monkeypatch):
         },
     }
     message.delete.assert_awaited_once()
+    assert "using_db" in message.delete.await_args.kwargs
 
     message_query.value = None
     with pytest.raises(BusinessError) as error:

--- a/backend/tests/api/test_agents.py
+++ b/backend/tests/api/test_agents.py
@@ -595,6 +595,8 @@ async def test_conversation_crud_and_missing_paths(monkeypatch):
 @pytest.mark.anyio
 async def test_delete_message_updates_token_totals(monkeypatch):
     current_user = user()
+    fixed_updated_at = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(agents, "now_utc", lambda: fixed_updated_at)
     conv = conversation(user_id=current_user.id)
     message = SimpleNamespace(
         id=uuid4(),
@@ -603,20 +605,35 @@ async def test_delete_message_updates_token_totals(monkeypatch):
     )
     conv_query = Query(conv)
     message_query = Query(message)
+    audit_log = AsyncMock()
     monkeypatch.setattr(agents.Conversation, "filter", lambda **_kwargs: conv_query)
     monkeypatch.setattr(agents.Message, "filter", lambda **_kwargs: message_query)
+    monkeypatch.setattr(agents.AuditLogService, "log", audit_log)
 
-    result = await agents.delete_message(conv.id, message.id, current_user)
+    result = await agents.delete_message(conv.id, message.id, request(), current_user)
 
     assert result["data"]["id"] == str(message.id)
     update = next(call for call in conv_query.calls if call[0] == "update")
     assert "token_usage" in update[2]
+    assert update[2]["updated_at"] == fixed_updated_at
     assert "updated_at" in update[2]
+    audit_log.assert_awaited_once()
+    assert audit_log.call_args.kwargs["action"] == "delete_message"
+    assert audit_log.call_args.kwargs["changes"]["before"] == {
+        "message_count": 2,
+        "token_usage": 5,
+        "updated_at": conv.updated_at.isoformat(),
+    }
+    assert audit_log.call_args.kwargs["changes"]["after"] == {
+        "message_count": 1,
+        "token_usage": -2,
+        "updated_at": fixed_updated_at.isoformat(),
+    }
     message.delete.assert_awaited_once()
 
     message_query.value = None
     with pytest.raises(BusinessError) as error:
-        await agents.delete_message(conv.id, uuid4(), current_user)
+        await agents.delete_message(conv.id, uuid4(), request(), current_user)
     assert error.value.msg_key == "message_not_found"
 
 
@@ -900,7 +917,7 @@ async def test_conversation_optional_and_not_found_branches(monkeypatch):
     assert error.value.msg_key == "conversation_not_found"
 
     with pytest.raises(BusinessError) as error:
-        await agents.delete_message(uuid4(), uuid4(), current_user)
+        await agents.delete_message(uuid4(), uuid4(), request(), current_user)
     assert error.value.msg_key == "conversation_not_found"
 
 
@@ -912,8 +929,9 @@ async def test_delete_message_without_usage_updates_count(monkeypatch):
     conv_query = Query(conv)
     monkeypatch.setattr(agents.Conversation, "filter", lambda **_kwargs: conv_query)
     monkeypatch.setattr(agents.Message, "filter", lambda **_kwargs: Query(message))
+    monkeypatch.setattr(agents.AuditLogService, "log", AsyncMock())
 
-    await agents.delete_message(conv.id, message.id, current_user)
+    await agents.delete_message(conv.id, message.id, request(), current_user)
 
     assert any(call[0] == "update" for call in conv_query.calls)
     message.delete.assert_awaited_once()

--- a/backend/tests/api/test_agents_conversation_branches_issue255.py
+++ b/backend/tests/api/test_agents_conversation_branches_issue255.py
@@ -8,6 +8,14 @@ from app.api.v1.endpoints import agents
 from starlette.requests import Request
 
 
+from contextlib import asynccontextmanager
+
+
+@asynccontextmanager
+async def transaction():
+    yield object()
+
+
 class Query:
     def __init__(self, value):
         self.value = value
@@ -17,14 +25,20 @@ class Query:
         self.calls.append((name, args, kwargs))
         return self
 
-    def prefetch_related(self, *args):
-        return self._chain("prefetch_related", *args)
+    async def update(self, **kwargs):
+        return self._chain("update", **kwargs)
+
+    async def refresh_from_db(self, **_kwargs):
+        return self.value
+
+    def using_db(self, *_args):
+        return self
+
+    def select_for_update(self):
+        return self
 
     async def first(self):
         return self.value
-
-    async def update(self, **kwargs):
-        return self._chain("update", **kwargs)
 
 
 @pytest.mark.anyio
@@ -71,12 +85,13 @@ async def test_get_conversation_without_messages_skips_version_query(monkeypatch
 async def test_delete_message_defaults_missing_token_usage_counters(
     monkeypatch, token_usage, expected_tokens
 ):
-    conversation = SimpleNamespace(id=uuid4())
+    conversation = SimpleNamespace(id=uuid4(), refresh_from_db=AsyncMock())
     message = SimpleNamespace(id=uuid4(), token_usage=token_usage, delete=AsyncMock())
     conversation_query = Query(conversation)
     monkeypatch.setattr(
         agents.Conversation, "filter", lambda **_kwargs: conversation_query
     )
+    monkeypatch.setattr(agents, "in_transaction", lambda: transaction())
     monkeypatch.setattr(agents.Message, "filter", lambda **_kwargs: Query(message))
     monkeypatch.setattr(agents.AuditLogService, "log", AsyncMock())
 

--- a/backend/tests/api/test_agents_conversation_branches_issue255.py
+++ b/backend/tests/api/test_agents_conversation_branches_issue255.py
@@ -34,6 +34,9 @@ class Query:
     def using_db(self, *_args):
         return self
 
+    def prefetch_related(self, *args, **kwargs):
+        return self._chain("prefetch_related", *args, **kwargs)
+
     def select_for_update(self):
         return self
 
@@ -109,3 +112,4 @@ async def test_delete_message_defaults_missing_token_usage_counters(
     update = next(call for call in conversation_query.calls if call[0] == "update")
     assert update[2]["token_usage"].right.value == expected_tokens
     message.delete.assert_awaited_once()
+    assert "using_db" in message.delete.await_args.kwargs

--- a/backend/tests/api/test_agents_conversation_branches_issue255.py
+++ b/backend/tests/api/test_agents_conversation_branches_issue255.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 
 from app.api.v1.endpoints import agents
+from starlette.requests import Request
 
 
 class Query:
@@ -77,8 +78,18 @@ async def test_delete_message_defaults_missing_token_usage_counters(
         agents.Conversation, "filter", lambda **_kwargs: conversation_query
     )
     monkeypatch.setattr(agents.Message, "filter", lambda **_kwargs: Query(message))
+    monkeypatch.setattr(agents.AuditLogService, "log", AsyncMock())
 
-    await agents.delete_message(conversation.id, message.id, SimpleNamespace())
+    request = Request(
+        {
+            "type": "http",
+            "method": "DELETE",
+            "path": "/conversations",
+            "headers": [],
+            "query_string": b"",
+        }
+    )
+    await agents.delete_message(conversation.id, message.id, request, SimpleNamespace())
 
     update = next(call for call in conversation_query.calls if call[0] == "update")
     assert update[2]["token_usage"].right.value == expected_tokens

--- a/backend/tests/api/test_chat_edit_stream_issue255.py
+++ b/backend/tests/api/test_chat_edit_stream_issue255.py
@@ -273,7 +273,13 @@ async def test_edit_stream_creates_version_and_persists_regenerated_reply(monkey
     assert state.assistant.model_used == state.model_id
     assert state.assistant.round_status == MessageRoundStatus.COMPLETED
     assert state.assistant.created_at == "completed-at"
-    assert state.assistant.token_usage == {"prompt": 31, "completion": 17}
+    assert state.assistant.token_usage == {
+        "prompt": 31,
+        "completion": 17,
+        "cache_read": 0,
+        "cache_creation": 0,
+        "total_input": 31,
+    }
     state.assistant.save.assert_awaited_once()
     assert chat.activate_conversation_branch.await_count == 2
     chat.stale_session_memory_if_source_outside_active_branch.assert_awaited_once_with(
@@ -288,6 +294,9 @@ async def test_edit_stream_creates_version_and_persists_regenerated_reply(monkey
         "prompt_tokens": 31,
         "completion_tokens": 17,
         "total_tokens": 48,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "total_input_tokens": 31,
     }
     state.agent_stats.update.assert_awaited_once()
     state.team_stats.update.assert_awaited_once()

--- a/backend/tests/api/test_chat_edit_stream_issue255.py
+++ b/backend/tests/api/test_chat_edit_stream_issue255.py
@@ -133,6 +133,7 @@ async def setup_edit(monkeypatch, *, rag_mode=RAGMode.OFF):
         "app.services.sandbox.gateway.sandbox_gateway.create_session",
         AsyncMock(return_value="sandbox-session"),
     )
+    monkeypatch.setattr("app.llm.model_manager.record_stream_usage", AsyncMock())
     monkeypatch.setattr(chat, "collect_conversation_images", lambda *_args: ([], []))
     monkeypatch.setattr(
         chat, "append_conversation_image_inventory", lambda text, _inventory: text

--- a/backend/tests/api/test_chat_edit_stream_issue255.py
+++ b/backend/tests/api/test_chat_edit_stream_issue255.py
@@ -8,7 +8,7 @@ import pytest
 
 from app.api.v1.endpoints import chat
 from app.llm.errors import LLMError
-from app.llm.types import ChatStreamChunk, ChatStreamDelta, FinishReason, Message
+from app.llm.types import ChatStreamChunk, ChatStreamDelta, FinishReason, Message, Usage
 from app.models.agent import MessageRole, MessageRoundStatus, RAGMode
 from app.schemas.agent import EditMessageRequest
 from app.schemas.response import BusinessError, ResponseCode
@@ -237,6 +237,7 @@ async def test_edit_stream_creates_version_and_persists_regenerated_reply(monkey
             id="content",
             model="stub/unit-model",
             delta=ChatStreamDelta(content="new answer"),
+            usage=Usage(prompt_tokens=31, completion_tokens=17, total_tokens=48),
             finish_reason=FinishReason.LENGTH,
         ),
     ]
@@ -272,7 +273,7 @@ async def test_edit_stream_creates_version_and_persists_regenerated_reply(monkey
     assert state.assistant.model_used == state.model_id
     assert state.assistant.round_status == MessageRoundStatus.COMPLETED
     assert state.assistant.created_at == "completed-at"
-    assert state.assistant.token_usage == {"prompt": 3, "completion": 2}
+    assert state.assistant.token_usage == {"prompt": 31, "completion": 17}
     state.assistant.save.assert_awaited_once()
     assert chat.activate_conversation_branch.await_count == 2
     chat.stale_session_memory_if_source_outside_active_branch.assert_awaited_once_with(
@@ -284,9 +285,9 @@ async def test_edit_stream_creates_version_and_persists_regenerated_reply(monkey
     )
     chat.AuditLogService.log.assert_awaited_once()
     assert end["usage"] == {
-        "prompt_tokens": 3,
-        "completion_tokens": 2,
-        "total_tokens": 5,
+        "prompt_tokens": 31,
+        "completion_tokens": 17,
+        "total_tokens": 48,
     }
     state.agent_stats.update.assert_awaited_once()
     state.team_stats.update.assert_awaited_once()

--- a/backend/tests/api/test_chat_edit_stream_remaining_arcs_issue255.py
+++ b/backend/tests/api/test_chat_edit_stream_remaining_arcs_issue255.py
@@ -151,6 +151,7 @@ async def setup_edit(monkeypatch, *, max_iterations=2, active=True):
         "app.services.sandbox.gateway.sandbox_gateway.create_session",
         AsyncMock(return_value="session"),
     )
+    monkeypatch.setattr("app.llm.model_manager.record_stream_usage", AsyncMock())
     monkeypatch.setattr(chat, "collect_conversation_images", lambda *_args: ([], []))
     monkeypatch.setattr(
         chat, "append_conversation_image_inventory", lambda text, _inventory: text

--- a/backend/tests/api/test_chat_endpoint_edge_branches_issue255.py
+++ b/backend/tests/api/test_chat_endpoint_edge_branches_issue255.py
@@ -252,7 +252,13 @@ async def test_stream_finish_length_emits_truncation_and_records_zero_usage(
     assert "event: output_truncated" in body
     assert "event: message_end" in body
     assert record_usage.await_count == 0
-    assert chat_env.created[1].token_usage == {"prompt": 8, "completion": 0}
+    assert chat_env.created[1].token_usage == {
+        "prompt": 8,
+        "completion": 0,
+        "cache_read": 0,
+        "cache_creation": 0,
+        "total_input": 8,
+    }
     assert chat_env.created[1].is_manually_stopped is False
 
 

--- a/backend/tests/api/test_chat_endpoint_edge_branches_issue255.py
+++ b/backend/tests/api/test_chat_endpoint_edge_branches_issue255.py
@@ -251,8 +251,8 @@ async def test_stream_finish_length_emits_truncation_and_records_zero_usage(
 
     assert "event: output_truncated" in body
     assert "event: message_end" in body
-    assert record_usage.await_args_list[0][1]["output_text_length"] == 0
-    assert chat_env.created[1].content == ""
+    assert record_usage.await_count == 0
+    assert chat_env.created[1].token_usage == {"prompt": 8, "completion": 0}
     assert chat_env.created[1].is_manually_stopped is False
 
 

--- a/backend/tests/api/test_chat_endpoint_helpers_issue255.py
+++ b/backend/tests/api/test_chat_endpoint_helpers_issue255.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
@@ -22,6 +23,75 @@ def _chunk(**kwargs):
         delta=ChatStreamDelta(**kwargs.pop("delta", {})),
         **kwargs,
     )
+
+
+def test_calculate_model_usage_prefers_provider_totals(monkeypatch):
+    monkeypatch.setattr(
+        chat,
+        "count_message_tokens",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError()),
+    )
+    monkeypatch.setattr(
+        chat,
+        "count_tokens",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError()),
+    )
+
+    assert chat._calculate_model_usage(
+        messages=[{"role": "user", "content": "question"}],
+        content="answer",
+        reasoning_content=None,
+        tool_calls=None,
+        tools=None,
+        usage=SimpleNamespace(prompt_tokens=13, completion_tokens=5),
+        model_id="unit-model",
+        provider="stub",
+    ) == (13, 5)
+
+
+def test_calculate_model_usage_counts_messages_and_output_without_provider_totals(
+    monkeypatch,
+):
+    monkeypatch.setattr(chat, "count_message_tokens", lambda *_args, **_kwargs: 11)
+    monkeypatch.setattr(chat, "count_tokens", lambda text, *_args: len(text))
+
+    assert chat._calculate_model_usage(
+        messages=[{"role": "user", "content": "question"}],
+        content="answer",
+        reasoning_content="think",
+        tool_calls=None,
+        tools=None,
+        usage=None,
+        model_id="unit-model",
+        provider="stub",
+    ) == (11, 11)
+
+
+def test_calculate_model_usage_counts_tool_request_payloads(monkeypatch):
+    message_tokens = Mock(return_value=11)
+    tool_definition_tokens = Mock(return_value=7)
+    monkeypatch.setattr(chat, "count_message_tokens", message_tokens)
+    monkeypatch.setattr(chat, "count_tool_definition_tokens", tool_definition_tokens)
+    monkeypatch.setattr(chat, "count_tokens", lambda text, *_args: len(text))
+    tools = [{"type": "function", "function": {"name": "lookup"}}]
+
+    assert chat._calculate_model_usage(
+        messages=[{"role": "user", "content": "question"}],
+        content="answer",
+        reasoning_content=None,
+        tool_calls=None,
+        tools=tools,
+        usage=None,
+        model_id="unit-model",
+        provider="stub",
+    ) == (18, 6)
+    message_tokens.assert_called_once_with(
+        [{"role": "user", "content": "question"}],
+        "unit-model",
+        "stub",
+        include_tool_calls=True,
+    )
+    tool_definition_tokens.assert_called_once_with(tools, "unit-model", "stub")
 
 
 def test_stream_activity_detects_keepalive_and_model_output_boundaries():

--- a/backend/tests/api/test_chat_endpoint_helpers_issue255.py
+++ b/backend/tests/api/test_chat_endpoint_helpers_issue255.py
@@ -43,10 +43,15 @@ def test_calculate_model_usage_prefers_provider_totals(monkeypatch):
         reasoning_content=None,
         tool_calls=None,
         tools=None,
-        usage=SimpleNamespace(prompt_tokens=13, completion_tokens=5),
+        usage=SimpleNamespace(
+            prompt_tokens=13,
+            completion_tokens=5,
+            cache_read_tokens=4,
+            cache_creation_tokens=2,
+        ),
         model_id="unit-model",
         provider="stub",
-    ) == (13, 5)
+    ) == (13, 5, 4, 2, 13)
 
 
 def test_calculate_model_usage_counts_messages_and_output_without_provider_totals(
@@ -64,7 +69,7 @@ def test_calculate_model_usage_counts_messages_and_output_without_provider_total
         usage=None,
         model_id="unit-model",
         provider="stub",
-    ) == (11, 11)
+    ) == (11, 11, 0, 0, 11)
 
 
 def test_calculate_model_usage_counts_tool_request_payloads(monkeypatch):
@@ -84,7 +89,7 @@ def test_calculate_model_usage_counts_tool_request_payloads(monkeypatch):
         usage=None,
         model_id="unit-model",
         provider="stub",
-    ) == (18, 6)
+    ) == (18, 6, 0, 0, 18)
     message_tokens.assert_called_once_with(
         [{"role": "user", "content": "question"}],
         "unit-model",

--- a/backend/tests/api/test_chat_generators_residual_issue255.py
+++ b/backend/tests/api/test_chat_generators_residual_issue255.py
@@ -274,6 +274,7 @@ async def setup_regenerate(monkeypatch, *, rag_mode=RAGMode.OFF, branch_parent_i
         "app.services.sandbox.gateway.sandbox_gateway.create_session",
         AsyncMock(return_value="session"),
     )
+    monkeypatch.setattr("app.llm.model_manager.record_stream_usage", AsyncMock())
     monkeypatch.setattr(chat, "collect_conversation_images", lambda *_a: ([], []))
     monkeypatch.setattr(
         chat, "append_conversation_image_inventory", lambda text, _images: text

--- a/backend/tests/api/test_chat_nonstream_orchestration_issue255.py
+++ b/backend/tests/api/test_chat_nonstream_orchestration_issue255.py
@@ -220,12 +220,21 @@ async def test_chat_persists_rag_attachments_and_completed_round(monkeypatch):
     user_message.save.assert_awaited_once_with(update_fields=["file_urls"])
     assert assistant.content == "answer"
     assert assistant.model_used == state.model_id
-    assert assistant.token_usage == {"prompt": 3, "completion": 2}
+    assert assistant.token_usage == {
+        "prompt": 3,
+        "completion": 2,
+        "cache_read": 0,
+        "cache_creation": 0,
+        "total_input": 3,
+    }
     assert assistant.round_status == MessageRoundStatus.COMPLETED
     assert result["data"].usage == {
         "prompt_tokens": 3,
         "completion_tokens": 2,
         "total_tokens": 5,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "total_input_tokens": 3,
     }
     chat.activate_conversation_branch.assert_awaited_once_with(
         state.conversation.id, [user_message, assistant]
@@ -325,7 +334,13 @@ async def test_chat_executes_tool_round_and_aggregates_usage(monkeypatch):
     assert tool_result.content == {"answer": 42}
     assert tool_result.tool_call_id == "call-1"
     assert assistant.content == "final answer"
-    assert assistant.token_usage == {"prompt": 6, "completion": 4}
+    assert assistant.token_usage == {
+        "prompt": 6,
+        "completion": 4,
+        "cache_read": 0,
+        "cache_creation": 0,
+        "total_input": 6,
+    }
     assert result["data"].usage["total_tokens"] == 10
     execute.assert_awaited_once_with(
         "lookup",

--- a/backend/tests/api/test_chat_nonstream_residual_companion_issue255.py
+++ b/backend/tests/api/test_chat_nonstream_residual_companion_issue255.py
@@ -330,7 +330,13 @@ async def test_chat_caps_tool_iterations_with_invalid_arguments_and_display_fall
     final_msg = ctx.created_messages[-1]
     assert final_msg.reasoning_content is None
     assert final_msg.tool_calls is None
-    assert final_msg.token_usage == {"prompt": 2, "completion": 5}
+    assert final_msg.token_usage == {
+        "prompt": 2,
+        "completion": 5,
+        "cache_read": 0,
+        "cache_creation": 0,
+        "total_input": 2,
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_chat_nonstream_target_arcs_issue255_companion.py
+++ b/backend/tests/api/test_chat_nonstream_target_arcs_issue255_companion.py
@@ -239,7 +239,7 @@ async def test_nonstream_accepts_response_without_usage(monkeypatch):
 
     result = await run_chat(state)
 
-    assert result["data"].usage["total_tokens"] == 0
+    assert result["data"].usage["total_tokens"] == 9
 
 
 @pytest.mark.anyio

--- a/backend/tests/api/test_chat_regenerate_outer_loop_companion_issue255.py
+++ b/backend/tests/api/test_chat_regenerate_outer_loop_companion_issue255.py
@@ -125,6 +125,7 @@ async def setup_regeneration(
         "app.services.sandbox.gateway.sandbox_gateway.create_session",
         AsyncMock(return_value="session"),
     )
+    monkeypatch.setattr("app.llm.model_manager.record_stream_usage", AsyncMock())
     monkeypatch.setattr(chat, "collect_conversation_images", lambda *_args: ([], []))
     monkeypatch.setattr(
         chat, "append_conversation_image_inventory", lambda text, _inventory: text

--- a/backend/tests/api/test_chat_regenerate_stream_issue255.py
+++ b/backend/tests/api/test_chat_regenerate_stream_issue255.py
@@ -213,7 +213,13 @@ async def test_regenerate_stream_persists_and_activates_new_version(monkeypatch)
     assert state.created.version_number == 3
     assert state.created.round_status == MessageRoundStatus.COMPLETED
     assert state.created.created_at == "completed-at"
-    assert state.created.token_usage == {"prompt": 23, "completion": 13}
+    assert state.created.token_usage == {
+        "prompt": 23,
+        "completion": 13,
+        "cache_read": 0,
+        "cache_creation": 0,
+        "total_input": 23,
+    }
     state.created.save.assert_awaited_once()
     chat.activate_conversation_branch.assert_awaited_once_with(
         state.conversation.id, [state.user_message, state.created]
@@ -229,6 +235,9 @@ async def test_regenerate_stream_persists_and_activates_new_version(monkeypatch)
         "prompt_tokens": 23,
         "completion_tokens": 13,
         "total_tokens": 36,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "total_input_tokens": 23,
     }
     assert prepare.await_count == 1
     for call in prepare.call_args_list:

--- a/backend/tests/api/test_chat_regenerate_stream_issue255.py
+++ b/backend/tests/api/test_chat_regenerate_stream_issue255.py
@@ -139,6 +139,7 @@ async def setup_regeneration(monkeypatch):
     )
 
     monkeypatch.setattr(chat, "enqueue_session_memory_extraction", Mock())
+    monkeypatch.setattr("app.llm.model_manager.record_stream_usage", AsyncMock())
     monkeypatch.setattr(chat, "now_utc", lambda: "completed-at")
 
     response = await chat.regenerate_message(

--- a/backend/tests/api/test_chat_regenerate_stream_issue255.py
+++ b/backend/tests/api/test_chat_regenerate_stream_issue255.py
@@ -8,7 +8,7 @@ import pytest
 
 from app.api.v1.endpoints import chat
 from app.llm.errors import LLMError
-from app.llm.types import ChatStreamChunk, ChatStreamDelta, FinishReason, Message
+from app.llm.types import ChatStreamChunk, ChatStreamDelta, FinishReason, Message, Usage
 from app.models.agent import MessageRole, MessageRoundStatus, RAGMode
 from app.schemas.agent import RegenerateRequest
 from app.schemas.response import BusinessError, ResponseCode
@@ -187,6 +187,7 @@ async def test_regenerate_stream_persists_and_activates_new_version(monkeypatch)
             id="content",
             model="stub/unit-model",
             delta=ChatStreamDelta(content="new answer"),
+            usage=Usage(prompt_tokens=23, completion_tokens=13, total_tokens=36),
             finish_reason=FinishReason.STOP,
         ),
     ]
@@ -212,7 +213,7 @@ async def test_regenerate_stream_persists_and_activates_new_version(monkeypatch)
     assert state.created.version_number == 3
     assert state.created.round_status == MessageRoundStatus.COMPLETED
     assert state.created.created_at == "completed-at"
-    assert state.created.token_usage == {"prompt": 3, "completion": 2}
+    assert state.created.token_usage == {"prompt": 23, "completion": 13}
     state.created.save.assert_awaited_once()
     chat.activate_conversation_branch.assert_awaited_once_with(
         state.conversation.id, [state.user_message, state.created]
@@ -225,11 +226,11 @@ async def test_regenerate_stream_persists_and_activates_new_version(monkeypatch)
         state.agent, state.conversation, state.created
     )
     assert end["usage"] == {
-        "prompt_tokens": 3,
-        "completion_tokens": 2,
-        "total_tokens": 5,
+        "prompt_tokens": 23,
+        "completion_tokens": 13,
+        "total_tokens": 36,
     }
-    assert prepare.await_count == 2
+    assert prepare.await_count == 1
     for call in prepare.call_args_list:
         # Regenerate must not leak the old round's tool-call chain into history:
         # the cutoff is the triggering user message, not the old assistant reply.

--- a/backend/tests/api/test_chat_residual_issue255.py
+++ b/backend/tests/api/test_chat_residual_issue255.py
@@ -238,6 +238,9 @@ async def test_chat_retries_context_length_from_initial_prepare(chat_harness):
         "prompt_tokens": 3,
         "completion_tokens": 4,
         "total_tokens": 7,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "total_input_tokens": 3,
     }
 
 

--- a/backend/tests/api/test_chat_residual_max_iterations_issue255.py
+++ b/backend/tests/api/test_chat_residual_max_iterations_issue255.py
@@ -225,6 +225,9 @@ async def test_chat_tool_loop_terminal_message_when_max_iterations_reached(monke
         "prompt_tokens": 3,
         "completion_tokens": 4,
         "total_tokens": 7,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "total_input_tokens": 3,
     }
 
 

--- a/backend/tests/api/test_chat_send_stream_core.py
+++ b/backend/tests/api/test_chat_send_stream_core.py
@@ -193,7 +193,13 @@ async def test_chat_success_persists_round_and_usage(core_chat, monkeypatch):
     assert result["data"].usage["total_tokens"] == 10
     assert user_message.role == MessageRole.USER
     assert assistant_message.branch_parent_id == user_message.id
-    assert assistant_message.token_usage == {"prompt": 7, "completion": 3}
+    assert assistant_message.token_usage == {
+        "prompt": 7,
+        "completion": 3,
+        "cache_read": 0,
+        "cache_creation": 0,
+        "total_input": 7,
+    }
     assert assistant_message.round_status == MessageRoundStatus.COMPLETED
     chat_api.activate_conversation_branch.assert_awaited_once()
 

--- a/backend/tests/api/test_chat_sse_triptych_issue255.py
+++ b/backend/tests/api/test_chat_sse_triptych_issue255.py
@@ -362,7 +362,13 @@ async def test_chat_stream_persists_reasoning_content_and_usage(monkeypatch):
     assert assistant.content == "answer"
     assert assistant.reasoning_content == "thinking"
     assert assistant.round_status == MessageRoundStatus.COMPLETED
-    assert assistant.token_usage == {"prompt": 29, "completion": 11}
+    assert assistant.token_usage == {
+        "prompt": 29,
+        "completion": 11,
+        "cache_read": 0,
+        "cache_creation": 0,
+        "total_input": 29,
+    }
     assistant.save.assert_awaited_once()
     chat.activate_conversation_branch.assert_awaited_once()
     record_usage.assert_awaited_once_with(
@@ -690,6 +696,12 @@ async def test_edit_generator_persists_rag_reasoning_and_truncation(monkeypatch)
     assert assistant.content == "answer"
     assert assistant.reasoning_content == "thinking"
     assert assistant.round_status == MessageRoundStatus.COMPLETED
-    assert assistant.token_usage == {"prompt": 8, "completion": 2}
+    assert assistant.token_usage == {
+        "prompt": 8,
+        "completion": 2,
+        "cache_read": 0,
+        "cache_creation": 0,
+        "total_input": 8,
+    }
     assistant.save.assert_awaited_once()
     assert chat.activate_conversation_branch.await_count == 2

--- a/backend/tests/api/test_chat_sse_triptych_issue255.py
+++ b/backend/tests/api/test_chat_sse_triptych_issue255.py
@@ -443,6 +443,7 @@ async def setup_regenerate(monkeypatch, *, rag_mode=RAGMode.OFF, branch_parent_i
         "app.services.sandbox.gateway.sandbox_gateway.create_session",
         AsyncMock(return_value="session"),
     )
+    monkeypatch.setattr("app.llm.model_manager.record_stream_usage", AsyncMock())
     monkeypatch.setattr(chat, "collect_conversation_images", lambda *_a: ([], []))
     monkeypatch.setattr(
         chat, "append_conversation_image_inventory", lambda text, _images: text
@@ -667,6 +668,7 @@ async def test_edit_generator_persists_rag_reasoning_and_truncation(monkeypatch)
     monkeypatch.setattr(
         "app.llm.model_manager.team_chat_stream", lambda **_kwargs: object()
     )
+    monkeypatch.setattr("app.llm.model_manager.record_stream_usage", AsyncMock())
     monkeypatch.setattr(chat, "activate_conversation_branch", AsyncMock())
     monkeypatch.setattr(
         chat, "stale_session_memory_if_source_outside_active_branch", AsyncMock()

--- a/backend/tests/api/test_chat_sse_triptych_issue255.py
+++ b/backend/tests/api/test_chat_sse_triptych_issue255.py
@@ -327,6 +327,7 @@ async def test_chat_stream_persists_reasoning_content_and_usage(monkeypatch):
             id="answer",
             model="stub",
             delta=ChatStreamDelta(content="answer"),
+            usage=Usage(prompt_tokens=29, completion_tokens=11, total_tokens=40),
             finish_reason=FinishReason.STOP,
         )
 
@@ -361,14 +362,22 @@ async def test_chat_stream_persists_reasoning_content_and_usage(monkeypatch):
     assert assistant.content == "answer"
     assert assistant.reasoning_content == "thinking"
     assert assistant.round_status == MessageRoundStatus.COMPLETED
+    assert assistant.token_usage == {"prompt": 29, "completion": 11}
     assistant.save.assert_awaited_once()
     chat.activate_conversation_branch.assert_awaited_once()
     record_usage.assert_awaited_once_with(
         team_id=str(agent.team_id),
         model_id=ANY,
-        input_text_length=5,
-        output_text_length=14,
+        input_tokens=29,
+        output_tokens=11,
     )
+    conversation_update = next(
+        call.kwargs
+        for call in update_query.update.await_args_list
+        if "token_usage" in call.kwargs
+    )
+    assert "updated_at" in conversation_update
+    assert chat.prepare_model_context.await_count == 1
 
 
 async def setup_regenerate(monkeypatch, *, rag_mode=RAGMode.OFF, branch_parent_id=None):
@@ -681,6 +690,6 @@ async def test_edit_generator_persists_rag_reasoning_and_truncation(monkeypatch)
     assert assistant.content == "answer"
     assert assistant.reasoning_content == "thinking"
     assert assistant.round_status == MessageRoundStatus.COMPLETED
-    assert assistant.token_usage == {"prompt": 2, "completion": 1}
+    assert assistant.token_usage == {"prompt": 8, "completion": 2}
     assistant.save.assert_awaited_once()
     assert chat.activate_conversation_branch.await_count == 2

--- a/backend/tests/api/test_chat_stream_loop_arcs_issue255_companion.py
+++ b/backend/tests/api/test_chat_stream_loop_arcs_issue255_companion.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
@@ -422,3 +423,64 @@ async def test_stream_tool_emits_media_result(monkeypatch):
     assert "event: tool_result" in events
     assert "media" in events
     assert "event: iteration_cap_reached" in events
+
+
+@pytest.mark.anyio
+async def test_stream_uses_provider_usage_from_terminal_chunk(monkeypatch):
+    state = await setup_stream(monkeypatch)
+    # OpenAI/DeepSeek 风格：usage 在 finish 之后的独立 chunk（choices 为空）
+    monkeypatch.setattr(
+        "app.llm.model_manager.team_chat_stream",
+        lambda **_kwargs: chunks(
+            ChatStreamChunk(
+                id="content",
+                model="stub",
+                delta=ChatStreamDelta(content="answer"),
+            ),
+            ChatStreamChunk(
+                id="done",
+                model="stub",
+                delta=ChatStreamDelta(),
+                finish_reason=FinishReason.STOP,
+            ),
+            ChatStreamChunk(
+                id="usage",
+                model="stub",
+                delta=ChatStreamDelta(),
+                usage=Usage(
+                    prompt_tokens=10,
+                    completion_tokens=4,
+                    total_tokens=14,
+                    cache_read_tokens=6,
+                    cache_creation_tokens=2,
+                ),
+            ),
+        ),
+    )
+
+    events = await collect(state.response)
+
+    assert "event: content_delta" in events
+    assert "event: message_end" in events
+    data_line = next(
+        line
+        for line in events.split("\n")
+        if line.startswith("data:") and '"usage"' in line
+    )
+    payload = json.loads(data_line[len("data:") :])
+    assert payload["usage"] == {
+        "prompt_tokens": 10,
+        "completion_tokens": 4,
+        "total_tokens": 14,
+        "cache_read_tokens": 6,
+        "cache_creation_tokens": 2,
+        "total_input_tokens": 10,
+    }
+    # 接口返回的 usage 优先于本地 tiktoken 估算被持久化
+    assert state.created[1].token_usage == {
+        "prompt": 10,
+        "completion": 4,
+        "cache_read": 6,
+        "cache_creation": 2,
+        "total_input": 10,
+    }

--- a/backend/tests/api/test_chat_stream_nonstream_residual_issue255.py
+++ b/backend/tests/api/test_chat_stream_nonstream_residual_issue255.py
@@ -248,6 +248,9 @@ async def test_nonstream_retries_prepare_context_and_cleans_user_input_request(
         "prompt_tokens": 8,
         "completion_tokens": 4,
         "total_tokens": 12,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "total_input_tokens": 8,
     }
     assert created[0].file_urls == [{"url": "updated"}]
     assert created[-1].content == "clean answer"

--- a/backend/tests/api/test_chat_stream_nonstream_residual_issue255.py
+++ b/backend/tests/api/test_chat_stream_nonstream_residual_issue255.py
@@ -320,4 +320,4 @@ async def test_stream_empty_upstream_falls_back_to_nonstream_reasoning_and_conte
     assert created[-1].content == "fallback content"
     assert created[-1].reasoning_content == "fallback reasoning"
     assert created[-1].round_status == MessageRoundStatus.COMPLETED
-    record_usage.assert_awaited_once()
+    record_usage.assert_not_awaited()

--- a/backend/tests/llm/test_anthropic_adapter.py
+++ b/backend/tests/llm/test_anthropic_adapter.py
@@ -1,14 +1,16 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from app.llm.adapters.chat.anthropic_adapter import AnthropicAdapter
 from app.llm.types import (
     FinishReason,
+    FunctionCall,
     FunctionDefinition,
     Message,
     MessageRole,
+    ToolCall,
     ToolDefinition,
 )
 
@@ -71,7 +73,12 @@ async def test_chat_builds_request_and_normalizes_mixed_response():
                 type="tool_use", id="call-1", name="lookup", input={"q": "docs"}
             ),
         ],
-        usage=SimpleNamespace(input_tokens=9, output_tokens=4),
+        usage=SimpleNamespace(
+            input_tokens=9,
+            output_tokens=4,
+            cache_read_input_tokens=6,
+            cache_creation_input_tokens=3,
+        ),
     )
     client = build_client(response=response)
     adapter = build_adapter(
@@ -123,6 +130,9 @@ async def test_chat_builds_request_and_normalizes_mixed_response():
         "prompt_tokens": 9,
         "completion_tokens": 4,
         "total_tokens": 13,
+        "cache_read_tokens": 6,
+        "cache_creation_tokens": 3,
+        "total_input_tokens": 18,
     }
     client.close.assert_awaited_once()
 
@@ -237,4 +247,200 @@ async def test_chat_stream_closes_client_when_iteration_fails():
         ):
             pass
 
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_chat_stream_captures_usage_from_message_delta():
+    events = [
+        SimpleNamespace(
+            type="content_block_delta",
+            delta=SimpleNamespace(type="text_delta", text="answer"),
+        ),
+        SimpleNamespace(
+            type="message_delta",
+            delta=SimpleNamespace(stop_reason="end_turn"),
+            usage=SimpleNamespace(
+                input_tokens=9,
+                output_tokens=4,
+                cache_read_input_tokens=6,
+                cache_creation_input_tokens=3,
+            ),
+        ),
+    ]
+    stream = AsyncStream(events)
+    client = build_client(stream=stream)
+
+    with patch("anthropic.AsyncAnthropic", return_value=client):
+        chunks = [
+            chunk
+            async for chunk in build_adapter().chat_stream(
+                [Message(role=MessageRole.USER, content="Hi")]
+            )
+        ]
+
+    assert chunks[-1].finish_reason is FinishReason.STOP
+    assert chunks[-1].usage.model_dump() == {
+        "prompt_tokens": 9,
+        "completion_tokens": 4,
+        "total_tokens": 13,
+        "cache_read_tokens": 6,
+        "cache_creation_tokens": 3,
+        "total_input_tokens": 18,
+    }
+    client.close.assert_awaited_once()
+
+
+LONG_TEXT = "cache me " * 2000  # cl100k 估算远超 1024 token 缓存门槛
+
+
+def _tool_def():
+    return ToolDefinition(
+        type="function",
+        function=FunctionDefinition(
+            name="lookup",
+            description="lookup",
+            parameters={"type": "object", "properties": {"q": {"type": "string"}}},
+        ),
+    )
+
+
+def _tool_use_message():
+    return Message(
+        role=MessageRole.ASSISTANT,
+        content="first answer",
+        tool_calls=[
+            ToolCall(
+                id="call-1",
+                type="function",
+                function=FunctionCall(name="lookup", arguments='{"q":"x"}'),
+            )
+        ],
+    )
+
+
+def _tool_result_message():
+    return Message(role=MessageRole.TOOL, tool_call_id="call-1", content="tool result")
+
+
+@pytest.mark.anyio
+async def test_chat_adds_cache_breakpoints_to_system_tools_and_history():
+    messages = [
+        Message(role=MessageRole.SYSTEM, content=LONG_TEXT),
+        Message(role=MessageRole.USER, content="first question " + LONG_TEXT),
+        _tool_use_message(),
+        _tool_result_message(),
+        Message(role=MessageRole.USER, content="second question " + LONG_TEXT),
+        _tool_use_message(),
+        _tool_result_message(),
+        Message(role=MessageRole.USER, content="third question " + LONG_TEXT),
+    ]
+    response = SimpleNamespace(
+        id="response-1",
+        content=[SimpleNamespace(type="text", text="done")],
+        stop_reason="end_turn",
+        usage=SimpleNamespace(input_tokens=9, output_tokens=4),
+    )
+    client = build_client(response=response)
+    adapter = build_adapter()
+
+    with patch("anthropic.AsyncAnthropic", return_value=client):
+        await adapter.chat(messages, tools=[_tool_def()])
+
+    request = client.messages.create.await_args.kwargs
+    # system → 块数组 + cache_control
+    assert request["system"] == [
+        {"type": "text", "text": LONG_TEXT, "cache_control": {"type": "ephemeral"}}
+    ]
+    # tools → 最后一个工具带 cache_control
+    assert request["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+    # 第一条 + 倒数第二条真 user 消息打点，当前请求的最后一条 user 不打点
+    user_contents = [
+        msg["content"] for msg in request["messages"] if msg["role"] == "user"
+    ]
+    assert len(user_contents) == 5  # 3 真 user + 2 tool_result
+    assert user_contents[0][0]["cache_control"] == {"type": "ephemeral"}
+    assert user_contents[2][0]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_control" not in user_contents[3][0]  # tool_result 不打点
+    assert "cache_control" not in user_contents[4][0]  # 当前请求 user 不打点
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_chat_stream_adds_cache_breakpoints():
+    events = [
+        SimpleNamespace(
+            type="content_block_delta",
+            delta=SimpleNamespace(type="text_delta", text="answer"),
+        ),
+        SimpleNamespace(
+            type="message_delta",
+            delta=SimpleNamespace(stop_reason="end_turn"),
+            usage=SimpleNamespace(input_tokens=9, output_tokens=4),
+        ),
+    ]
+    stream = AsyncStream(events)
+    client = build_client(stream=stream)
+    client.messages.stream = Mock(return_value=stream)
+
+    with patch("anthropic.AsyncAnthropic", return_value=client):
+        chunks = [
+            chunk
+            async for chunk in build_adapter().chat_stream(
+                [
+                    Message(role=MessageRole.SYSTEM, content=LONG_TEXT),
+                    Message(role=MessageRole.USER, content="question " + LONG_TEXT),
+                ],
+                tools=[_tool_def()],
+            )
+        ]
+
+    request = client.messages.stream.call_args.kwargs
+    assert request["system"] == [
+        {"type": "text", "text": LONG_TEXT, "cache_control": {"type": "ephemeral"}}
+    ]
+    assert request["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert request["messages"][0]["content"][0]["cache_control"] == {
+        "type": "ephemeral"
+    }
+    assert chunks[-1].finish_reason is FinishReason.STOP
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_chat_skips_cache_breakpoints_when_disabled_or_too_short():
+    # 开关关闭：即使长前缀也不打点
+    adapter = build_adapter()
+    adapter.model_config.config = {"cache_control": False}
+    response = SimpleNamespace(
+        id="response-1",
+        content=[SimpleNamespace(type="text", text="done")],
+        stop_reason="end_turn",
+        usage=SimpleNamespace(input_tokens=9, output_tokens=4),
+    )
+    client = build_client(response=response)
+    with patch("anthropic.AsyncAnthropic", return_value=client):
+        await adapter.chat(
+            [
+                Message(role=MessageRole.SYSTEM, content=LONG_TEXT),
+                Message(role=MessageRole.USER, content="question"),
+            ]
+        )
+    request = client.messages.create.await_args.kwargs
+    assert request["system"] == LONG_TEXT
+    assert "cache_control" not in request["messages"][0]["content"]
+    client.close.assert_awaited_once()
+
+    # 前缀过短：即使开关开启也不打点
+    client = build_client(response=response)
+    with patch("anthropic.AsyncAnthropic", return_value=client):
+        await build_adapter().chat(
+            [
+                Message(role=MessageRole.SYSTEM, content="short"),
+                Message(role=MessageRole.USER, content="hi"),
+            ]
+        )
+    request = client.messages.create.await_args.kwargs
+    assert request["system"] == "short"
+    assert request["messages"][0]["content"] == "hi"
     client.close.assert_awaited_once()

--- a/backend/tests/llm/test_anthropic_adapter.py
+++ b/backend/tests/llm/test_anthropic_adapter.py
@@ -332,6 +332,75 @@ async def test_chat_stream_captures_usage_from_message_start_and_delta():
     client.close.assert_awaited_once()
 
 
+@pytest.mark.anyio
+async def test_chat_stream_emits_usage_without_terminal_delta():
+    events = [
+        SimpleNamespace(
+            type="message_start",
+            message=SimpleNamespace(
+                usage=SimpleNamespace(
+                    input_tokens=9,
+                    cache_read_input_tokens=6,
+                    cache_creation_input_tokens=3,
+                )
+            ),
+        ),
+        SimpleNamespace(
+            type="message_delta",
+            delta=None,
+            usage=SimpleNamespace(output_tokens=4),
+        ),
+    ]
+    stream = AsyncStream(events)
+    client = build_client(stream=stream)
+
+    with patch("anthropic.AsyncAnthropic", return_value=client):
+        chunks = [
+            chunk
+            async for chunk in build_adapter().chat_stream(
+                [Message(role=MessageRole.USER, content="Hi")]
+            )
+        ]
+
+    assert len(chunks) == 1
+    assert chunks[0].finish_reason is None
+    assert chunks[0].usage.model_dump() == {
+        "prompt_tokens": 9,
+        "completion_tokens": 4,
+        "total_tokens": 22,
+        "cache_read_tokens": 6,
+        "cache_creation_tokens": 3,
+        "total_input_tokens": 18,
+    }
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_chat_stream_treats_unnamed_tool_start_as_activity():
+    stream = AsyncStream(
+        [
+            SimpleNamespace(
+                type="content_block_start",
+                content_block=SimpleNamespace(type="tool_use", id="call-1", name=""),
+            )
+        ]
+    )
+    client = build_client(stream=stream)
+
+    with patch("anthropic.AsyncAnthropic", return_value=client):
+        chunks = [
+            chunk
+            async for chunk in build_adapter().chat_stream(
+                [Message(role=MessageRole.USER, content="Hi")]
+            )
+        ]
+
+    assert len(chunks) == 1
+    assert chunks[0].delta.stream_activity is True
+    assert chunks[0].delta.tool_calls is None
+    client.close.assert_awaited_once()
+
+
 LONG_TEXT = "cache me " * 2000  # cl100k 估算远超 1024 token 缓存门槛
 
 
@@ -362,6 +431,59 @@ def test_message_text_serializes_tool_result_content_blocks():
         )
         == '[{"type": "text", "text": "done"}]'
     )
+
+
+def test_message_helpers_ignore_nontext_content_and_tool_result_wrappers():
+    adapter = build_adapter()
+
+    assert adapter._message_text({"content": {"type": "text"}}) == ""
+    assert (
+        adapter._message_text(
+            {
+                "content": [
+                    None,
+                    {"type": "image"},
+                    {"type": "tool_result", "content": "done"},
+                ]
+            }
+        )
+        == "done"
+    )
+    assert not adapter._is_real_user_message(
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "content": "done"}],
+        }
+    )
+
+
+def test_message_cache_breakpoint_skips_nontext_blocks_before_marking_text():
+    adapter = build_adapter()
+    message = {
+        "content": [
+            None,
+            {"type": "image"},
+            {"type": "text", "text": "history"},
+        ]
+    }
+
+    adapter._mark_message_cache_breakpoint(message)
+
+    assert "cache_control" not in message["content"][1]
+    assert message["content"][2]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_cache_breakpoints_mark_system_without_real_user_messages():
+    system, messages, _ = build_adapter()._apply_cache_breakpoints(
+        LONG_TEXT,
+        [{"role": "assistant", "content": "assistant reply"}],
+        None,
+    )
+
+    assert system == [
+        {"type": "text", "text": LONG_TEXT, "cache_control": {"type": "ephemeral"}}
+    ]
+    assert messages == [{"role": "assistant", "content": "assistant reply"}]
 
 
 def _tool_def():

--- a/backend/tests/llm/test_anthropic_adapter.py
+++ b/backend/tests/llm/test_anthropic_adapter.py
@@ -283,7 +283,48 @@ async def test_chat_stream_captures_usage_from_message_delta():
     assert chunks[-1].usage.model_dump() == {
         "prompt_tokens": 9,
         "completion_tokens": 4,
-        "total_tokens": 13,
+        "total_tokens": 22,
+        "cache_read_tokens": 6,
+        "cache_creation_tokens": 3,
+        "total_input_tokens": 18,
+    }
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_chat_stream_captures_usage_from_message_start_and_delta():
+    events = [
+        SimpleNamespace(
+            type="message_start",
+            message=SimpleNamespace(
+                usage=SimpleNamespace(
+                    input_tokens=9,
+                    cache_read_input_tokens=6,
+                    cache_creation_input_tokens=3,
+                )
+            ),
+        ),
+        SimpleNamespace(
+            type="message_delta",
+            delta=SimpleNamespace(stop_reason="end_turn"),
+            usage=SimpleNamespace(output_tokens=4),
+        ),
+    ]
+    stream = AsyncStream(events)
+    client = build_client(stream=stream)
+
+    with patch("anthropic.AsyncAnthropic", return_value=client):
+        chunks = [
+            chunk
+            async for chunk in build_adapter().chat_stream(
+                [Message(role=MessageRole.USER, content="Hi")]
+            )
+        ]
+
+    assert chunks[-1].usage.model_dump() == {
+        "prompt_tokens": 9,
+        "completion_tokens": 4,
+        "total_tokens": 22,
         "cache_read_tokens": 6,
         "cache_creation_tokens": 3,
         "total_input_tokens": 18,
@@ -292,6 +333,35 @@ async def test_chat_stream_captures_usage_from_message_delta():
 
 
 LONG_TEXT = "cache me " * 2000  # cl100k 估算远超 1024 token 缓存门槛
+
+
+def test_cache_prefix_floor_uses_model_specific_minimum():
+    adapter = build_adapter()
+    assert adapter._min_cache_prefix_tokens() == 1280
+
+    adapter.model_config.model_id = "claude-3-haiku-20240307"
+    assert adapter._min_cache_prefix_tokens() == 2304
+
+    adapter.model_config.model_id = "claude-3-5-haiku-20241022"
+    assert adapter._min_cache_prefix_tokens() == 1280
+
+
+def test_message_text_serializes_tool_result_content_blocks():
+    adapter = build_adapter()
+
+    assert (
+        adapter._message_text(
+            {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "content": [{"type": "text", "text": "done"}],
+                    }
+                ]
+            }
+        )
+        == '[{"type": "text", "text": "done"}]'
+    )
 
 
 def _tool_def():
@@ -389,7 +459,13 @@ async def test_chat_stream_adds_cache_breakpoints():
             async for chunk in build_adapter().chat_stream(
                 [
                     Message(role=MessageRole.SYSTEM, content=LONG_TEXT),
-                    Message(role=MessageRole.USER, content="question " + LONG_TEXT),
+                    Message(
+                        role=MessageRole.USER,
+                        content="historical question " + LONG_TEXT,
+                    ),
+                    Message(
+                        role=MessageRole.USER, content="current question " + LONG_TEXT
+                    ),
                 ],
                 tools=[_tool_def()],
             )
@@ -403,6 +479,7 @@ async def test_chat_stream_adds_cache_breakpoints():
     assert request["messages"][0]["content"][0]["cache_control"] == {
         "type": "ephemeral"
     }
+    assert "cache_control" not in request["messages"][1]["content"][0]
     assert chunks[-1].finish_reason is FinishReason.STOP
     client.close.assert_awaited_once()
 

--- a/backend/tests/llm/test_anthropic_adapter_issue255.py
+++ b/backend/tests/llm/test_anthropic_adapter_issue255.py
@@ -257,7 +257,12 @@ async def test_chat_builds_structured_output_without_thinking(
     assert request["top_p"] == 0.8
     assert request["extra_body"] == {"service_tier": "standard"}
     assert result.content == '{"ok": true}'
-    assert result.usage == Usage(prompt_tokens=3, completion_tokens=2, total_tokens=5)
+    assert result.usage == Usage(
+        prompt_tokens=3,
+        completion_tokens=2,
+        total_tokens=5,
+        total_input_tokens=3,
+    )
     client.close.assert_awaited_once()
 
 

--- a/backend/tests/llm/test_deepseek_adapter.py
+++ b/backend/tests/llm/test_deepseek_adapter.py
@@ -71,7 +71,13 @@ async def test_chat_builds_request_and_normalizes_reasoning_tool_response():
                 ),
             )
         ],
-        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=4, total_tokens=14),
+        usage=SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=4,
+            total_tokens=14,
+            prompt_cache_hit_tokens=8,
+            prompt_cache_miss_tokens=2,
+        ),
     )
     client = build_client(response)
     tools = [
@@ -115,6 +121,8 @@ async def test_chat_builds_request_and_normalizes_reasoning_tool_response():
     assert result.finish_reason is FinishReason.TOOL_CALLS
     assert result.tool_calls[0].function.name == "lookup"
     assert result.usage.total_tokens == 14
+    assert result.usage.cache_read_tokens == 8
+    assert result.usage.total_input_tokens == 10
     client.close.assert_awaited_once()
 
 
@@ -224,4 +232,43 @@ async def test_chat_stream_closes_client_when_iteration_fails():
         ):
             pass
 
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_chat_stream_captures_cache_usage_and_total_input():
+    stream = AsyncChunks(
+        [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="answer", tool_calls=None),
+                        finish_reason="stop",
+                    )
+                ]
+            ),
+            SimpleNamespace(
+                choices=[],
+                usage=SimpleNamespace(
+                    prompt_tokens=10,
+                    completion_tokens=4,
+                    total_tokens=14,
+                    prompt_cache_hit_tokens=8,
+                    prompt_cache_miss_tokens=2,
+                ),
+            ),
+        ]
+    )
+    client = build_client(stream)
+
+    with patch("openai.AsyncOpenAI", return_value=client):
+        chunks = [
+            chunk
+            async for chunk in build_adapter().chat_stream(
+                [Message(role=MessageRole.USER, content="Hi")]
+            )
+        ]
+
+    assert chunks[-1].usage.cache_read_tokens == 8
+    assert chunks[-1].usage.total_input_tokens == 10
     client.close.assert_awaited_once()

--- a/backend/tests/llm/test_gemini_adapter.py
+++ b/backend/tests/llm/test_gemini_adapter.py
@@ -53,6 +53,7 @@ def response(parts=None, *, finish_reason="STOP", usage=True):
             prompt_token_count=7,
             candidates_token_count=3,
             total_token_count=10,
+            cached_content_token_count=5,
         )
         if usage
         else None
@@ -260,6 +261,9 @@ async def test_chat_builds_request_and_normalizes_reasoning_tool_and_usage():
         "prompt_tokens": 7,
         "completion_tokens": 3,
         "total_tokens": 10,
+        "cache_read_tokens": 5,
+        "cache_creation_tokens": 0,
+        "total_input_tokens": 7,
     }
 
 
@@ -366,3 +370,31 @@ async def test_chat_stream_can_be_closed_after_first_chunk():
 
     assert first.delta.content == "first"
     assert stream.requested == 1
+
+
+@pytest.mark.anyio
+async def test_chat_stream_captures_usage_metadata_from_terminal_chunk():
+    stream = AsyncChunks(
+        [
+            response([part(thought=False, text="answer")], finish_reason="STOP"),
+        ]
+    )
+    client = build_client(stream=stream)
+
+    with patch("google.genai.Client", return_value=client):
+        chunks = [
+            chunk
+            async for chunk in build_adapter().chat_stream(
+                [Message(role=MessageRole.USER, content="Hi")]
+            )
+        ]
+
+    assert chunks[-1].finish_reason is FinishReason.STOP
+    assert chunks[-1].usage.model_dump() == {
+        "prompt_tokens": 7,
+        "completion_tokens": 3,
+        "total_tokens": 10,
+        "cache_read_tokens": 5,
+        "cache_creation_tokens": 0,
+        "total_input_tokens": 7,
+    }

--- a/backend/tests/llm/test_model_manager_behavior_255.py
+++ b/backend/tests/llm/test_model_manager_behavior_255.py
@@ -596,11 +596,16 @@ async def test_team_stream_and_usage_recording_use_selected_model(
     )
     record = AsyncMock()
     monkeypatch.setattr(manager, "_check_and_record_usage", record)
-    monkeypatch.setattr("app.llm.token_counter.count_tokens", Mock(side_effect=[2, 3]))
+    monkeypatch.setattr(
+        "app.llm.token_counter.estimate_tokens_from_chars",
+        Mock(side_effect=[2, 3, 3]),
+    )
 
     assert [chunk async for chunk in manager.team_chat_stream("team", [])] == ["chunk"]
     await manager.record_stream_usage("team", None, 8, 12)
     await manager.record_stream_usage("team", None, input_tokens=11, output_tokens=13)
+    await manager.record_stream_usage("team", None, 80, 12, input_tokens=11)
+    await manager.record_stream_usage("team", None, 0, 0, output_tokens=0)
     assert record.await_args_list[0].kwargs == {
         "team_id": "team",
         "model_id": str(model.id),
@@ -610,6 +615,16 @@ async def test_team_stream_and_usage_recording_use_selected_model(
         "team_id": "team",
         "model_id": str(model.id),
         "tokens_used": 24,
+    }
+    assert record.await_args_list[2].kwargs == {
+        "team_id": "team",
+        "model_id": str(model.id),
+        "tokens_used": 14,
+    }
+    assert record.await_args_list[3].kwargs == {
+        "team_id": "team",
+        "model_id": str(model.id),
+        "tokens_used": 0,
     }
 
 

--- a/backend/tests/llm/test_model_manager_behavior_255.py
+++ b/backend/tests/llm/test_model_manager_behavior_255.py
@@ -525,6 +525,54 @@ async def test_team_chat_checks_quota_records_usage_and_maps_quota(
 
 
 @pytest.mark.anyio
+async def test_team_chat_estimates_usage_when_provider_omits_totals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = SimpleNamespace(id=uuid4(), provider="openai", model_id="gpt-4o")
+    team_model = SimpleNamespace(is_enabled=True)
+    result = SimpleNamespace(
+        usage=None,
+        content="answer",
+        reasoning_content=None,
+        tool_calls=None,
+    )
+    adapter = SimpleNamespace(chat=AsyncMock(return_value=result))
+    manager = ModelManager()
+    monkeypatch.setattr(
+        manager, "_get_team_model", AsyncMock(return_value=(model, team_model))
+    )
+    monkeypatch.setattr(manager, "_get_chat_adapter", lambda _config: adapter)
+    monkeypatch.setattr(
+        manager_module.usage_tracker, "check_quota_with_model", AsyncMock()
+    )
+    monkeypatch.setattr(
+        "app.llm.token_counter.count_message_tokens", Mock(return_value=7)
+    )
+    monkeypatch.setattr("app.llm.token_counter.count_tokens", Mock(side_effect=[3, 0]))
+    count_tool_definition_tokens = Mock(return_value=4)
+    monkeypatch.setattr(
+        "app.llm.token_counter.count_tool_definition_tokens",
+        count_tool_definition_tokens,
+    )
+    record = AsyncMock()
+    monkeypatch.setattr(manager, "_check_and_record_usage", record)
+    tools = [SimpleNamespace()]
+
+    assert (
+        await manager.team_chat(
+            "team", [{"role": "user", "content": "question"}], tools=tools
+        )
+        is result
+    )
+    count_tool_definition_tokens.assert_called_once_with(
+        tools, model.model_id, model.provider
+    )
+    record.assert_awaited_once_with(
+        team_id="team", model_id=str(model.id), tokens_used=14
+    )
+
+
+@pytest.mark.anyio
 async def test_team_stream_and_usage_recording_use_selected_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -552,9 +600,17 @@ async def test_team_stream_and_usage_recording_use_selected_model(
 
     assert [chunk async for chunk in manager.team_chat_stream("team", [])] == ["chunk"]
     await manager.record_stream_usage("team", None, 8, 12)
-    record.assert_awaited_once_with(
-        team_id="team", model_id=str(model.id), tokens_used=5
-    )
+    await manager.record_stream_usage("team", None, input_tokens=11, output_tokens=13)
+    assert record.await_args_list[0].kwargs == {
+        "team_id": "team",
+        "model_id": str(model.id),
+        "tokens_used": 5,
+    }
+    assert record.await_args_list[1].kwargs == {
+        "team_id": "team",
+        "model_id": str(model.id),
+        "tokens_used": 24,
+    }
 
 
 @pytest.mark.anyio

--- a/backend/tests/llm/test_openai_adapter.py
+++ b/backend/tests/llm/test_openai_adapter.py
@@ -71,7 +71,12 @@ async def test_chat_builds_request_and_normalizes_tool_response():
                 ),
             )
         ],
-        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=4, total_tokens=14),
+        usage=SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=4,
+            total_tokens=14,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=6),
+        ),
     )
     client = build_client(response)
     tools = [
@@ -84,7 +89,7 @@ async def test_chat_builds_request_and_normalizes_tool_response():
         )
     ]
 
-    with patch("openai.AsyncOpenAI", return_value=client) as client_class:
+    with patch("openai.AsyncOpenAI", return_value=client):
         result = await adapter.chat(
             [Message(role=MessageRole.USER, content="Find docs")],
             tools=tools,
@@ -121,8 +126,10 @@ async def test_chat_builds_request_and_normalizes_tool_response():
         "prompt_tokens": 10,
         "completion_tokens": 4,
         "total_tokens": 14,
+        "cache_read_tokens": 6,
+        "cache_creation_tokens": 0,
+        "total_input_tokens": 10,
     }
-    client_class.assert_called_once()
     client.close.assert_awaited_once()
 
 
@@ -246,3 +253,50 @@ async def test_chat_stream_builds_request_and_normalizes_activity_content_and_to
     assert result[3].delta.tool_calls[0].function.arguments == '{"query":"docs"}'
     assert len({chunk.id for chunk in result}) == 1
     client.close.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_chat_stream_captures_usage_from_terminal_chunk():
+    chunks = AsyncChunks(
+        [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="answer", tool_calls=None),
+                        finish_reason="stop",
+                    )
+                ]
+            ),
+            # OpenAI 流式：usage 在 finish 之后的独立 chunk（choices 为空）
+            SimpleNamespace(
+                choices=[],
+                usage=SimpleNamespace(
+                    prompt_tokens=10,
+                    completion_tokens=4,
+                    total_tokens=14,
+                    prompt_tokens_details=SimpleNamespace(cached_tokens=6),
+                ),
+            ),
+        ]
+    )
+    client = build_client(chunks)
+    adapter = build_adapter()
+
+    with patch("openai.AsyncOpenAI", return_value=client):
+        result = [
+            chunk
+            async for chunk in adapter.chat_stream(
+                [Message(role=MessageRole.USER, content="Hi")]
+            )
+        ]
+
+    request = client.chat.completions.create.await_args.kwargs
+    assert request["stream_options"] == {"include_usage": True}
+    assert result[-1].usage.model_dump() == {
+        "prompt_tokens": 10,
+        "completion_tokens": 4,
+        "total_tokens": 14,
+        "cache_read_tokens": 6,
+        "cache_creation_tokens": 0,
+        "total_input_tokens": 10,
+    }

--- a/backend/tests/llm/test_openai_compatible_adapter.py
+++ b/backend/tests/llm/test_openai_compatible_adapter.py
@@ -272,6 +272,38 @@ async def test_chat_stream_normalizes_activity_reasoning_and_tool_calls():
 
 
 @pytest.mark.anyio
+async def test_chat_stream_tolerates_incomplete_terminal_usage():
+    async def stream():
+        yield SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(
+                prompt_tokens=None,
+                completion_tokens=None,
+                total_tokens=None,
+            ),
+        )
+
+    client = FakeAsyncOpenAI(stream())
+    with patch("openai.AsyncOpenAI", return_value=client):
+        chunks = [
+            chunk
+            async for chunk in OpenAICompatibleAdapter(build_model()).chat_stream(
+                [Message(role=MessageRole.USER, content="Hi")]
+            )
+        ]
+
+    assert chunks[-1].usage.model_dump() == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "total_input_tokens": 0,
+    }
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     ("provider_reason", "expected"),
     [

--- a/backend/tests/llm/test_token_counter_behavior_255.py
+++ b/backend/tests/llm/test_token_counter_behavior_255.py
@@ -4,10 +4,20 @@ import pytest
 import tiktoken
 
 from app.llm import token_counter
+from app.llm.types.chat import FunctionDefinition, ToolDefinition
 
 
 def encoded_length(encoding: tiktoken.Encoding, *values: str) -> int:
     return sum(len(encoding.encode(value)) for value in values)
+
+
+def test_serialize_tool_calls_accepts_mapping_values() -> None:
+    assert (
+        token_counter.serialize_tool_calls(
+            [{"id": "call-1", "function": {"name": "lookup", "arguments": "{}"}}]
+        )
+        == '[{"id":"call-1","function":{"name":"lookup","arguments":"{}"}}]'
+    )
 
 
 def test_count_tokens_uses_real_model_encoding() -> None:
@@ -90,10 +100,14 @@ def test_message_count_covers_text_media_names_and_tool_structures() -> None:
             "metadata": {"ignored": True},
         },
     ]
+    tool_call_tokens = encoded_length(
+        encoding, token_counter.serialize_tool_calls(messages[2]["tool_calls"])
+    )
     expected = (
         3 * len(messages)
         + 3
         + 1
+        + tool_call_tokens
         + encoded_length(
             encoding,
             "system",
@@ -109,7 +123,27 @@ def test_message_count_covers_text_media_names_and_tool_structures() -> None:
         )
     )
 
-    assert token_counter.count_message_tokens(messages) == expected
+    assert (
+        token_counter.count_message_tokens(messages, include_tool_calls=True)
+        == expected
+    )
+    assert token_counter.count_message_tokens(messages) == expected - tool_call_tokens
+
+
+def test_tool_definition_count_serializes_pydantic_schema() -> None:
+    tool = ToolDefinition(
+        function=FunctionDefinition(
+            name="lookup",
+            description="Find information",
+            parameters={"type": "object"},
+        )
+    )
+    serialized = token_counter.serialize_tool_calls([tool])
+
+    assert token_counter.count_tool_definition_tokens(
+        [tool]
+    ) == token_counter.count_tokens(serialized)
+    assert token_counter.count_tool_definition_tokens([]) == 0
 
 
 def test_message_count_handles_empty_and_sparse_messages() -> None:
@@ -133,6 +167,28 @@ def test_count_tokens_logs_and_estimates_when_tokenizer_fails(caplog) -> None:
         "Token counting failed, using fallback: bad encoding",
         "Token counting failed, using fallback: bad encoding",
     ]
+
+
+def test_message_fallback_counts_tool_calls_when_requested() -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        }
+    ]
+    serialized = token_counter.serialize_tool_calls(messages[0]["tool_calls"])
+
+    with patch.object(
+        token_counter, "get_encoding_for_model", side_effect=RuntimeError("offline")
+    ):
+        assert token_counter.count_message_tokens(
+            messages, include_tool_calls=True
+        ) == max(len(serialized) // 4, 1)
 
 
 def test_message_fallback_extracts_only_text_content(caplog) -> None:

--- a/backend/tests/llm/test_xai_adapter.py
+++ b/backend/tests/llm/test_xai_adapter.py
@@ -262,6 +262,41 @@ async def test_chat_stream_normalizes_reasoning_tool_activity_and_completion():
 
 
 @pytest.mark.anyio
+async def test_chat_stream_tolerates_incomplete_terminal_usage():
+    stream = AsyncChunks(
+        [
+            SimpleNamespace(
+                choices=[],
+                usage=SimpleNamespace(
+                    prompt_tokens=None,
+                    completion_tokens=None,
+                    total_tokens=None,
+                ),
+            )
+        ]
+    )
+    client = build_client(stream)
+
+    with patch("openai.AsyncOpenAI", return_value=client):
+        chunks = [
+            chunk
+            async for chunk in build_adapter().chat_stream(
+                [Message(role=MessageRole.USER, content="Hi")]
+            )
+        ]
+
+    assert chunks[-1].usage.model_dump() == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "total_input_tokens": 0,
+    }
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.anyio
 async def test_chat_closes_client_when_request_fails():
     client = build_client(None)
     client.chat.completions.create.side_effect = RuntimeError("provider failed")

--- a/backend/tests/services/test_audit_log_changes.py
+++ b/backend/tests/services/test_audit_log_changes.py
@@ -135,6 +135,20 @@ def test_json_safe_masks_sensitive_keys_inside_lists() -> None:
     assert result == [{"api_key": "sk-very-***", "name": "x"}]
 
 
+def test_sanitize_changes_preserves_numeric_token_usage_counters() -> None:
+    svc = audit_log.AuditLogService
+    result = svc.sanitize_changes(
+        {
+            "before": {"token_usage": 5, "access_token": "secret-value"},
+            "after": {"token_usage": 3, "access_token": "new-secret"},
+        }
+    )
+    assert result == {
+        "before": {"token_usage": 5, "access_token": "secret-v***"},
+        "after": {"token_usage": 3, "access_token": "new-secr***"},
+    }
+
+
 def test_json_safe_masks_nested_email_in_small_values() -> None:
     svc = audit_log.AuditLogService
     result = svc._json_safe({"profile": {"email": "alice@example.com"}})

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,6 +1,11 @@
 # Implementation Plan
 
 ## Active
+- **model-prompt-caching-visibility** — Complete. Provider-reported cache hit/write token details flow through `Usage`, all chat adapters, message persistence, message_end SSE, and the token-stats popover. Cache hit rate is intentionally not displayed. Verified: 3316 backend + 2242 frontend tests, tsc and Ruff clean. See `docs/plan/model-prompt-caching-visibility.md`
+  - [x] 1. Usage 类型扩展 + 全部 adapter 解析
+  - [x] 2. chat.py 记账与 SSE 透传
+  - [x] 3. 前端透传与展示
+  - [x] 4. 全量验证
 - **context-compression-three-level-redesign** — Planned. Replace the current overlapping compaction paths with bounded content normalization, active tool-loop rolling compaction, and Pi-style between-turn historical checkpoints while preserving branch-aware context assembly. See `docs/plan/context-compression-three-level-redesign.md`
   - [ ] 1. Establish the budget contract and compression observability
   - [ ] 2. Implement always-on bounded content normalization

--- a/docs/plan/model-prompt-caching-visibility.md
+++ b/docs/plan/model-prompt-caching-visibility.md
@@ -20,16 +20,17 @@
 ## High-Level Design
 
 ### 数据流
-```
+```text
 供应商响应 usage
-  → adapter 解析原生字段 → 统一 Usage{cache_read_tokens, cache_creation_tokens}
+  → adapter 解析原生字段 → 统一 Usage{total_input_tokens, cache_read_tokens, cache_creation_tokens}
   → chat.py _calculate_model_usage / 流式 stream_usage 透传
-  → 消息 token_usage = {prompt, completion, cache_read?, cache_creation?}
+  → 消息 token_usage = {prompt, completion, total_input?, cache_read?, cache_creation?}
   → message_end SSE usage 透传
   → 前端 message-converter 重建 metadata.usage → TokenStatsContent 展示
 ```
 
 ### 字段归一化映射
+
 | 供应商 | 原生字段 | → cache_read_tokens | → cache_creation_tokens |
 |---|---|---|---|
 | OpenAI / OpenAI-compatible | `prompt_tokens_details.cached_tokens` | ✓ | — |
@@ -43,17 +44,17 @@
 
 ### Stage 1: Usage 类型扩展 + adapter 解析
 - **Files**: `backend/app/llm/types/base.py`、7 个 adapter（openai / openai_compatible / deepseek / moonshot / xai / anthropic / gemini）
-- **逻辑**: `Usage` 增加 `cache_read_tokens` / `cache_creation_tokens`（默认 0）；每个 adapter 的非流式 `chat()` 与流式 usage chunk 解析处按上表填充。
+- **逻辑**: `Usage` 增加 `total_input_tokens`、`cache_read_tokens` / `cache_creation_tokens`（默认 0）；每个 adapter 的非流式 `chat()` 与流式 usage chunk 解析处按上表填充缓存明细，并保留完整输入 token 总量。
 - **Validation**: 各 adapter 单测断言 usage 缓存字段；现有断言不受影响（新字段默认 0）。
 
 ### Stage 2: chat.py 记账与 SSE 透传
 - **Files**: `backend/app/api/v1/endpoints/chat.py`（6 处流式循环 + 非流式 + message_end 事件）
-- **逻辑**: `_calculate_model_usage` 增加缓存字段透传；消息 `token_usage` 扩展 `{prompt, completion, cache_read?, cache_creation?}`；`message_end` SSE `usage` 增加 `cache_read_tokens` / `cache_creation_tokens`。
+- **逻辑**: `_calculate_model_usage` 增加完整输入与缓存字段透传；消息 `token_usage` 扩展 `{prompt, completion, total_input?, cache_read?, cache_creation?}`；`message_end` SSE `usage` 增加 `total_input_tokens`、`cache_read_tokens` / `cache_creation_tokens`。
 - **Validation**: 端到端测试断言 message_end 与持久化含缓存字段；旧格式兼容。
 
 ### Stage 3: 前端透传与展示
 - **Files**: `frontend/lib/api/agents.ts`（BackendMessage token_usage 类型）、`frontend/lib/utils/message-converter.ts`、`frontend/components/chat/message.tsx`、`frontend/i18n/{en,zh}/chat.json`、`frontend/i18n/types/chat.ts`
-- **逻辑**: `token_usage` 类型加可选 `cache_read`/`cache_creation`；converter 重建 usage 含缓存字段；`TokenStatsContent` 分别展示"缓存命中"与"缓存写入"行（各自仅当 >0 时显示）；i18n 键 `cachedTokens` / `cacheCreationTokens`。
+- **逻辑**: `token_usage` 类型加可选 `total_input`、`cache_read` / `cache_creation`；converter 重建 usage 含完整输入与缓存字段；`TokenStatsContent` 使用该完整输入字段保持 token 统计口径一致；i18n 键 `cachedTokens` / `cacheCreationTokens`。
 - **Validation**: converter 单测 + message 组件测试（若存在）。
 ### Stage 4: 全量验证
 - 后端：llm 目录全部测试 + chat 相关 + Ruff。
@@ -61,8 +62,7 @@
 
 
 ## Testing Strategy
-- 每 adapter：非流式 + 流式 usage 缓存字段解析断言（mock 供应商响应）。
-- 端到端：message_end SSE usage 含缓存字段；持久化 token_usage 含缓存字段。
+- 端到端：message_end SSE usage 含 `total_input_tokens` 与缓存字段；持久化 token_usage 含 `total_input` 与缓存字段。
 - 回归：旧响应（无缓存字段）→ 新字段默认 0，现有断言不变。
 - 前端：converter 重建 usage 含缓存字段；popover 渲染条件（>0 才显示）。
 

--- a/docs/plan/model-prompt-caching-visibility.md
+++ b/docs/plan/model-prompt-caching-visibility.md
@@ -1,0 +1,75 @@
+# Model Prompt Caching Visibility 设计文档
+
+## Background & Goals
+
+### 背景
+- Anthropic 对话缓存已启用（`cache_control` 断点，见上轮改动），OpenAI/Gemini/DeepSeek/Moonshot 为服务端自动/隐式缓存。
+- 但各供应商响应中回报的缓存命中/写入明细（`cached_tokens`、`cache_read_input_tokens`、`cached_content_token_count`、`prompt_cache_hit_tokens` 等）**全部被丢弃**：`Usage` 类型只有 `prompt/completion/total`，消息持久化 `token_usage` 只有 `{prompt, completion}`。
+- 结果：缓存是否真正命中不可见，无法验证缓存生效、无法做成本分析。
+
+### 目标
+1. `Usage` 统一透传缓存明细字段（缓存命中 + 缓存写入），全部 7 个 chat adapter（非流式 + 流式）解析供应商原生字段并归一化。
+2. 消息持久化 `token_usage` 扩展可选缓存字段（向后兼容）。
+3. 前端 token 统计 popover 展示缓存命中 token 数（i18n 双语）。
+
+### 非目标
+- xAI `x-grok-conv-id` 会话路由 header（需要调用链传会话 id，改动面大，收益低；单独评估）。
+- Gemini 1.5 显式 `cachedContent` 资源管理（需额外 API 生命周期管理，32k+ tokens 门槛；2.5+ 隐式缓存已覆盖）。
+- OpenAI 缓存写入计费（`cache_write_tokens`，仅 GPT-5.6+，当前无模型接入）。
+
+## High-Level Design
+
+### 数据流
+```
+供应商响应 usage
+  → adapter 解析原生字段 → 统一 Usage{cache_read_tokens, cache_creation_tokens}
+  → chat.py _calculate_model_usage / 流式 stream_usage 透传
+  → 消息 token_usage = {prompt, completion, cache_read?, cache_creation?}
+  → message_end SSE usage 透传
+  → 前端 message-converter 重建 metadata.usage → TokenStatsContent 展示
+```
+
+### 字段归一化映射
+| 供应商 | 原生字段 | → cache_read_tokens | → cache_creation_tokens |
+|---|---|---|---|
+| OpenAI / OpenAI-compatible | `prompt_tokens_details.cached_tokens` | ✓ | — |
+| Anthropic | `cache_read_input_tokens` | ✓ | `cache_creation_input_tokens` |
+| Gemini | `usage_metadata.cached_content_token_count` | ✓ | — |
+| DeepSeek | `prompt_cache_hit_tokens` | ✓ | — |
+| Moonshot | `prompt_tokens_details.cached_tokens`（OpenAI 兼容） | ✓ | — |
+| xAI | `cached_prompt_text_tokens` 或 `prompt_tokens_details.cached_tokens` | ✓ | — |
+
+## Implementation Plan
+
+### Stage 1: Usage 类型扩展 + adapter 解析
+- **Files**: `backend/app/llm/types/base.py`、7 个 adapter（openai / openai_compatible / deepseek / moonshot / xai / anthropic / gemini）
+- **逻辑**: `Usage` 增加 `cache_read_tokens` / `cache_creation_tokens`（默认 0）；每个 adapter 的非流式 `chat()` 与流式 usage chunk 解析处按上表填充。
+- **Validation**: 各 adapter 单测断言 usage 缓存字段；现有断言不受影响（新字段默认 0）。
+
+### Stage 2: chat.py 记账与 SSE 透传
+- **Files**: `backend/app/api/v1/endpoints/chat.py`（6 处流式循环 + 非流式 + message_end 事件）
+- **逻辑**: `_calculate_model_usage` 增加缓存字段透传；消息 `token_usage` 扩展 `{prompt, completion, cache_read?, cache_creation?}`；`message_end` SSE `usage` 增加 `cache_read_tokens` / `cache_creation_tokens`。
+- **Validation**: 端到端测试断言 message_end 与持久化含缓存字段；旧格式兼容。
+
+### Stage 3: 前端透传与展示
+- **Files**: `frontend/lib/api/agents.ts`（BackendMessage token_usage 类型）、`frontend/lib/utils/message-converter.ts`、`frontend/components/chat/message.tsx`、`frontend/i18n/{en,zh}/chat.json`、`frontend/i18n/types/chat.ts`
+- **逻辑**: `token_usage` 类型加可选 `cache_read`/`cache_creation`；converter 重建 usage 含缓存字段；`TokenStatsContent` 分别展示"缓存命中"与"缓存写入"行（各自仅当 >0 时显示）；i18n 键 `cachedTokens` / `cacheCreationTokens`。
+- **Validation**: converter 单测 + message 组件测试（若存在）。
+### Stage 4: 全量验证
+- 后端：llm 目录全部测试 + chat 相关 + Ruff。
+- 前端：受影响的 hook/converter/组件测试与 tsc。
+
+
+## Testing Strategy
+- 每 adapter：非流式 + 流式 usage 缓存字段解析断言（mock 供应商响应）。
+- 端到端：message_end SSE usage 含缓存字段；持久化 token_usage 含缓存字段。
+- 回归：旧响应（无缓存字段）→ 新字段默认 0，现有断言不变。
+- 前端：converter 重建 usage 含缓存字段；popover 渲染条件（>0 才显示）。
+
+## Risks & Mitigation
+- **缓存字段语义差异**：供应商 `prompt_tokens` 是否含缓存命中？OpenAI/DeepSeek 的 `prompt_tokens` 是总输入（含命中），`cached_tokens` 是其中命中部分——只做明细展示，不改 prompt/completion 记账语义，避免统计口径变化。
+- **流式 usage 快照**：沿用现有"最后 chunk 覆盖"逻辑，缓存字段随同一 Usage 对象透传，无额外合并风险。
+- **前端兼容**：`cache_read`/`cache_creation` 为可选字段，旧消息无此字段时展示逻辑跳过。
+
+## Rollback
+- 全部为纯增量字段（默认 0 / 可选），无 schema 迁移；回退只需还原 Usage 类型与 adapter 解析。

--- a/frontend/app/(chat)/chat/[id]/page.test.tsx
+++ b/frontend/app/(chat)/chat/[id]/page.test.tsx
@@ -32,7 +32,10 @@ let chatState = {
   isStreaming: false,
   conversationId: null as string | null,
 }
-let chatOptions: { onConversationChange?: () => void } = {}
+let chatOptions: {
+  onConversationChange?: () => void
+  onStreamEnd?: () => void
+} = {}
 let variableValues: Record<string, unknown> = {}
 let chatContainerProps: Record<string, unknown> = {}
 let chatInputProps: Record<string, unknown> = {}
@@ -338,6 +341,8 @@ describe('PublicChatPage', () => {
     expect(deleteConversation).toHaveBeenCalledWith('conv-2')
 
     await act(async () => (chatOptions.onConversationChange?.()))
+    expect(getConversations).toHaveBeenCalledWith('agent-1', { page: 1, pageSize: 5 })
+    await act(async () => chatOptions.onStreamEnd?.())
     expect(getConversations).toHaveBeenCalledWith('agent-1', { page: 1, pageSize: 5 })
 
     const newChat = renderer!.root.findAllByProps({ 'aria-label': 'newChat' })[0]

--- a/frontend/app/(chat)/chat/[id]/page.tsx
+++ b/frontend/app/(chat)/chat/[id]/page.tsx
@@ -217,6 +217,7 @@ export default function PublicChatPage({
       refreshConversations()
       onExternalConversationChange?.(id)
     },
+    onStreamEnd: refreshConversations,
     api: adapter,
     initialMessages: greetingMessages,
   })

--- a/frontend/components/chat/message.test.tsx
+++ b/frontend/components/chat/message.test.tsx
@@ -153,7 +153,14 @@ describe('message rendering', () => {
           preservedPartialProgress: true,
           errorMessage: 'Network fell over',
           isManuallyStopped: true,
-          usage: { prompt_tokens: 1200, completion_tokens: 34, total_tokens: 1234 },
+          usage: {
+            prompt_tokens: 1200,
+            completion_tokens: 34,
+            total_tokens: 1234,
+            cache_read_tokens: 900,
+            cache_creation_tokens: 100,
+            total_input_tokens: 1200,
+          },
           timing: { first_token_ms: 250, duration_ms: 1234, tokens_per_second: 12.5 },
         },
         parts: [{ type: 'text', text: 'Partial answer [[cite:1]]' }],
@@ -167,6 +174,10 @@ describe('message rendering', () => {
     expect(html).toContain('chat.message.manuallyStopped')
     expect(html).toContain('1,200')
     expect(html).toContain('1.2s')
+    expect(html).toContain('chat.message.cachedTokens')
+    expect(html).toContain('chat.message.cacheCreationTokens')
+    expect(html).toContain('900')
+    expect(html).toContain('100')
     expect(html).toContain('chat.message.helpful')
     expect(html).toContain('chat.message.regenerate')
   })

--- a/frontend/components/chat/message.tsx
+++ b/frontend/components/chat/message.tsx
@@ -502,7 +502,7 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
     const { isOpen: lightboxOpen, imageSrc, imageAlt, openLightbox, closeLightbox } = useLightbox()
 
     // Token usage and timing stats from message_end
-    const usage = message.metadata?.usage as { prompt_tokens: number; completion_tokens: number; total_tokens: number } | undefined
+    const usage = message.metadata?.usage as { prompt_tokens: number; completion_tokens: number; total_tokens: number; cache_read_tokens?: number; cache_creation_tokens?: number } | undefined
     const timing = message.metadata?.timing as { first_token_ms: number | null; duration_ms: number; tokens_per_second: number | null } | undefined
 
     // Group sources together (only document sources for citations)
@@ -1664,7 +1664,7 @@ function TokenStatsContent({
   timing,
   t,
 }: {
-  usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number }
+  usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number; cache_read_tokens?: number; cache_creation_tokens?: number }
   timing?: { first_token_ms: number | null; duration_ms: number; tokens_per_second: number | null }
   t: (key: string) => string
 }) {
@@ -1672,6 +1672,8 @@ function TokenStatsContent({
     if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`
     return `${ms}ms`
   }
+  const cacheReadTokens = usage.cache_read_tokens ?? 0
+  const cacheCreationTokens = usage.cache_creation_tokens ?? 0
 
   return (
     <div className="space-y-1.5">
@@ -1683,6 +1685,18 @@ function TokenStatsContent({
         <span className="text-muted-foreground">{t('outputTokens')}</span>
         <span className="font-mono tabular-nums">{usage.completion_tokens.toLocaleString()}</span>
       </div>
+      {cacheReadTokens > 0 && (
+        <div className="flex justify-between gap-8">
+          <span className="text-muted-foreground">{t('cachedTokens')}</span>
+          <span className="font-mono tabular-nums">{cacheReadTokens.toLocaleString()}</span>
+        </div>
+      )}
+      {cacheCreationTokens > 0 && (
+        <div className="flex justify-between gap-8">
+          <span className="text-muted-foreground">{t('cacheCreationTokens')}</span>
+          <span className="font-mono tabular-nums">{cacheCreationTokens.toLocaleString()}</span>
+        </div>
+      )}
       {timing?.first_token_ms != null && (
         <div className="flex justify-between gap-8">
           <span className="text-muted-foreground">{t('firstTokenTime')}</span>

--- a/frontend/hooks/use-chat.test.ts
+++ b/frontend/hooks/use-chat.test.ts
@@ -178,11 +178,24 @@ describe('useChat', () => {
     expect(result.messages.map((message) => message.role)).toEqual(['user', 'assistant'])
     expect(result.messages[0].parts[0]).toMatchObject({ type: 'text', text: 'Hello' })
 
+    const terminalData = {
+      version_number: 2,
+      version_count: 3,
+      usage: {
+        prompt_tokens: 1200,
+        completion_tokens: 34,
+        total_tokens: 1234,
+        cache_read_tokens: 900,
+        cache_creation_tokens: 100,
+      },
+      timing: { first_token_ms: 250, duration_ms: 1234, tokens_per_second: 12.5 },
+    }
+
     streamEvents = [
       { event: 'message_start', data: { conversation_id: 'conversation-1', message_id: 'message-1', user_message_id: 'user-message-1' } },
       { event: 'content_delta', data: { delta: 'Hi there' } },
       releaseStream.promise,
-      { event: 'message_end', data: { version_number: 2, version_count: 3 } },
+      { event: 'message_end', data: terminalData },
     ]
     response.resolve(new Response())
     await flush()
@@ -191,7 +204,7 @@ describe('useChat', () => {
     expect(result.isStreaming).toBe(true)
     expect(onStreamStart).toHaveBeenCalledTimes(1)
 
-    releaseStream.resolve({ event: 'message_end', data: { version_number: 2, version_count: 3 } })
+    releaseStream.resolve({ event: 'message_end', data: terminalData })
     await sending
 
     expect(result.status).toBe('idle')
@@ -203,7 +216,12 @@ describe('useChat', () => {
       id: 'message-1',
       versionNumber: 2,
       versionCount: 3,
-      metadata: { isLoading: false, isError: false },
+      metadata: {
+        isLoading: false,
+        isError: false,
+        usage: terminalData.usage,
+        timing: terminalData.timing,
+      },
     })
     expect(result.messages[1].parts).toContainEqual({ type: 'text', text: 'Hi there', state: 'done' })
   })

--- a/frontend/i18n/en/auditLogs.json
+++ b/frontend/i18n/en/auditLogs.json
@@ -180,6 +180,7 @@
     "actionduplicate_agent": "Duplicate Agent",
     "actionedit_message": "Edit Message",
     "actiondelete_conversation": "Delete Conversation",
+    "actiondelete_message": "Delete Message",
     "actionbatch_delete_conversations": "Batch Delete Conversations",
     "actionrun_workflow_embed": "Run Workflow (Embed)",
     "actionupload_document": "Upload Document",

--- a/frontend/i18n/en/chat.json
+++ b/frontend/i18n/en/chat.json
@@ -136,6 +136,8 @@
       "firstTokenTime": "First Token",
       "totalTime": "Total Time",
       "speed": "Speed",
+      "cachedTokens": "Cache Read",
+      "cacheCreationTokens": "Cache Write",
       "mermaidDiagram": "Diagram",
       "mermaidCode": "Code",
       "mermaidZoomIn": "Zoom in",

--- a/frontend/i18n/types/auditLogs.ts
+++ b/frontend/i18n/types/auditLogs.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-08-17T05:37:33.233Z
+// GENERATED — 2026-08-19T13:12:45.578Z
 // Source: i18n/en/auditLogs.json
 export type AuditLogsMessages = {
   auditLogs: {
@@ -182,6 +182,7 @@ export type AuditLogsMessages = {
     actionduplicate_agent: string
     actionedit_message: string
     actiondelete_conversation: string
+    actiondelete_message: string
     actionbatch_delete_conversations: string
     actionrun_workflow_embed: string
     actionupload_document: string

--- a/frontend/i18n/types/chat.ts
+++ b/frontend/i18n/types/chat.ts
@@ -138,6 +138,8 @@ export type ChatMessages = {
       firstTokenTime: string
       totalTime: string
       speed: string
+      cachedTokens: string
+      cacheCreationTokens: string
       mermaidDiagram: string
       mermaidCode: string
       mermaidZoomIn: string

--- a/frontend/i18n/types/chat.ts
+++ b/frontend/i18n/types/chat.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-08-17T05:37:33.234Z
+// GENERATED — 2026-08-19T13:12:45.580Z
 // Source: i18n/en/chat.json
 export type ChatMessages = {
   chat: {

--- a/frontend/i18n/zh/auditLogs.json
+++ b/frontend/i18n/zh/auditLogs.json
@@ -180,6 +180,7 @@
     "actionduplicate_agent": "复制 智能体",
     "actionedit_message": "编辑消息",
     "actiondelete_conversation": "删除对话",
+    "actiondelete_message": "删除消息",
     "actionbatch_delete_conversations": "批量删除对话",
     "actionrun_workflow_embed": "运行工作流（嵌入）",
     "actionupload_document": "上传文档",

--- a/frontend/i18n/zh/chat.json
+++ b/frontend/i18n/zh/chat.json
@@ -136,6 +136,8 @@
       "firstTokenTime": "首 Token 耗时",
       "totalTime": "总耗时",
       "speed": "生成速度",
+      "cachedTokens": "缓存命中",
+      "cacheCreationTokens": "缓存写入",
       "mermaidDiagram": "图表",
       "mermaidCode": "代码",
       "mermaidZoomIn": "放大",

--- a/frontend/lib/api/agents.test.ts
+++ b/frontend/lib/api/agents.test.ts
@@ -235,9 +235,18 @@ describe('public agents API requests', () => {
 
     const headers = { 'Content-Type': 'application/json' }
     expect(fetch).toHaveBeenNthCalledWith(1, `${API_BASE_URL}/agents/agent-1/public`, { headers })
-    expect(fetch).toHaveBeenNthCalledWith(2, `${API_BASE_URL}/agents/agent-1/conversations?page=1&page_size=50`, { headers })
-    expect(fetch).toHaveBeenNthCalledWith(3, `${API_BASE_URL}/agents/agent-1/conversations?page=3&page_size=5`, { headers })
-    expect(fetch).toHaveBeenNthCalledWith(4, `${API_BASE_URL}/agents/conversations/conversation-1`, { headers })
+    expect(fetch).toHaveBeenNthCalledWith(2, `${API_BASE_URL}/agents/agent-1/conversations?page=1&page_size=50`, {
+      headers,
+      cache: 'no-store',
+    })
+    expect(fetch).toHaveBeenNthCalledWith(3, `${API_BASE_URL}/agents/agent-1/conversations?page=3&page_size=5`, {
+      headers,
+      cache: 'no-store',
+    })
+    expect(fetch).toHaveBeenNthCalledWith(4, `${API_BASE_URL}/agents/conversations/conversation-1`, {
+      headers,
+      cache: 'no-store',
+    })
   })
 
   it('uses exact public mutation routes and payloads', async () => {

--- a/frontend/lib/api/agents.ts
+++ b/frontend/lib/api/agents.ts
@@ -372,7 +372,13 @@ export interface MessageRoundStep {
   tool_name?: string | null
   reasoning_content?: string | null
   model_used?: string | null
-  token_usage?: { prompt: number; completion: number } | null
+  token_usage?: {
+    prompt: number
+    completion: number
+    cache_read?: number
+    cache_creation?: number
+    total_input?: number
+  } | null
   duration_ms?: number | null
   is_manually_stopped?: boolean
   rag_context?: Record<string, unknown>[] | null
@@ -401,7 +407,13 @@ export interface Message {
   reasoning_content?: string | null
   // Metadata
   model_used?: string | null
-  token_usage?: { prompt: number; completion: number } | null
+  token_usage?: {
+    prompt: number
+    completion: number
+    cache_read?: number
+    cache_creation?: number
+    total_input?: number
+  } | null
   duration_ms?: number | null
   is_manually_stopped?: boolean
   rag_context?: Record<string, unknown>[] | null
@@ -579,6 +591,9 @@ export interface SSEMessageEnd {
     prompt_tokens: number
     completion_tokens: number
     total_tokens: number
+    cache_read_tokens?: number
+    cache_creation_tokens?: number
+    total_input_tokens?: number
   }
   timing?: {
     first_token_ms: number | null

--- a/frontend/lib/api/agents.ts
+++ b/frontend/lib/api/agents.ts
@@ -1291,6 +1291,7 @@ export const publicAgentsApi = {
         'Content-Type': 'application/json',
         ...(token && { Authorization: `Bearer ${token}` }),
       },
+      cache: 'no-store',
     })
     
     if (!response.ok) {
@@ -1313,6 +1314,7 @@ export const publicAgentsApi = {
         'Content-Type': 'application/json',
         ...(token && { Authorization: `Bearer ${token}` }),
       },
+      cache: 'no-store',
     })
     
     if (!response.ok) {

--- a/frontend/lib/utils/message-converter.test.ts
+++ b/frontend/lib/utils/message-converter.test.ts
@@ -70,7 +70,7 @@ describe('message converter', () => {
 
   it('reconstructs usage and timing metadata from persisted token fields', () => {
     const converted = convertBackendMessage(message({
-      token_usage: { prompt: 120, completion: 45 },
+      token_usage: { prompt: 120, completion: 45, cache_read: 30, cache_creation: 10, total_input: 40 },
       duration_ms: 2000,
       first_token_ms: 300,
     }))
@@ -79,7 +79,14 @@ describe('message converter', () => {
       isManuallyStopped: false,
       isError: false,
       preservedPartialProgress: false,
-      usage: { prompt_tokens: 120, completion_tokens: 45, total_tokens: 165 },
+      usage: {
+        prompt_tokens: 120,
+        completion_tokens: 45,
+        total_tokens: 165,
+        cache_read_tokens: 30,
+        cache_creation_tokens: 10,
+        total_input_tokens: 40,
+      },
       timing: {
         first_token_ms: 300,
         duration_ms: 2000,
@@ -108,7 +115,14 @@ describe('message converter', () => {
       isManuallyStopped: false,
       isError: false,
       preservedPartialProgress: false,
-      usage: { prompt_tokens: 120, completion_tokens: 45, total_tokens: 165 },
+      usage: {
+        prompt_tokens: 120,
+        completion_tokens: 45,
+        total_tokens: 165,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+        total_input_tokens: 120,
+      },
       timing: {
         first_token_ms: 300,
         tokens_per_second: null,

--- a/frontend/lib/utils/message-converter.ts
+++ b/frontend/lib/utils/message-converter.ts
@@ -86,6 +86,9 @@ export interface BackendMessage {
   token_usage?: {
     prompt: number
     completion: number
+    cache_read?: number
+    cache_creation?: number
+    total_input?: number
   } | null
   duration_ms?: number | null
   first_token_ms?: number | null
@@ -419,6 +422,9 @@ export function convertBackendMessage(message: BackendMessage): ChatMessage | nu
           prompt_tokens: message.token_usage.prompt ?? 0,
           completion_tokens: message.token_usage.completion ?? 0,
           total_tokens: (message.token_usage.prompt ?? 0) + (message.token_usage.completion ?? 0),
+          cache_read_tokens: message.token_usage.cache_read ?? 0,
+          cache_creation_tokens: message.token_usage.cache_creation ?? 0,
+          total_input_tokens: message.token_usage.total_input ?? message.token_usage.prompt ?? 0,
         }
       : undefined
     if (usage) {


### PR DESCRIPTION
## Summary
- Normalize provider-reported cache read/write token usage across chat adapters.
- Persist and expose cache token details through message usage and SSE.
- Show cache read/write token counts in chat token stats; intentionally do not display cache hit rate.

## Verification
- Backend: 3316 tests passed; Ruff and compile checks passed.
- Frontend: 2242 tests passed; TypeScript and ESLint checks passed.

Linear: YUN-142

Closes #388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat token statistics now include cached input, cache-creation, and total-input tokens.
  * Token usage is more accurately reported across supported providers, streaming responses, and tool calls.
  * Cache usage details are displayed in chat message statistics.
  * Public conversation lists refresh automatically after responses complete.
  * Deleted messages now generate localized audit-log entries.
* **Bug Fixes**
  * Improved handling of final streaming usage data, incomplete provider metrics, and context retries.
  * Deleted messages correctly update conversation activity timestamps.
* **Documentation**
  * Added documentation covering prompt-cache visibility and usage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->